### PR TITLE
Core: Preserve metadata log snapshot details after snapshot expiration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
@@ -20,19 +20,28 @@ package org.apache.iceberg;
 
 import java.util.List;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.SnapshotUtil;
 
 public class MetadataLogEntriesTable extends BaseMetadataTable {
+
+  private static final Types.NestedField LATEST_SNAPSHOT_ID =
+      Types.NestedField.optional(3, "latest_snapshot_id", Types.LongType.get());
+
+  private static final Types.NestedField LATEST_SCHEMA_ID =
+      Types.NestedField.optional(4, "latest_schema_id", Types.IntegerType.get());
+
+  private static final Types.NestedField LATEST_SEQUENCE_NUMBER =
+      Types.NestedField.optional(5, "latest_sequence_number", Types.LongType.get());
 
   private static final Schema METADATA_LOG_ENTRIES_SCHEMA =
       new Schema(
           Types.NestedField.required(1, "timestamp", Types.TimestampType.withZone()),
           Types.NestedField.required(2, "file", Types.StringType.get()),
-          Types.NestedField.optional(3, "latest_snapshot_id", Types.LongType.get()),
-          Types.NestedField.optional(4, "latest_schema_id", Types.IntegerType.get()),
-          Types.NestedField.optional(5, "latest_sequence_number", Types.LongType.get()));
+          LATEST_SNAPSHOT_ID,
+          LATEST_SCHEMA_ID,
+          LATEST_SEQUENCE_NUMBER);
 
   MetadataLogEntriesTable(Table table) {
     this(table, table.name() + ".metadata_log_entries");
@@ -59,18 +68,46 @@ public class MetadataLogEntriesTable extends BaseMetadataTable {
 
   private DataTask task(TableScan scan) {
     TableMetadata current = table().operations().current();
+
     List<TableMetadata.MetadataLogEntry> metadataLogEntries =
         Lists.newArrayList(current.previousFiles().listIterator());
+
     metadataLogEntries.add(
         new TableMetadata.MetadataLogEntry(
             current.lastUpdatedMillis(), current.metadataFileLocation()));
+
+    Schema projectedSchema = scan.schema();
+    boolean shouldLoadSnapshotDetails =
+        projectedSchema.findField(LATEST_SNAPSHOT_ID.fieldId()) != null
+            || projectedSchema.findField(LATEST_SCHEMA_ID.fieldId()) != null
+            || projectedSchema.findField(LATEST_SEQUENCE_NUMBER.fieldId()) != null;
+
     return StaticDataTask.of(
         table().io().newInputFile(current.metadataFileLocation()),
         schema(),
-        scan.schema(),
+        projectedSchema,
         metadataLogEntries,
         metadataLogEntry ->
-            MetadataLogEntriesTable.metadataLogEntryToRow(metadataLogEntry, table()));
+            metadataLogEntryToRow(metadataLogEntry, current, shouldLoadSnapshotDetails));
+  }
+
+  private Snapshot latestSnapshotForEntry(
+      TableMetadata.MetadataLogEntry metadataLogEntry, TableMetadata current) {
+    // Resolve snapshot details from the metadata file represented by this entry because snapshots
+    // may have been removed from the current table history after snapshot expiration.
+    TableMetadata metadata =
+        metadataLogEntry.file().equals(current.metadataFileLocation())
+            ? current
+            : TableMetadataParser.read(table().io(), metadataLogEntry.file());
+
+    List<HistoryEntry> snapshotLog = metadata.snapshotLog();
+    if (snapshotLog.isEmpty()) {
+      // The initial table metadata does not contain a snapshot.
+      return null;
+    }
+
+    HistoryEntry latestEntry = Iterables.getLast(snapshotLog);
+    return metadata.snapshot(latestEntry.snapshotId());
   }
 
   private class MetadataLogScan extends StaticTableScan {
@@ -102,22 +139,17 @@ public class MetadataLogEntriesTable extends BaseMetadataTable {
     }
   }
 
-  private static StaticDataTask.Row metadataLogEntryToRow(
-      TableMetadata.MetadataLogEntry metadataLogEntry, Table table) {
-    Long latestSnapshotId = null;
-    Snapshot latestSnapshot = null;
-    try {
-      latestSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, metadataLogEntry.timestampMillis());
-      latestSnapshot = table.snapshot(latestSnapshotId);
-    } catch (IllegalArgumentException ignored) {
-      // implies this metadata file was created at table creation
-    }
+  private StaticDataTask.Row metadataLogEntryToRow(
+      TableMetadata.MetadataLogEntry metadataLogEntry,
+      TableMetadata current,
+      boolean shouldLoadSnapshotDetails) {
+    Snapshot latestSnapshot =
+        shouldLoadSnapshotDetails ? latestSnapshotForEntry(metadataLogEntry, current) : null;
 
     return StaticDataTask.Row.of(
         metadataLogEntry.timestampMillis() * 1000,
         metadataLogEntry.file(),
-        // latest snapshot in this file corresponding to the log entry
-        latestSnapshotId,
+        latestSnapshot != null ? latestSnapshot.snapshotId() : null,
         latestSnapshot != null ? latestSnapshot.schemaId() : null,
         latestSnapshot != null ? latestSnapshot.sequenceNumber() : null);
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestMetadataLogEntriesTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestMetadataLogEntriesTable.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hadoop;
+
+import static org.apache.iceberg.MetadataTableType.METADATA_LOG_ENTRIES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataTask;
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.junit.jupiter.api.Test;
+
+class TestMetadataLogEntriesTable extends HadoopTableTestBase {
+
+  @Test
+  void preservesSnapshotDetailsAfterSnapshotExpiration() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot firstSnapshot = table.currentSnapshot();
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot secondSnapshot = table.currentSnapshot();
+
+    TableMetadata beforeExpiration = ((HasTableOperations) table).operations().current();
+    List<TableMetadata.MetadataLogEntry> metadataLog = beforeExpiration.previousFiles();
+
+    table
+        .expireSnapshots()
+        .expireSnapshotId(firstSnapshot.snapshotId())
+        .cleanupLevel(ExpireSnapshots.CleanupLevel.NONE)
+        .commit();
+
+    TableMetadata afterExpiration = ((HasTableOperations) table).operations().current();
+
+    Table metadataTable =
+        MetadataTableUtils.createMetadataTableInstance(table, METADATA_LOG_ENTRIES);
+
+    try (CloseableIterable<FileScanTask> tasks = metadataTable.newScan().planFiles()) {
+      DataTask task = Iterables.getOnlyElement(tasks).asDataTask();
+
+      try (CloseableIterable<StructLike> rows = task.rows()) {
+        Iterator<StructLike> iterator = rows.iterator();
+
+        assertMetadataLogRow(iterator.next(), metadataLog.get(0).file(), null);
+        assertMetadataLogRow(iterator.next(), metadataLog.get(1).file(), firstSnapshot);
+        assertMetadataLogRow(
+            iterator.next(), beforeExpiration.metadataFileLocation(), secondSnapshot);
+        assertMetadataLogRow(
+            iterator.next(), afterExpiration.metadataFileLocation(), secondSnapshot);
+
+        assertThat(iterator).isExhausted();
+      }
+    }
+  }
+
+  @Test
+  void avoidLoadHistoricalMetadataWhenSnapshotColumnsAreNotProjected() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    TableMetadata current = ((HasTableOperations) table).operations().current();
+
+    List<String> expectedFiles =
+        current.previousFiles().stream()
+            .map(TableMetadata.MetadataLogEntry::file)
+            .collect(Collectors.toList());
+    expectedFiles.add(current.metadataFileLocation());
+
+    Table metadataTable =
+        MetadataTableUtils.createMetadataTableInstance(table, METADATA_LOG_ENTRIES);
+
+    for (TableMetadata.MetadataLogEntry entry : current.previousFiles()) {
+      table.io().deleteFile(entry.file());
+    }
+
+    try (CloseableIterable<FileScanTask> tasks =
+        metadataTable.newScan().select("file").planFiles()) {
+      DataTask task = Iterables.getOnlyElement(tasks).asDataTask();
+
+      try (CloseableIterable<StructLike> rows = task.rows()) {
+        assertThat(rows)
+            .extracting(row -> row.get(0, String.class))
+            .containsExactlyElementsOf(expectedFiles);
+      }
+    }
+  }
+
+  private static void assertMetadataLogRow(
+      StructLike row, String expectedFile, Snapshot expectedSnapshot) {
+    assertThat(row.get(1, String.class)).isEqualTo(expectedFile);
+
+    if (expectedSnapshot == null) {
+      assertThat(row.get(2, Long.class)).isNull();
+      assertThat(row.get(3, Integer.class)).isNull();
+      assertThat(row.get(4, Long.class)).isNull();
+    } else {
+      assertThat(row.get(2, Long.class)).isEqualTo(expectedSnapshot.snapshotId());
+      assertThat(row.get(3, Integer.class)).isEqualTo(expectedSnapshot.schemaId());
+      assertThat(row.get(4, Long.class)).isEqualTo(expectedSnapshot.sequenceNumber());
+    }
+  }
+}


### PR DESCRIPTION
Fixes #17761

## Summary
Snapshot details are now resolved from each entry's metadata file instead of the current table history. Historical metadata files are loaded only when snapshot detail columns are required.

## Tests
Tests cover snapshot expiration and projection without loading historical metadata files.