### PR TITLE
API: Add a builder usage example to PartitionSpec Javadoc

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -49,6 +49,15 @@ import org.apache.iceberg.types.Types.StructType;
  *
  * <p>Partition data is produced by transforming columns in a table. Each column transform is
  * represented by a named {@link PartitionField}.
+ *
+ * <p>Partition specs are created using a builder obtained from {@link #builderFor(Schema)}:
+ *
+ * <pre>{@code
+ * PartitionSpec spec = PartitionSpec.builderFor(schema)
+ *     .hour("ts")
+ *     .bucket("id", 10)
+ *     .build();
+ * }</pre>
  */
 public class PartitionSpec implements Serializable {
   // IDs for partition fields start at 1000


### PR DESCRIPTION
Adds a short usage example to the `PartitionSpec` class Javadoc showing how to construct a spec via the builder returned by `builderFor(Schema)`. The class already documents what a partition spec is but gives no example of building one. Javadoc-only; no code change.