### PR TITLE
Core: Make PlanTableScanResponse buider withCredentials replace instead of append

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.PlanStatus;
 import org.apache.iceberg.rest.credentials.Credential;
 
@@ -110,7 +109,7 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
 
     private PlanStatus planStatus;
     private ErrorResponse errorResponse;
-    private final List<Credential> credentials = Lists.newArrayList();
+    private List<Credential> credentials = ImmutableList.of();
 
     public Builder withPlanStatus(PlanStatus status) {
       this.planStatus = status;
@@ -122,8 +121,10 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
       return this;
     }
 
-    public Builder withCredentials(List<Credential> credentialsToAdd) {
-      credentials.addAll(credentialsToAdd);
+    public Builder withCredentials(List<Credential> newCredentials) {
+      Preconditions.checkArgument(null != newCredentials, "Invalid credentials: null");
+      Preconditions.checkArgument(!newCredentials.contains(null), "Invalid credential: null");
+      this.credentials = ImmutableList.copyOf(newCredentials);
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.PlanStatus;
 import org.apache.iceberg.rest.credentials.Credential;
 
@@ -144,7 +143,7 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
     private PlanStatus planStatus;
     private String planId;
     private ErrorResponse errorResponse;
-    private final List<Credential> credentials = Lists.newArrayList();
+    private List<Credential> credentials = ImmutableList.of();
 
     private Builder() {}
 
@@ -163,8 +162,10 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
       return this;
     }
 
-    public Builder withCredentials(List<Credential> credentialsToAdd) {
-      credentials.addAll(credentialsToAdd);
+    public Builder withCredentials(List<Credential> newCredentials) {
+      Preconditions.checkArgument(null != newCredentials, "Invalid credentials: null");
+      Preconditions.checkArgument(!newCredentials.contains(null), "Invalid credential: null");
+      this.credentials = ImmutableList.copyOf(newCredentials);
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.DeleteFile;
@@ -57,6 +58,17 @@ public class TestFetchPlanningResultResponseParser {
           .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
           .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
+
+  private static final Credential S3_CREDENTIAL =
+      ImmutableCredential.builder()
+          .prefix("s3://custom-uri")
+          .config(ImmutableMap.of("s3.access-key-id", "keyId"))
+          .build();
+  private static final Credential GCS_CREDENTIAL =
+      ImmutableCredential.builder()
+          .prefix("gs://custom-uri")
+          .config(ImmutableMap.of("gcs.oauth2.token", "gcsToken"))
+          .build();
 
   @BeforeEach
   public void before() {
@@ -383,5 +395,31 @@ public class TestFetchPlanningResultResponseParser {
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid response: error can only be returned in a 'failed' status");
+  }
+
+  @Test
+  void withCredentialsReplacesPreviouslySetCredentials() {
+    FetchPlanningResultResponse response =
+        FetchPlanningResultResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withCredentials(ImmutableList.of(S3_CREDENTIAL))
+            .withCredentials(ImmutableList.of(GCS_CREDENTIAL))
+            .build();
+
+    assertThat(response.credentials()).containsExactly(GCS_CREDENTIAL);
+  }
+
+  @Test
+  void nullCredentials() {
+    assertThatThrownBy(() -> FetchPlanningResultResponse.builder().withCredentials(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid credentials: null");
+
+    assertThatThrownBy(
+            () ->
+                FetchPlanningResultResponse.builder()
+                    .withCredentials(Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid credential: null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TestBase.SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.DataFile;
@@ -49,6 +50,17 @@ import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.junit.jupiter.api.Test;
 
 public class TestPlanTableScanResponseParser {
+
+  private static final Credential S3_CREDENTIAL =
+      ImmutableCredential.builder()
+          .prefix("s3://custom-uri")
+          .config(ImmutableMap.of("s3.access-key-id", "keyId"))
+          .build();
+  private static final Credential GCS_CREDENTIAL =
+      ImmutableCredential.builder()
+          .prefix("gs://custom-uri")
+          .config(ImmutableMap.of("gcs.oauth2.token", "gcsToken"))
+          .build();
 
   @Test
   public void nullAndEmptyCheck() {
@@ -854,5 +866,30 @@ public class TestPlanTableScanResponseParser {
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid response: error can only be defined when status is 'failed'");
+  }
+
+  @Test
+  void withCredentialsReplacesPreviouslySetCredentials() {
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .withCredentials(ImmutableList.of(S3_CREDENTIAL))
+            .withCredentials(ImmutableList.of(GCS_CREDENTIAL))
+            .build();
+
+    assertThat(response.credentials()).containsExactly(GCS_CREDENTIAL);
+  }
+
+  @Test
+  void nullCredentials() {
+    assertThatThrownBy(() -> PlanTableScanResponse.builder().withCredentials(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid credentials: null");
+
+    assertThatThrownBy(
+            () -> PlanTableScanResponse.builder().withCredentials(Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid credential: null");
   }
 }


### PR DESCRIPTION
Follow up of https://github.com/apache/iceberg/pull/17638#issuecomment-5350304623 with changes in `PlanTableScanResponse.Builder` and `FetchPlanningResultResponse.Builder`

1. `withCredentials(List<Credential>)` now replaces the builder's credentials instead of appending to them. 
1. It now rejects a `null` list and `null` elements as the follow up of https://github.com/apache/iceberg/pull/14994#discussion_r2674976008
4. `build()` now passes `ImmutableList.copyOf(credentials)` instead of the builder's live `ArrayList`.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: reviewed
- Prompt Summary: Investigate the `withCredentials` append-vs-replace question raised in review of #17638.