### PR TITLE
Core: Read DELETE manifests in ReachableFileCleanup

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -103,17 +103,22 @@ public class ManifestFiles {
   }
 
   /**
-   * Returns a {@link CloseableIterable} of file paths in the {@link ManifestFile}.
+   * Returns a {@link CloseableIterable} of live file paths in the {@link ManifestFile}.
+   *
+   * <p>Works for both {@link ManifestContent#DATA DATA} and {@link ManifestContent#DELETES DELETE}
+   * manifests: data manifests yield data file locations and delete manifests yield delete file
+   * locations (position-delete files and DVs). Only entries currently marked as live are returned;
+   * tombstone entries (DELETED status) are skipped.
    *
    * @param manifest a ManifestFile
    * @param io a FileIO
    * @param specsById a Map from spec ID to partition spec
-   * @return a manifest reader
+   * @return a CloseableIterable of live file locations referenced by the manifest
    */
   public static CloseableIterable<String> readPaths(
       ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
     return CloseableIterable.transform(
-        read(manifest, io, specsById).select(ImmutableList.of("file_path")).liveEntries(),
+        open(manifest, io, specsById).select(ImmutableList.of("file_path")).liveEntries(),
         entry -> entry.file().location());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1599,6 +1599,53 @@ public class TestRemoveSnapshots extends TestBase {
   }
 
   @TestTemplate
+  public void testReachableCleanupWithDeleteManifestFromRemovedBranch() {
+    // Regression test: ManifestFiles.readPaths previously required a DATA manifest and threw
+    // IllegalArgumentException on DELETE manifests. ReachableFileCleanup calls readPaths on every
+    // manifest reachable only through expired snapshots; when one was a DELETE manifest (as happens
+    // after a branch that added delete files is removed), the exception was logged and swallowed
+    // by the suppressFailureWhenFinished task loop, silently orphaning the referenced delete and
+    // DV files on object storage.
+    //
+    // Only V2 and V3 tables carry standalone delete manifests. V1 has no delete files and V4+
+    // unifies delete entries into the root manifest.
+    assumeThat(formatVersion)
+        .as("Standalone delete manifests only exist in V2 and V3 tables")
+        .isIn(2, 3);
+    assumeThat(incrementalCleanup)
+        .as("This test targets ReachableFileCleanup, not IncrementalFileCleanup")
+        .isFalse();
+
+    String branch = "delete-branch";
+
+    table.newAppend().appendFile(FILE_A).commit();
+    Snapshot mainAppend = table.currentSnapshot();
+
+    table.manageSnapshots().createBranch(branch, mainAppend.snapshotId()).commit();
+
+    table.newRowDelta().addDeletes(FILE_A_DELETES).toBranch(branch).commit();
+    Snapshot branchDelta = table.snapshot(branch);
+    assertThat(branchDelta.deleteManifests(table.io()))
+        .as("Branch tip should own a delete manifest referencing FILE_A_DELETES")
+        .hasSize(1);
+
+    // Remove the branch so its snapshots and manifests become expiration candidates.
+    table.manageSnapshots().removeBranch(branch).commit();
+
+    table.newAppend().appendFile(FILE_B).commit();
+    long tAfterCommits = waitUntilAfter(table.currentSnapshot().timestampMillis());
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    removeSnapshots(table).expireOlderThan(tAfterCommits).deleteWith(deletedFiles::add).commit();
+
+    assertThat(deletedFiles)
+        .as(
+            "ReachableFileCleanup must enumerate DELETE manifests and delete the delete files "
+                + "they reference; otherwise DV and position-delete files are silently orphaned.")
+        .contains(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
   public void testRemoveFromTableWithBulkIO() {
     TestTables.TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestTables.TestBulkLocalFileIO());
 


### PR DESCRIPTION
## Summary
`ReachableFileCleanup#findFilesToDelete` uses `ManifestFiles.readPaths` to enumerate live file paths for every manifest scheduled for deletion. `readPaths` is only defined for DATA manifests — it calls `ManifestFiles.read` which asserts `manifest.content() == ManifestContent.DATA` and throws `IllegalArgumentException` otherwise. Because the surrounding `Tasks.foreach(...).retry(3).suppressFailureWhenFinished()` catches only `IOException` explicitly and suppresses everything else, the exception is logged per retry and swallowed, so DELETE manifests reachable only through expired snapshots are silently skipped. The delete files and DV Puffin blobs they reference are left as orphans on object storage.
`ReachableFileCleanup` is selected by `RemoveSnapshots.cleanExpirenapshots` whenever specific snapshot IDs are given, when a non-main snapshot was removed, or when there are non-main snapshots — i.e., any workflow that touches branches or tags.
`IncrementalFileCleanup.findFilesToDelete` already handles this correctly by using `ManifestFiles.open`, which returns a `ManifestReader` for either DATA or DELETE manifest content. This PR aligns `ReachableFileCleanup` with that pattern and adds a regression test.
## Change
- Replace both `ManifestFiles.readPaths(...)` calls in `ReachableFileCleanup#findFilesToDelete` with `ManifestFiles.open(...).select("file_path").liveEntries()`, projecting only the file-path column so the read cost is unchanged.
- New test `TestRemoveSnapshots#testReachableCleanupWithDeleteManifestFromRemovedBranch` stages a position-delete file on a branch, removes the branch, expires older snapshots, and asserts the delete-file location is enumerated for deletion. Gated with `assumeThat(formatVersion == 2)` and `assumeThat(!incrementalCleanup)` to target t reachable cleanup path.
## Test plan
- [ ] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestRemoveSnapshots"` passes.
- [ ] The new regression test fails without the code change and passes with it.
- [ ] `./gradlew spotlessCheck` passes.
---
**AI Disclosure**
- Platform/Tool: Cursor