### PR TITLE
Arrow: Release vectors decoded from dictionary encoded columns

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
@@ -47,8 +47,9 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
       closeVectors();
     }
 
-    // release the decoded vectors the previous batch materialized, safe with reused containers
-    // because only decoded vectors are released never the holders' vectors
+    // reading the next batch invalidates the previous one, so release the vectors it decoded
+    // from dictionary encoded columns. The holders' vectors are left alone, which keeps this
+    // safe when containers are reused.
     closeArrowVectors();
     this.columnVectors = new ColumnVector[readers.length];
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
@@ -28,6 +28,12 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  */
 class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
 
+  /**
+   * Column vectors handed out with the previous batch. Retained so that vectors allocated by
+   * dictionary decoding can be released, since this reader owns them.
+   */
+  private ColumnVector[] columnVectors;
+
   ArrowBatchReader(List<VectorizedReader<?>> readers) {
     super(readers);
   }
@@ -41,7 +47,11 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
       closeVectors();
     }
 
-    ColumnVector[] columnVectors = new ColumnVector[readers.length];
+    // release the decoded vectors the previous batch materialized, safe with reused containers
+    // because only decoded vectors are released never the holders' vectors
+    closeArrowVectors();
+    this.columnVectors = new ColumnVector[readers.length];
+
     for (int i = 0; i < readers.length; i += 1) {
       vectorHolders[i] = readers[i].read(vectorHolders[i], numRowsToRead);
       int numRowsInVector = vectorHolders[i].numValues();
@@ -54,5 +64,23 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
       columnVectors[i] = new ColumnVector(vectorHolders[i]);
     }
     return new ColumnarBatch(numRowsToRead, columnVectors);
+  }
+
+  @Override
+  public void close() {
+    closeArrowVectors();
+    super.close();
+  }
+
+  private void closeArrowVectors() {
+    if (columnVectors != null) {
+      for (ColumnVector columnVector : columnVectors) {
+        if (columnVector != null) {
+          columnVector.closeArrowVector();
+        }
+      }
+
+      this.columnVectors = null;
+    }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
@@ -52,6 +52,13 @@ public class ColumnVector implements AutoCloseable {
   private final ArrowVectorAccessor<?, String, ?, ?> accessor;
   private final NullabilityHolder nullabilityHolder;
 
+  /**
+   * Lazily materialized by {@link #getArrowVector()}. For a dictionary encoded column this is a
+   * newly allocated vector that this class owns, for every other column it is the holder's vector,
+   * which is owned by the reader.
+   */
+  private FieldVector arrowVector;
+
   ColumnVector(VectorHolder vectorHolder) {
     this.vectorHolder = vectorHolder;
     this.nullabilityHolder = vectorHolder.nullabilityHolder();
@@ -73,7 +80,11 @@ public class ColumnVector implements AutoCloseable {
    * @return instance of {@link FieldVector}
    */
   public FieldVector getArrowVector() {
-    return DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
+    if (arrowVector == null) {
+      this.arrowVector = DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
+    }
+
+    return arrowVector;
   }
 
   public boolean hasNull() {
@@ -86,7 +97,21 @@ public class ColumnVector implements AutoCloseable {
 
   @Override
   public void close() {
+    closeArrowVector();
     accessor.close();
+  }
+
+  /**
+   * Releases the vector materialized by {@link #getArrowVector()} if it was allocated by the
+   * dictionary decoding, which is the only case where this class owns it. The holder's vector
+   * belongs to the reader and is left alone.
+   */
+  void closeArrowVector() {
+    if (arrowVector != null && vectorHolder.isDictionaryEncoded()) {
+      arrowVector.close();
+    }
+
+    this.arrowVector = null;
   }
 
   public boolean isNullAt(int rowId) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -64,6 +64,23 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
         (type, value) -> value);
   }
 
+  public VectorizedReaderBuilder(
+      Schema expectedSchema,
+      MessageType parquetSchema,
+      boolean setArrowValidityVector,
+      Map<Integer, ?> idToConstant,
+      Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
+      BufferAllocator bufferAllocator) {
+    this(
+        expectedSchema,
+        parquetSchema,
+        setArrowValidityVector,
+        idToConstant,
+        readerFactory,
+        (type, value) -> value,
+        bufferAllocator);
+  }
+
   protected VectorizedReaderBuilder(
       Schema expectedSchema,
       MessageType parquetSchema,

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -78,6 +78,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.arrow.ArrowAllocation;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
@@ -116,6 +117,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestArrowReader {
 
   private static final int NUM_ROWS_PER_MONTH = 20;
+  private static final int NUM_DICT_ENCODED_ROWS = 100;
   private static final ImmutableList<String> ALL_COLUMNS =
       ImmutableList.of(
           "timestamp",
@@ -387,6 +389,43 @@ public class TestArrowReader {
     }
 
     assertThat(totalRowsRead).as("Should read all rows").isEqualTo(millisValues.size());
+  }
+
+  @Test
+  public void testReleasesDecodedVectorsWhenDictEncodedBatchIsMaterialized() throws Exception {
+    Table table = createDictEncodedTable();
+    long allocatedBefore = ArrowAllocation.rootAllocator().getAllocatedMemory();
+
+    int rowsRead = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        // repeated calls must return the cached decoded vector
+        assertThat(batch.column(0).getArrowVector()).isSameAs(batch.column(0).getArrowVector());
+        rowsRead += root.getRowCount();
+      }
+    }
+
+    assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
+    assertThat(ArrowAllocation.rootAllocator().getAllocatedMemory() - allocatedBefore).isZero();
+  }
+
+  @Test
+  public void testReleasesMemoryWhenDictEncodedBatchIsNotMaterialized() throws Exception {
+    Table table = createDictEncodedTable();
+    long allocatedBefore = ArrowAllocation.rootAllocator().getAllocatedMemory();
+
+    int rowsRead = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : reader) {
+        rowsRead += batch.numRows();
+      }
+    }
+
+    assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
+    assertThat(ArrowAllocation.rootAllocator().getAllocatedMemory() - allocatedBefore).isZero();
   }
 
   /**
@@ -1495,6 +1534,41 @@ public class TestArrowReader {
       records.add(rec);
     }
     return records;
+  }
+
+  private Table createDictEncodedTable() throws Exception {
+    tables = new HadoopTables();
+    Schema schema = new Schema(Types.NestedField.required(1, "s", Types.StringType.get()));
+    Table table = tables.create(schema, tableLocation);
+
+    MessageType parquetSchema =
+        new MessageType(
+            "test",
+            primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED)
+                .as(LogicalTypeAnnotation.stringType())
+                .id(1)
+                .named("s"));
+
+    File testFile = new File(tempDir, "dict-encoded.parquet");
+    try (ParquetWriter<Group> writer =
+        ExampleParquetWriter.builder(new Path(testFile.toURI())).withType(parquetSchema).build()) {
+      SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
+      for (int i = 0; i < NUM_DICT_ENCODED_ROWS; i++) {
+        // few distinct values, so Parquet dictionary encodes the column
+        writer.write(factory.newGroup().append("s", "v" + (i % 4)));
+      }
+    }
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(testFile.getAbsolutePath())
+            .withFileSizeInBytes(testFile.length())
+            .withFormat(FileFormat.PARQUET)
+            .withRecordCount(NUM_DICT_ENCODED_ROWS)
+            .build();
+
+    table.newAppend().appendFile(dataFile).commit();
+    return table;
   }
 
   private DataFile writeParquetFile(Table table, List<GenericRecord> records) throws IOException {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -44,6 +44,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -78,15 +80,16 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
-import org.apache.iceberg.arrow.ArrowAllocation;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -393,39 +396,36 @@ public class TestArrowReader {
 
   @Test
   public void testReleasesDecodedVectorsWhenDictEncodedBatchIsMaterialized() throws Exception {
-    Table table = createDictEncodedTable();
-    long allocatedBefore = ArrowAllocation.rootAllocator().getAllocatedMemory();
-
     int rowsRead = 0;
-    try (VectorizedTableScanIterable reader =
-        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
-      for (ColumnarBatch batch : reader) {
-        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
-        // repeated calls must return the cached decoded vector
-        assertThat(batch.column(0).getArrowVector()).isSameAs(batch.column(0).getArrowVector());
-        rowsRead += root.getRowCount();
-      }
-    }
 
-    assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
-    assertThat(ArrowAllocation.rootAllocator().getAllocatedMemory() - allocatedBefore).isZero();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      try (CloseableIterable<ColumnarBatch> batches = dictEncodedBatches(allocator)) {
+        for (ColumnarBatch batch : batches) {
+          VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+          // repeated calls must return the cached decoded vector
+          assertThat(batch.column(0).getArrowVector()).isSameAs(batch.column(0).getArrowVector());
+          rowsRead += root.getRowCount();
+        }
+      }
+
+      assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
+      assertThat(allocator.getAllocatedMemory()).isZero();
+    }
   }
 
   @Test
   public void testReleasesMemoryWhenDictEncodedBatchIsNotMaterialized() throws Exception {
-    Table table = createDictEncodedTable();
-    long allocatedBefore = ArrowAllocation.rootAllocator().getAllocatedMemory();
-
     int rowsRead = 0;
-    try (VectorizedTableScanIterable reader =
-        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
-      for (ColumnarBatch batch : reader) {
-        rowsRead += batch.numRows();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      try (CloseableIterable<ColumnarBatch> batches = dictEncodedBatches(allocator)) {
+        for (ColumnarBatch batch : batches) {
+          rowsRead += batch.numRows();
+        }
       }
-    }
 
-    assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
-    assertThat(ArrowAllocation.rootAllocator().getAllocatedMemory() - allocatedBefore).isZero();
+      assertThat(rowsRead).isEqualTo(NUM_DICT_ENCODED_ROWS);
+      assertThat(allocator.getAllocatedMemory()).isZero();
+    }
   }
 
   /**
@@ -1536,39 +1536,42 @@ public class TestArrowReader {
     return records;
   }
 
-  private Table createDictEncodedTable() throws Exception {
-    tables = new HadoopTables();
+  private CloseableIterable<ColumnarBatch> dictEncodedBatches(BufferAllocator allocator)
+      throws IOException {
     Schema schema = new Schema(Types.NestedField.required(1, "s", Types.StringType.get()));
-    Table table = tables.create(schema, tableLocation);
 
-    MessageType parquetSchema =
-        new MessageType(
-            "test",
-            primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED)
-                .as(LogicalTypeAnnotation.stringType())
-                .id(1)
-                .named("s"));
-
-    File testFile = new File(tempDir, "dict-encoded.parquet");
-    try (ParquetWriter<Group> writer =
-        ExampleParquetWriter.builder(new Path(testFile.toURI())).withType(parquetSchema).build()) {
-      SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
-      for (int i = 0; i < NUM_DICT_ENCODED_ROWS; i++) {
-        // few distinct values, so Parquet dictionary encodes the column
-        writer.write(factory.newGroup().append("s", "v" + (i % 4)));
-      }
+    GenericRecord record = GenericRecord.create(schema);
+    List<Record> records = Lists.newArrayListWithExpectedSize(NUM_DICT_ENCODED_ROWS);
+    for (int i = 0; i < NUM_DICT_ENCODED_ROWS; i++) {
+      // few distinct values, so Parquet dictionary encodes the column
+      records.add(record.copy(ImmutableMap.of("s", "v" + (i % 4))));
     }
 
-    DataFile dataFile =
-        DataFiles.builder(PartitionSpec.unpartitioned())
-            .withPath(testFile.getAbsolutePath())
-            .withFileSizeInBytes(testFile.length())
-            .withFormat(FileFormat.PARQUET)
-            .withRecordCount(NUM_DICT_ENCODED_ROWS)
-            .build();
+    File file = new File(tempDir, "dict-encoded.parquet");
+    try (FileAppender<Record> appender =
+        Parquet.write(Files.localOutput(file))
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      appender.addAll(records);
+    }
 
-    table.newAppend().appendFile(dataFile).commit();
-    return table;
+    return Parquet.read(localInput(file))
+        .project(schema)
+        .recordsPerBatch(1024)
+        .createBatchedReaderFunc(
+            fileSchema ->
+                TypeWithSchemaVisitor.visit(
+                    schema.asStruct(),
+                    fileSchema,
+                    new VectorizedReaderBuilder(
+                        schema,
+                        fileSchema,
+                        false,
+                        ImmutableMap.of(),
+                        ArrowBatchReader::new,
+                        allocator)))
+        .build();
   }
 
   private DataFile writeParquetFile(Table table, List<GenericRecord> records) throws IOException {


### PR DESCRIPTION
Fixes #17722.                                                                                                                
 
 `ColumnVector.getArrowVector()` allocates a decoded vector per call for dictionary encoded columns and nothing released it (details in the issue). Following the ownership model of #17296, the decoded vector is now materialized once per batch and `ArrowBatchReader` releases it when the next `read()` invalidates the batch and on `close()`. Only dict-decoded vectors are released, so `reuseContainers` and the reader-owned holder vectors are untouched.
Spark/Flink don't use this code path.                                             
                                                                                                                               
Tested with a differential pair in `TestArrowReader`: the materializing test fails on main (33,280 bytes retained for 100 rows / 1 batch / 1 string column) and passes with the fix. the non-materializing control passes on both.                                                                       

This contribution was developed with AI assistance Claude Code (Opus 5) and I have reviewed it