### PR TITLE
Core: Allow date to timestamp promotion for v3 tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -42,6 +42,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public class TypeUtil {
 
   private static final int HEADER_SIZE = 12;
+  private static final int DEFAULT_FORMAT_VERSION = 2;
+  private static final int MIN_FORMAT_VERSION_DATE_PROMOTION = 3;
 
   private TypeUtil() {}
 
@@ -469,6 +471,21 @@ public class TypeUtil {
   }
 
   public static boolean isPromotionAllowed(Type from, Type.PrimitiveType to) {
+    return isPromotionAllowed(from, to, DEFAULT_FORMAT_VERSION, false);
+  }
+
+  /**
+   * Returns whether a type may be promoted to another type.
+   *
+   * @param from the type to promote from
+   * @param to the type to promote to
+   * @param formatVersion the table format version
+   * @param partitionSource whether {@code from} is the source of a partition field whose transform
+   *     would produce a different value after the promotion
+   * @return true if the promotion is allowed
+   */
+  public static boolean isPromotionAllowed(
+      Type from, Type.PrimitiveType to, int formatVersion, boolean partitionSource) {
     // Warning! Before changing this function, make sure that the type change doesn't introduce
     // compatibility problems in partitioning.
     if (from.equals(to)) {
@@ -476,6 +493,8 @@ public class TypeUtil {
     }
 
     switch (from.typeId()) {
+      case DATE:
+        return isDatePromotionAllowed(to, formatVersion, partitionSource);
       case INTEGER:
         return to.typeId() == Type.TypeID.LONG;
 
@@ -494,6 +513,17 @@ public class TypeUtil {
     }
 
     return false;
+  }
+
+  private static boolean isDatePromotionAllowed(
+      Type.PrimitiveType to, int formatVersion, boolean partitionSource) {
+    if (formatVersion < MIN_FORMAT_VERSION_DATE_PROMOTION || partitionSource) {
+      return false;
+    }
+
+    // promotion to timestamptz and timestamptz_ns is not allowed
+    return Types.TimestampType.withoutZone().equals(to)
+        || Types.TimestampNanoType.withoutZone().equals(to);
   }
 
   /**

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -1167,4 +1167,33 @@ public class TestTypeUtil {
     Schema result = TypeUtil.replaceFieldTypes(schema, ImmutableMap.of(99, Types.LongType.get()));
     assertThat(result).isSameAs(schema);
   }
+
+  @Test
+  public void testDateToTimestampPromotion() {
+    // format version < 3 should not be accepted
+    assertThat(
+            TypeUtil.isPromotionAllowed(
+                Types.DateType.get(), Types.TimestampType.withoutZone(), 2, false))
+        .isFalse();
+    // timezone should not be accepted
+    assertThat(
+            TypeUtil.isPromotionAllowed(
+                Types.DateType.get(), Types.TimestampType.withZone(), 3, false))
+        .isFalse();
+    // timezone nano should not be accepted
+    assertThat(
+            TypeUtil.isPromotionAllowed(
+                Types.DateType.get(), Types.TimestampNanoType.withZone(), 3, false))
+        .isFalse();
+    // timestamp without timezone should be accepted
+    assertThat(
+            TypeUtil.isPromotionAllowed(
+                Types.DateType.get(), Types.TimestampType.withoutZone(), 3, false))
+        .isTrue();
+    // timestamp nano without timezone should be accepted
+    assertThat(
+            TypeUtil.isPromotionAllowed(
+                Types.DateType.get(), Types.TimestampNanoType.withoutZone(), 3, false))
+        .isTrue();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
 import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.schema.UnionByNameVisitor;
+import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -55,6 +56,7 @@ class SchemaUpdate implements UpdateSchema {
   private final TableOperations ops;
   private final TableMetadata base;
   private final Schema schema;
+  private final int formatVersion;
   private final Map<Integer, Integer> idToParent;
   private final List<Integer> deletes = Lists.newArrayList();
   private final Map<Integer, Types.NestedField> updates = Maps.newHashMap();
@@ -73,21 +75,33 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   @VisibleForTesting
+  SchemaUpdate(TableMetadata base) {
+    this(null, base, base.schema(), base.lastColumnId(), base.formatVersion());
+  }
+
+  @VisibleForTesting
   SchemaUpdate(Schema schema, int lastColumnId) {
-    this(null, null, schema, lastColumnId);
+    this(null, null, schema, lastColumnId, TableProperties.DEFAULT_FORMAT_VERSION);
+  }
+
+  @VisibleForTesting
+  SchemaUpdate(Schema schema, int lastColumnId, int formatVersion) {
+    this(null, null, schema, lastColumnId, formatVersion);
   }
 
   private SchemaUpdate(TableOperations ops, TableMetadata base) {
-    this(ops, base, base.schema(), base.lastColumnId());
+    this(ops, base, base.schema(), base.lastColumnId(), base.formatVersion());
   }
 
-  private SchemaUpdate(TableOperations ops, TableMetadata base, Schema schema, int lastColumnId) {
+  private SchemaUpdate(
+      TableOperations ops, TableMetadata base, Schema schema, int lastColumnId, int formatVersion) {
     this.ops = ops;
     this.base = base;
     this.schema = schema;
     this.lastColumnId = lastColumnId;
     this.idToParent = Maps.newHashMap(TypeUtil.indexParents(schema.asStruct()));
     this.identifierFieldNames = schema.identifierFieldNames();
+    this.formatVersion = formatVersion;
   }
 
   @Override
@@ -283,7 +297,8 @@ class SchemaUpdate implements UpdateSchema {
     }
 
     Preconditions.checkArgument(
-        TypeUtil.isPromotionAllowed(field.type(), newType),
+        TypeUtil.isPromotionAllowed(
+            field.type(), newType, formatVersion, isPartitionSource(field.fieldId())),
         "Cannot change column type: %s: %s -> %s",
         name,
         field.type(),
@@ -295,6 +310,23 @@ class SchemaUpdate implements UpdateSchema {
     updates.put(fieldId, newField);
 
     return this;
+  }
+
+  private boolean isPartitionSource(int fieldId) {
+    if (base == null) {
+      return false;
+    }
+
+    // data files written with an older spec are still partitioned by it
+    return base.specs().stream()
+        .flatMap(spec -> spec.getFieldsBySourceId(fieldId).stream())
+        .anyMatch(SchemaUpdate::changesPartitionValue);
+  }
+
+  private static boolean changesPartitionValue(PartitionField partitionField) {
+    Transform<?, ?> transform = partitionField.transform();
+    // year, month, day, and void produce the same value for a date and its promoted timestamp
+    return transform.isIdentity() || transform.toString().startsWith("bucket[");
   }
 
   @Override
@@ -376,7 +408,7 @@ class SchemaUpdate implements UpdateSchema {
 
   @Override
   public UpdateSchema unionByNameWith(Schema newSchema) {
-    UnionByNameVisitor.visit(this, schema, newSchema, caseSensitive);
+    UnionByNameVisitor.visit(this, schema, newSchema, caseSensitive, formatVersion);
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -41,6 +41,8 @@ public class TableProperties {
    */
   public static final String FORMAT_VERSION = "format-version";
 
+  public static final int DEFAULT_FORMAT_VERSION = 2;
+
   /** Reserved table property for table UUID. */
   public static final String UUID = "uuid";
 

--- a/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.schema;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
@@ -36,11 +37,14 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
   private final UpdateSchema api;
   private final Schema partnerSchema;
   private final boolean caseSensitive;
+  private final int formatVersion;
 
-  private UnionByNameVisitor(UpdateSchema api, Schema partnerSchema, boolean caseSensitive) {
+  private UnionByNameVisitor(
+      UpdateSchema api, Schema partnerSchema, boolean caseSensitive, int formatVersion) {
     this.api = api;
     this.partnerSchema = partnerSchema;
     this.caseSensitive = caseSensitive;
+    this.formatVersion = formatVersion;
   }
 
   /**
@@ -56,6 +60,11 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
     visit(api, existingSchema, newSchema, true);
   }
 
+  public static void visit(
+      UpdateSchema api, Schema existingSchema, Schema newSchema, boolean caseSensitive) {
+    visit(api, existingSchema, newSchema, caseSensitive, TableProperties.DEFAULT_FORMAT_VERSION);
+  }
+
   /**
    * Adds changes needed to produce a union of two schemas to an {@link UpdateSchema} operation.
    *
@@ -65,13 +74,18 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
    * @param existingSchema an existing schema
    * @param caseSensitive when false, the case of schema's fields are ignored
    * @param newSchema a new schema to compare with the existing
+   * @param formatVersion the table format version
    */
   public static void visit(
-      UpdateSchema api, Schema existingSchema, Schema newSchema, boolean caseSensitive) {
+      UpdateSchema api,
+      Schema existingSchema,
+      Schema newSchema,
+      boolean caseSensitive,
+      int formatVersion) {
     visit(
         newSchema,
         -1,
-        new UnionByNameVisitor(api, existingSchema, caseSensitive),
+        new UnionByNameVisitor(api, existingSchema, caseSensitive, formatVersion),
         new PartnerIdByNameAccessors(existingSchema, caseSensitive));
   }
 
@@ -204,7 +218,8 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
       // existingType:long -> newType:int returns true, meaning it is ignorable
       // existingType:int -> newType:long returns false, meaning it is not ignorable
       return newType.isPrimitiveType()
-          && TypeUtil.isPromotionAllowed(newType, existingType.asPrimitiveType());
+          && TypeUtil.isPromotionAllowed(
+              newType, existingType.asPrimitiveType(), formatVersion, false);
     } else {
       // Complex -> Complex
       return !newType.isPrimitiveType();

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -414,6 +414,49 @@ public class TestSchemaUnionByFieldName {
   }
 
   @Test
+  // date -> Can promote to timestamp
+  public void testTypePromoteDateToTimestamp() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", TimestampType.withoutZone()));
+
+    Schema applied = new SchemaUpdate(currentSchema, 1, 3).unionByNameWith(newSchema).apply();
+    assertThat(applied.asStruct()).isEqualTo(newSchema.asStruct());
+    assertThat(applied.asStruct().fields()).hasSize(1);
+    assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(TimestampType.withoutZone());
+  }
+
+  @Test
+  public void testTypePromoteDateToTimestampNano() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", Types.TimestampNanoType.withoutZone()));
+
+    Schema applied = new SchemaUpdate(currentSchema, 1, 3).unionByNameWith(newSchema).apply();
+    assertThat(applied.asStruct()).isEqualTo(newSchema.asStruct());
+  }
+
+  @Test
+  public void testTypePromoteDateToTimestampNotAllowedInV2() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", TimestampType.withoutZone()));
+
+    assertThatThrownBy(
+            () -> new SchemaUpdate(currentSchema, 1, 2).unionByNameWith(newSchema).apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: aCol: date -> timestamp");
+  }
+
+  @Test
+  public void testTypePromoteDateToTimestampWithZone() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", TimestampType.withZone()));
+
+    assertThatThrownBy(
+            () -> new SchemaUpdate(currentSchema, 1, 3).unionByNameWith(newSchema).apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: aCol: date -> timestamptz");
+  }
+
+  @Test
   public void testAddPrimitiveToNestedStruct() {
     Schema schema =
         new Schema(

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -2589,5 +2590,116 @@ public class TestSchemaUpdate {
             .apply();
 
     assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testDateToTimestampPromotionNotAllowedInV2() {
+    Schema schema = new Schema(required(1, "col", Types.DateType.get()));
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(schema, 1, 2)
+                    .updateColumn("col", Types.TimestampType.withoutZone()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: col: date -> timestamp");
+  }
+
+  @Test
+  public void testDateToTimestampTzPromotionNotAllowedInV3() {
+    Schema schema = new Schema(required(1, "col", Types.DateType.get()));
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(schema, 1, 3).updateColumn("col", Types.TimestampType.withZone()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: col: date -> timestamptz");
+  }
+
+  @Test
+  public void testUpdatePartitionedDateToTimestampV3Succeeds() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()), required(2, "ts", Types.DateType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).day("ts").build();
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            schema, spec, "file:/tmp", ImmutableMap.of("format-version", "3"));
+
+    Schema updated =
+        new SchemaUpdate(metadata).updateColumn("ts", Types.TimestampType.withoutZone()).apply();
+
+    Schema expected =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            required(2, "ts", Types.TimestampType.withoutZone()));
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testUpdatePartitionedDateToTimestampV3Fails() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()), required(2, "ts", Types.DateType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("ts", 4).build();
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            schema, spec, "file:/tmp", ImmutableMap.of("format-version", "3"));
+
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(metadata)
+                    .updateColumn("ts", Types.TimestampType.withoutZone())
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: ts: date -> timestamp");
+  }
+
+  @Test
+  public void testUpdateIdentityPartitionedDateToTimestampV3Fails() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()), required(2, "ts", Types.DateType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("ts").build();
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            schema, spec, "file:/tmp", ImmutableMap.of("format-version", "3"));
+
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(metadata)
+                    .updateColumn("ts", Types.TimestampType.withoutZone())
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: ts: date -> timestamp");
+  }
+
+  @Test
+  public void testUpdateDateToTimestampChecksHistoricalSpecs() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()), required(2, "ts", Types.DateType.get()));
+
+    PartitionSpec bucketSpec = PartitionSpec.builderFor(schema).bucket("ts", 4).build();
+
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            schema, bucketSpec, "file:/tmp", ImmutableMap.of("format-version", "3"));
+
+    // the bucket spec is replaced, but data files written with it are still bucketed by date
+    TableMetadata updated =
+        metadata.updatePartitionSpec(PartitionSpec.builderFor(schema).day("ts").build());
+
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(updated)
+                    .updateColumn("ts", Types.TimestampType.withoutZone())
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column type: ts: date -> timestamp");
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -45,6 +45,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -70,12 +72,15 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.parquet.ParquetMetricsRowGroupFilter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.FloatType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
@@ -1172,6 +1177,52 @@ public class TestMetricsRowGroupFilter {
         new ParquetMetricsRowGroupFilter(promotedSchema, equal("id", INT_MIN_VALUE + 1), true)
             .shouldRead(parquetSchema, rowGroupMetadata);
     assertThat(shouldRead).as("Should succeed with promoted schema").isTrue();
+  }
+
+  @TestTemplate
+  public void testParquetDateToTimestampPromotion() throws IOException {
+    assumeThat(format).as("Only valid for Parquet").isEqualTo(FileFormat.PARQUET);
+
+    Schema dateSchema = new Schema(required(1, "dt", Types.DateType.get()));
+    List<GenericRecord> records = Lists.newArrayList();
+    for (String date : new String[] {"2018-01-01", "2018-01-31"}) {
+      GenericRecord record = GenericRecord.create(dateSchema);
+      record.setField("dt", LocalDate.parse(date));
+      records.add(record);
+    }
+
+    File parquetFile = writeParquetFile("test-date-promotion", dateSchema, records);
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(parquetInputFile(Files.localInput(parquetFile)))) {
+      assertThat(reader.getRowGroups()).as("Should create only one row group").hasSize(1);
+      BlockMetaData rowGroup = reader.getRowGroups().get(0);
+      parquetSchema = reader.getFileMetaData().getSchema();
+
+      // bounds for both promoted types are given in micros, see Literals.LongLiteral#to
+      long withinRange =
+          DateTimeUtil.microsFromTimestamp(LocalDateTime.parse("2018-01-15T12:00:00"));
+      long belowRange =
+          DateTimeUtil.microsFromTimestamp(LocalDateTime.parse("2017-12-01T12:00:00"));
+
+      for (Type.PrimitiveType promoted :
+          ImmutableList.of(
+              Types.TimestampType.withoutZone(), Types.TimestampNanoType.withoutZone())) {
+        Schema promotedSchema = new Schema(required(1, "dt", promoted));
+
+        assertThat(
+                new ParquetMetricsRowGroupFilter(promotedSchema, lessThan("dt", withinRange), true)
+                    .shouldRead(parquetSchema, rowGroup))
+            .as("Should read %s: one possible date", promoted)
+            .isTrue();
+
+        assertThat(
+                new ParquetMetricsRowGroupFilter(promotedSchema, lessThan("dt", belowRange), true)
+                    .shouldRead(parquetSchema, rowGroup))
+            .as("Should not read %s: date range below lower bound", promoted)
+            .isFalse();
+      }
+    }
   }
 
   @TestTemplate

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
@@ -23,10 +23,12 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -82,6 +84,16 @@ class ParquetConversions {
       } else if (icebergType.typeId() == Type.TypeID.DOUBLE
           && parquetType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FLOAT) {
         return value -> ((Float) fromParquet.apply(value)).doubleValue();
+      } else if ((icebergType.typeId() == Type.TypeID.TIMESTAMP
+              || icebergType.typeId() == Type.TypeID.TIMESTAMP_NANO)
+          && parquetType.getLogicalTypeAnnotation()
+              instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+        // dates promoted to timestamps are stored as days and read as micros or nanos
+        long unitsPerDay =
+            icebergType.typeId() == Type.TypeID.TIMESTAMP
+                ? TimeUnit.DAYS.toMicros(1)
+                : TimeUnit.DAYS.toNanos(1);
+        return value -> ((Integer) fromParquet.apply(value)).longValue() * unitsPerDay;
       } else if (icebergType.typeId() == Type.TypeID.UUID) {
         return binary -> UUIDUtil.convert(((Binary) binary).toByteBuffer());
       }


### PR DESCRIPTION
The v3 spec allows for promoting a date -> timestamp / timestamp_ns.

This PR allows for the promotion and plumbs through the table formatVersion to make it possible. 

There's also an edge case around partitioning for this promotion in particular. According to the spec,

```
Type promotion is not allowed for a field that is referenced by source-id or source-ids of a partition field if the partition transform would produce a different value after promoting the type
```

This is only relevant for date -> timestamp / timestamp_ns promotions.