### PR TITLE
Core: Read delete manifests correctly during snapshot expiration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -84,6 +84,7 @@ abstract class FileCleanupStrategy {
           ManifestFile.schema(),
           ImmutableSet.of(
               ManifestFile.PATH.fieldId(),
+              ManifestFile.MANIFEST_CONTENT.fieldId(),
               ManifestFile.LENGTH.fieldId(),
               ManifestFile.SPEC_ID.fieldId(),
               ManifestFile.SNAPSHOT_ID.fieldId(),

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -103,7 +103,7 @@ public class ManifestFiles {
   }
 
   /**
-   * Returns a {@link CloseableIterable} of file paths in the {@link ManifestFile}.
+   * Returns a {@link CloseableIterable} of live file paths in the {@link ManifestFile}.
    *
    * @param manifest a ManifestFile
    * @param io a FileIO
@@ -113,7 +113,7 @@ public class ManifestFiles {
   public static CloseableIterable<String> readPaths(
       ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
     return CloseableIterable.transform(
-        read(manifest, io, specsById).select(ImmutableList.of("file_path")).liveEntries(),
+        open(manifest, io, specsById).select(ImmutableList.of("file_path")).liveEntries(),
         entry -> entry.file().location());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -82,6 +83,31 @@ public class TestManifestReader extends TestBase {
     assertThatThrownBy(() -> ManifestFiles.read(manifest, FILE_IO, table.specs()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot read from ManifestFile with null (unassigned) snapshot ID");
+  }
+
+  @TestTemplate
+  public void testReadPathsFromDataManifest() throws IOException {
+    ManifestFile manifest = writeManifest(1000L, FILE_A, FILE_B);
+    try (CloseableIterable<String> paths =
+        ManifestFiles.readPaths(manifest, FILE_IO, table.specs())) {
+      assertThat(paths).containsExactlyInAnyOrder(FILE_A.location(), FILE_B.location());
+    }
+  }
+
+  @TestTemplate
+  public void testReadPathsFromDeleteManifest() throws IOException {
+    assumeThat(formatVersion)
+        .as("Delete files are only supported in V2 and later")
+        .isGreaterThanOrEqualTo(2);
+
+    DeleteFile deletes = fileADeletes();
+    ManifestFile manifest = writeDeleteManifest(formatVersion, 1000L, deletes);
+    assertThat(manifest.content()).isEqualTo(ManifestContent.DELETES);
+
+    try (CloseableIterable<String> paths =
+        ManifestFiles.readPaths(manifest, FILE_IO, table.specs())) {
+      assertThat(paths).containsExactly(deletes.location());
+    }
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +44,7 @@ import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.puffin.Blob;
@@ -52,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.TestTemplate;
@@ -68,8 +71,12 @@ public class TestRemoveSnapshots extends TestBase {
     return Arrays.asList(
         new Object[] {1, true},
         new Object[] {2, true},
+        new Object[] {3, true},
+        new Object[] {4, true},
         new Object[] {1, false},
-        new Object[] {2, false});
+        new Object[] {2, false},
+        new Object[] {3, false},
+        new Object[] {4, false});
   }
 
   private long waitUntilAfter(long timestampMillis) {
@@ -2135,6 +2142,36 @@ public class TestRemoveSnapshots extends TestBase {
     assertThatThrownBy(() -> table.expireSnapshots().cleanupLevel(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid cleanup level: null");
+  }
+
+  @TestTemplate
+  void readManifestsProjectsManifestContent() throws IOException {
+    assumeThat(formatVersion)
+        .as("Delete files are only supported in V2 and later")
+        .isGreaterThanOrEqualTo(2);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(fileADeletes()).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    Map<String, ManifestContent> expected =
+        snapshot.allManifests(table.io()).stream()
+            .collect(Collectors.toMap(ManifestFile::path, ManifestFile::content));
+    assertThat(expected).containsValue(ManifestContent.DELETES);
+
+    FileCleanupStrategy cleanup =
+        incrementalCleanup
+            ? new IncrementalFileCleanup(table.io(), null, null, null)
+            : new ReachableFileCleanup(table.io(), null, null, null);
+
+    Map<String, ManifestContent> actual = Maps.newHashMap();
+    try (CloseableIterable<ManifestFile> manifests = cleanup.readManifests(snapshot)) {
+      for (ManifestFile manifest : manifests) {
+        actual.put(manifest.path(), manifest.content());
+      }
+    }
+
+    assertThat(actual).isEqualTo(expected);
   }
 
   private StatisticsFile writeStatsFile(


### PR DESCRIPTION
2 bugs make it right: 

1. FileCleanupStrategy#readManifests projects the manifest list without the content field (517) and GenericManifestFile defaults content to DATA and only assigns it when the field is projected, so every manifest handled by ReachableFileCleanup and IncrementalFileCleanup reports ManifestContent.DATA, including delete manifests.

2. ManifestFiles.readPath open reads data manifest and ManifestReader does not derive its schema from FileType. 

Clean up of delete manifest as part of snapshot expiration is already covered today in https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java#L1040