### PR TITLE
ORC: Fix timestamp nano predicate pushdown

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.orc;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +33,7 @@ import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.TypeID;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.common.type.HiveDecimal;
 import org.apache.orc.storage.ql.io.sarg.PredicateLeaf;
@@ -301,6 +301,7 @@ class ExpressionToSearchArgument
       case DATE:
         return PredicateLeaf.Type.DATE;
       case TIMESTAMP:
+      case TIMESTAMP_NANO:
         return PredicateLeaf.Type.TIMESTAMP;
       case STRING:
         return PredicateLeaf.Type.STRING;
@@ -328,11 +329,10 @@ class ExpressionToSearchArgument
       case DATE:
         return Date.valueOf(LocalDate.ofEpochDay((Integer) icebergLiteral));
       case TIMESTAMP:
-        long microsFromEpoch = (Long) icebergLiteral;
         return Timestamp.from(
-            Instant.ofEpochSecond(
-                Math.floorDiv(microsFromEpoch, 1_000_000),
-                Math.floorMod(microsFromEpoch, 1_000_000) * 1_000L));
+            DateTimeUtil.timestamptzFromMicros((Long) icebergLiteral).toInstant());
+      case TIMESTAMP_NANO:
+        return Timestamp.from(DateTimeUtil.timestamptzFromNanos((Long) icebergLiteral).toInstant());
       case DECIMAL:
         return new HiveDecimalWritable(HiveDecimal.create((BigDecimal) icebergLiteral, false));
       default:

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -27,10 +27,12 @@ import static org.apache.iceberg.expressions.Expressions.isNaN;
 import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.nanos;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.notNull;
+import static org.apache.iceberg.expressions.Expressions.predicate;
 import static org.apache.iceberg.expressions.Expressions.year;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
@@ -48,6 +50,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -61,6 +64,8 @@ import org.apache.orc.storage.ql.io.sarg.SearchArgument.TruthValue;
 import org.apache.orc.storage.ql.io.sarg.SearchArgumentFactory;
 import org.apache.orc.storage.serde2.io.HiveDecimalWritable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestExpressionToSearchArgument {
 
@@ -491,5 +496,36 @@ public class TestExpressionToSearchArgument {
     SearchArgument actual =
         ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));
     assertThat(actual.toString()).isEqualTo(expected.toString());
+  }
+
+  @ParameterizedTest
+  @MethodSource("timestampNanoTypes")
+  void convertsTimestampNanoPredicates(Types.TimestampNanoType timestampType) {
+    Schema schema = new Schema(optional(1, "ts", timestampType));
+    Instant predicateValue = Instant.parse("2019-10-02T00:47:28.207366123Z");
+    long nanosFromEpoch = ChronoUnit.NANOS.between(Instant.EPOCH, predicateValue);
+
+    Expression expr =
+        and(notNull("ts"), predicate(Expression.Operation.EQ, "ts", nanos(nanosFromEpoch)));
+    Expression boundFilter = Binder.bind(schema.asStruct(), expr, true);
+
+    SearchArgument expected =
+        SearchArgumentFactory.newBuilder()
+            .startAnd()
+            .startNot()
+            .isNull("`ts`", Type.TIMESTAMP)
+            .end()
+            .equals("`ts`", Type.TIMESTAMP, Timestamp.from(predicateValue))
+            .end()
+            .build();
+
+    SearchArgument actual =
+        ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));
+
+    assertThat(actual.toString()).isEqualTo(expected.toString());
+  }
+
+  private static Stream<Types.TimestampNanoType> timestampNanoTypes() {
+    return Stream.of(Types.TimestampNanoType.withoutZone(), Types.TimestampNanoType.withZone());
   }
 }

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
@@ -23,29 +23,36 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericDataUtil;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.orc.OrcConf;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestOrcDataReader implements WithAssertions {
 
@@ -166,5 +173,55 @@ public class TestOrcDataReader implements WithAssertions {
     assertThat(readRecords.get(0).get(0)).isEqualTo(3L);
     assertThat(readRecords.get(0).get(1)).isEqualTo("c");
     assertThat(readRecords.get(0).get(3)).isEqualTo(Arrays.asList(3, 4, 5));
+  }
+
+  @ParameterizedTest
+  @MethodSource("timestampNanoTypes")
+  void filtersTimestampNanosWithoutLosingPrecision(Types.TimestampNanoType timestampType)
+      throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "ts", timestampType));
+
+    long boundaryNanos = DateTimeUtil.isoTimestampToNanos("2026-01-01T00:00:00.000000000");
+    Object boundary = GenericDataUtil.internalToGeneric(timestampType, boundaryNanos);
+    Object matchingValue = GenericDataUtil.internalToGeneric(timestampType, boundaryNanos + 1);
+
+    GenericRecord recordTemplate = GenericRecord.create(schema);
+    OutputFile timestampFile =
+        Files.localOutput(File.createTempFile("timestamp-nano-", ".orc", temp));
+
+    try (FileAppender<Record> writer =
+        ORC.write(timestampFile)
+            .schema(schema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .build()) {
+      writer.add(recordTemplate.copy("id", 1L, "ts", boundary));
+      writer.add(recordTemplate.copy("id", 2L, "ts", matchingValue));
+      writer.add(recordTemplate.copy("id", 3L));
+    }
+
+    Expression filter =
+        Expressions.predicate(Expression.Operation.GT, "ts", Expressions.nanos(boundaryNanos));
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader =
+        ORC.read(timestampFile.toInputFile())
+            .project(schema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+            .filter(filter)
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .config(OrcConf.READER_USE_SELECTED.getAttribute(), String.valueOf(true))
+            .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    assertThat(rows).extracting(row -> row.getField("id")).containsExactly(2L);
+  }
+
+  private static Stream<Types.TimestampNanoType> timestampNanoTypes() {
+    return Stream.of(Types.TimestampNanoType.withoutZone(), Types.TimestampNanoType.withZone());
   }
 }


### PR DESCRIPTION
Fixes #17749

## Summary

- Support ORC predicate pushdown for `timestamp_ns` and `timestamptz_ns`.
- Preserve nanosecond precision when converting predicate literals.
- Add SARG conversion and ORC reader correctness tests.