### PR TITLE
Core: Fix commit validation when a data file has multiple DVs across snapshots

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -776,6 +776,26 @@ acceptedBreaks:
         \ java.util.Set<java.lang.Integer>, org.apache.iceberg.mapping.NameMapping)"
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
+      old: "method org.apache.iceberg.DeleteFileIndex org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedDeleteFiles(org.apache.iceberg.TableMetadata,\
+        \ java.lang.Long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.util.PartitionSet,\
+        \ org.apache.iceberg.Snapshot) @ org.apache.iceberg.BaseOverwriteFiles"
+      justification: "Internal validation helper, not an extension point"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.DeleteFileIndex org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedDeleteFiles(org.apache.iceberg.TableMetadata,\
+        \ java.lang.Long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.util.PartitionSet,\
+        \ org.apache.iceberg.Snapshot) @ org.apache.iceberg.BaseReplacePartitions"
+      justification: "Internal validation helper, not an extension point"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.DeleteFileIndex org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedDeleteFiles(org.apache.iceberg.TableMetadata,\
+        \ java.lang.Long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.util.PartitionSet,\
+        \ org.apache.iceberg.Snapshot) @ org.apache.iceberg.BaseRowDelta"
+      justification: "Internal validation helper, not an extension point"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.DeleteFileIndex org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedDeleteFiles(org.apache.iceberg.TableMetadata,\
+        \ java.lang.Long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.util.PartitionSet,\
+        \ org.apache.iceberg.Snapshot) @ org.apache.iceberg.StreamingDelete"
+      justification: "Internal validation helper, not an extension point"
+    - code: "java.method.removed"
       old: "method org.apache.iceberg.ManifestReader<org.apache.iceberg.DataFile>\
         \ org.apache.iceberg.ManifestFiles::read(org.apache.iceberg.ManifestFile,\
         \ org.apache.iceberg.io.FileIO)"

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -25,7 +25,7 @@ import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFA
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -528,26 +528,38 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       return;
     }
 
-    DeleteFileIndex deletes = addedDeleteFiles(base, startingSnapshotId, dataFilter, null, parent);
+    List<DeleteFileIndex> deleteIndexes =
+        addedDeleteFilesIndexedPerSnapshot(base, startingSnapshotId, dataFilter, null, parent);
 
     long startingSequenceNumber = startingSequenceNumber(base, startingSnapshotId);
     for (DataFile dataFile : dataFiles) {
-      // if any delete is found that applies to files written in or before the starting snapshot,
-      // fail
-      DeleteFile[] deleteFiles = deletes.forDataFile(startingSequenceNumber, dataFile);
-      if (ignoreEqualityDeletes) {
-        ValidationException.check(
-            Arrays.stream(deleteFiles)
-                .noneMatch(deleteFile -> deleteFile.content() == FileContent.POSITION_DELETES),
-            "Cannot commit, found new position delete for replaced data file: %s",
-            dataFile);
-      } else {
-        ValidationException.check(
-            deleteFiles.length == 0,
-            "Cannot commit, found new delete for replaced data file: %s",
-            dataFile);
+      for (DeleteFileIndex deletes : deleteIndexes) {
+        // if any delete is found that applies to files written in or before the starting snapshot,
+        // fail
+        DeleteFile[] deleteFiles = deletes.forDataFile(startingSequenceNumber, dataFile);
+        if (ignoreEqualityDeletes) {
+          ValidationException.check(
+              !containsPositionDeletes(deleteFiles),
+              "Cannot commit, found new position delete for replaced data file: %s",
+              dataFile);
+        } else {
+          ValidationException.check(
+              deleteFiles.length == 0,
+              "Cannot commit, found new delete for replaced data file: %s",
+              dataFile);
+        }
       }
     }
+  }
+
+  private static boolean containsPositionDeletes(DeleteFile[] deleteFiles) {
+    for (DeleteFile deleteFile : deleteFiles) {
+      if (deleteFile.content() == FileContent.POSITION_DELETES) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -561,12 +573,14 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
    */
   protected void validateNoNewDeleteFiles(
       TableMetadata base, Long startingSnapshotId, Expression dataFilter, Snapshot parent) {
-    DeleteFileIndex deletes = addedDeleteFiles(base, startingSnapshotId, dataFilter, null, parent);
+    Set<String> locations =
+        referencedDeleteFileLocations(
+            addedDeleteFilesIndexedPerSnapshot(base, startingSnapshotId, dataFilter, null, parent));
     ValidationException.check(
-        deletes.isEmpty(),
+        locations.isEmpty(),
         "Found new conflicting delete files that can apply to records matching %s: %s",
         dataFilter,
-        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::location));
+        locations);
   }
 
   /**
@@ -580,17 +594,35 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
    */
   protected void validateNoNewDeleteFiles(
       TableMetadata base, Long startingSnapshotId, PartitionSet partitionSet, Snapshot parent) {
-    DeleteFileIndex deletes =
-        addedDeleteFiles(base, startingSnapshotId, null, partitionSet, parent);
+    Set<String> locations =
+        referencedDeleteFileLocations(
+            addedDeleteFilesIndexedPerSnapshot(
+                base, startingSnapshotId, null, partitionSet, parent));
     ValidationException.check(
-        deletes.isEmpty(),
+        locations.isEmpty(),
         "Found new conflicting delete files that can apply to records matching %s: %s",
         partitionSet,
-        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::location));
+        locations);
+  }
+
+  private static Set<String> referencedDeleteFileLocations(List<DeleteFileIndex> deleteIndexes) {
+    Set<String> locations = Sets.newLinkedHashSet();
+    for (DeleteFileIndex deletes : deleteIndexes) {
+      for (DeleteFile deleteFile : deletes.referencedDeleteFiles()) {
+        locations.add(deleteFile.location());
+      }
+    }
+
+    return locations;
   }
 
   /**
-   * Returns matching delete files have been added to the table since a starting snapshot.
+   * Returns one index per snapshot in the validation window, covering the matching delete files
+   * added since a starting snapshot.
+   *
+   * <p>Callers must check every index. A single index cannot hold them all because it allows at
+   * most one deletion vector per data file. That holds within a snapshot but not across them: a
+   * data file can be referenced by a replacement deletion vector in each snapshot in the window.
    *
    * @param base table metadata to validate
    * @param startingSnapshotId id of the snapshot current at the start of the operation
@@ -598,17 +630,15 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
    * @param partitionSet a partition set used to find delete files
    * @param parent parent snapshot of the branch
    */
-  protected DeleteFileIndex addedDeleteFiles(
+  private List<DeleteFileIndex> addedDeleteFilesIndexedPerSnapshot(
       TableMetadata base,
       Long startingSnapshotId,
       Expression dataFilter,
       PartitionSet partitionSet,
       Snapshot parent) {
-    // if there is no current table state, return empty delete file index
+    // if there is no current table state, no delete files have been added
     if (parent == null || base.formatVersion() < 2) {
-      return DeleteFileIndex.builderFor(ops().io(), ImmutableList.of())
-          .specsById(base.specsById())
-          .build();
+      return ImmutableList.of();
     }
 
     Pair<List<ManifestFile>, Set<Long>> history =
@@ -618,10 +648,24 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             VALIDATE_ADDED_DELETE_FILES_OPERATIONS,
             ManifestContent.DELETES,
             parent);
-    List<ManifestFile> deleteManifests = history.first();
+
+    // the history collects a manifest only from the snapshot that added it, so grouping by
+    // snapshot ID assigns each manifest to exactly one index and still reads it once.
+    // LinkedHashMap keeps the history order, which keeps the failure message deterministic.
+    Map<Long, List<ManifestFile>> deleteManifestsBySnapshot =
+        history.first().stream()
+            .collect(
+                Collectors.groupingBy(
+                    ManifestFile::snapshotId, LinkedHashMap::new, Collectors.toList()));
 
     long startingSequenceNumber = startingSequenceNumber(base, startingSnapshotId);
-    return buildDeleteFileIndex(deleteManifests, startingSequenceNumber, dataFilter, partitionSet);
+    List<DeleteFileIndex> deleteIndexes = Lists.newArrayList();
+    for (List<ManifestFile> deleteManifests : deleteManifestsBySnapshot.values()) {
+      deleteIndexes.add(
+          buildDeleteFileIndex(deleteManifests, startingSequenceNumber, dataFilter, partitionSet));
+    }
+
+    return deleteIndexes;
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -684,6 +684,43 @@ public class TestOverwriteWithValidation extends TestBase {
   }
 
   @TestTemplate
+  public void testConcurrentSuccessiveDVsForUnrelatedDataFile() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_DAY_1).appendFile(FILE_DAY_2), branch);
+
+    Snapshot firstSnapshot = latestSnapshot(table, branch);
+
+    OverwriteFiles overwrite =
+        table
+            .newOverwrite()
+            .deleteFile(FILE_DAY_2)
+            .addFile(FILE_DAY_2_MODIFIED)
+            .validateFromSnapshot(firstSnapshot.snapshotId())
+            .conflictDetectionFilter(alwaysTrue())
+            .validateNoConflictingDeletes();
+
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, FILE_DAY_1);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, FILE_DAY_1);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1)
+            .addDeletes(dv2)
+            .validateFromSnapshot(dvSnapshot.snapshotId()),
+        branch);
+
+    commit(table, overwrite, branch);
+
+    validateBranchFiles(table, branch, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+  }
+
+  @TestTemplate
   public void testConcurrentConflictingPositionDeletesOverwriteByFilter() {
     assumeThat(formatVersion).isEqualTo(2);
 

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -670,6 +670,46 @@ public class TestReplacePartitions extends TestBase {
   }
 
   @TestTemplate
+  public void testConcurrentSuccessiveDVsReplaceConflict() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newFastAppend().appendFile(FILE_A), branch);
+
+    TableMetadata base = readMetadata();
+    long baseId = latestSnapshot(base, branch).snapshotId();
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1).validateFromSnapshot(baseId), branch);
+
+    long dvSnapshotId = latestSnapshot(readMetadata(), branch).snapshotId();
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table.newRowDelta().removeDeletes(dv1).addDeletes(dv2).validateFromSnapshot(dvSnapshotId),
+        branch);
+
+    assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    table
+                        .newReplacePartitions()
+                        .validateFromSnapshot(baseId)
+                        .validateNoConflictingDeletes()
+                        .addFile(FILE_A),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Found new conflicting delete files that can apply to records matching "
+                + "[data_bucket=0]: ["
+                + dv2.location()
+                + ", "
+                + dv1.location()
+                + "]");
+  }
+
+  @TestTemplate
   public void testDeleteReplaceConflictNonPartitioned() {
     assumeThat(formatVersion).isEqualTo(2);
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -813,4 +813,314 @@ public class TestRewriteFiles extends TestBase {
         files(fileADeletes(), fileBDeletes()),
         statuses(ManifestEntry.Status.DELETED, ManifestEntry.Status.EXISTING));
   }
+
+  @TestTemplate
+  public void testRewriteOfFileWithSuccessiveDVReplacementsRejectedAsConflict() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+    Snapshot s1 = latestSnapshot(table, branch);
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1)
+            .addDeletes(dv2)
+            .validateFromSnapshot(s1.snapshotId()),
+        branch);
+
+    assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    table
+                        .newRewrite()
+                        .validateFromSnapshot(s0.snapshotId())
+                        .rewriteFiles(
+                            ImmutableSet.of(FILE_A),
+                            ImmutableSet.of(),
+                            ImmutableSet.of(FILE_B),
+                            ImmutableSet.of()),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot commit, found new delete for replaced data file");
+  }
+
+  @TestTemplate
+  public void testRewriteOfUnrelatedFileSucceedsWithSuccessiveDVReplacements() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+    Snapshot s1 = latestSnapshot(table, branch);
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1)
+            .addDeletes(dv2)
+            .validateFromSnapshot(s1.snapshotId()),
+        branch);
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    commit(
+        table,
+        table
+            .newRewrite()
+            .validateFromSnapshot(s0.snapshotId())
+            .rewriteFiles(
+                ImmutableSet.of(FILE_B),
+                ImmutableSet.of(),
+                ImmutableSet.of(FILE_C),
+                ImmutableSet.of()),
+        branch);
+
+    Snapshot finalSnapshot = latestSnapshot(table, branch);
+    assertThat(finalSnapshot.operation()).isEqualTo(DataOperations.REPLACE);
+
+    List<ManifestFile> manifests = finalSnapshot.allManifests(table.io());
+    assertThat(manifests).hasSize(3);
+
+    long rewriteSnapshotId = finalSnapshot.snapshotId();
+    validateManifestEntries(
+        manifests.get(0), ids(rewriteSnapshotId), files(FILE_C), statuses(ADDED));
+    validateManifestEntries(
+        manifests.get(1),
+        ids(s0.snapshotId(), rewriteSnapshotId),
+        files(FILE_A, FILE_B),
+        statuses(EXISTING, DELETED));
+
+    validateDeleteManifest(
+        manifests.get(2),
+        dataSeqs(dvSnapshot.sequenceNumber()),
+        fileSeqs(dvSnapshot.sequenceNumber()),
+        ids(dvSnapshot.snapshotId()),
+        files(dv2),
+        statuses(ADDED));
+  }
+
+  @TestTemplate
+  public void testRewriteOfUnrelatedFileSucceedsWhenDVRemovedByReplaceSnapshot() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+
+    // VALIDATE_ADDED_DELETE_FILES_OPERATIONS excludes "replace", so the window never opens the
+    // manifest that records the removal of DV1 and DV1 keeps a live entry in it
+    DeleteFile dv1prime = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRewrite()
+            .rewriteFiles(
+                ImmutableSet.of(),
+                ImmutableSet.of(dv1),
+                ImmutableSet.of(),
+                ImmutableSet.of(dv1prime)),
+        branch);
+    Snapshot s2 = latestSnapshot(table, branch);
+    assertThat(s2.operation()).isEqualTo(DataOperations.REPLACE);
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1prime)
+            .addDeletes(dv2)
+            .validateFromSnapshot(s2.snapshotId()),
+        branch);
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    commit(
+        table,
+        table
+            .newRewrite()
+            .validateFromSnapshot(s0.snapshotId())
+            .rewriteFiles(
+                ImmutableSet.of(FILE_B),
+                ImmutableSet.of(),
+                ImmutableSet.of(FILE_C),
+                ImmutableSet.of()),
+        branch);
+
+    Snapshot finalSnapshot = latestSnapshot(table, branch);
+    assertThat(finalSnapshot.operation()).isEqualTo(DataOperations.REPLACE);
+
+    List<ManifestFile> manifests = finalSnapshot.allManifests(table.io());
+    assertThat(manifests).hasSize(3);
+
+    long rewriteSnapshotId = finalSnapshot.snapshotId();
+    validateManifestEntries(
+        manifests.get(0), ids(rewriteSnapshotId), files(FILE_C), statuses(ADDED));
+    validateManifestEntries(
+        manifests.get(1),
+        ids(s0.snapshotId(), rewriteSnapshotId),
+        files(FILE_A, FILE_B),
+        statuses(EXISTING, DELETED));
+
+    validateDeleteManifest(
+        manifests.get(2),
+        dataSeqs(dvSnapshot.sequenceNumber()),
+        fileSeqs(dvSnapshot.sequenceNumber()),
+        ids(dvSnapshot.snapshotId()),
+        files(dv2),
+        statuses(ADDED));
+  }
+
+  @TestTemplate
+  public void testRewriteWithOldSequenceNumberRejectsSuccessiveDVReplacements() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+    long oldSequenceNumber = s0.sequenceNumber();
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+    Snapshot s1 = latestSnapshot(table, branch);
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1)
+            .addDeletes(dv2)
+            .validateFromSnapshot(s1.snapshotId()),
+        branch);
+
+    assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    table
+                        .newRewrite()
+                        .validateFromSnapshot(s0.snapshotId())
+                        .rewriteFiles(
+                            ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_D), oldSequenceNumber),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot commit, found new position delete for replaced data file");
+  }
+
+  @TestTemplate
+  public void testRewriteOfUnrelatedFileSucceedsWhenDVIsLiveInTwoManifests() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(
+        table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B).appendFile(FILE_C), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+
+    // both DVs land in one delete manifest
+    DeleteFile dvA = newDV(FILE_A);
+    DeleteFile dvB = newDV(FILE_B);
+    commit(table, table.newRowDelta().addDeletes(dvA).addDeletes(dvB), branch);
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    // dropping FILE_B's DV as dangling rewrites that manifest, and the copy still carries the DV
+    // for FILE_A, leaving it live in both
+    commit(table, table.newDelete().deleteFile(FILE_B), branch);
+    Snapshot danglingSnapshot = latestSnapshot(table, branch);
+
+    commit(
+        table,
+        table
+            .newRewrite()
+            .validateFromSnapshot(s0.snapshotId())
+            .rewriteFiles(
+                ImmutableSet.of(FILE_C),
+                ImmutableSet.of(),
+                ImmutableSet.of(FILE_D),
+                ImmutableSet.of()),
+        branch);
+
+    Snapshot finalSnapshot = latestSnapshot(table, branch);
+    assertThat(finalSnapshot.operation()).isEqualTo(DataOperations.REPLACE);
+
+    List<ManifestFile> manifests = finalSnapshot.allManifests(table.io());
+    assertThat(manifests).hasSize(3);
+
+    long rewriteSnapshotId = finalSnapshot.snapshotId();
+    validateManifestEntries(
+        manifests.get(0), ids(rewriteSnapshotId), files(FILE_D), statuses(ADDED));
+    validateManifestEntries(
+        manifests.get(1),
+        ids(s0.snapshotId(), rewriteSnapshotId),
+        files(FILE_A, FILE_C),
+        statuses(EXISTING, DELETED));
+
+    // the rewrite carries the delete manifest forward untouched, so the DV for FILE_A is still
+    // live in the copy written when FILE_B's DV was dropped
+    assertThat(manifests.get(2).snapshotId()).isEqualTo(danglingSnapshot.snapshotId());
+    validateDeleteManifest(
+        manifests.get(2),
+        dataSeqs(dvSnapshot.sequenceNumber(), dvSnapshot.sequenceNumber()),
+        fileSeqs(dvSnapshot.sequenceNumber(), dvSnapshot.sequenceNumber()),
+        ids(dvSnapshot.snapshotId(), danglingSnapshot.snapshotId()),
+        files(dvA, dvB),
+        statuses(EXISTING, DELETED));
+  }
+
+  @TestTemplate
+  public void testRewriteOfUnrelatedFileSucceedsWithSingleDV() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
+    Snapshot s0 = latestSnapshot(table, branch);
+
+    DeleteFile dv = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv), branch);
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    commit(
+        table,
+        table
+            .newRewrite()
+            .validateFromSnapshot(s0.snapshotId())
+            .rewriteFiles(
+                ImmutableSet.of(FILE_B),
+                ImmutableSet.of(),
+                ImmutableSet.of(FILE_C),
+                ImmutableSet.of()),
+        branch);
+
+    Snapshot finalSnapshot = latestSnapshot(table, branch);
+    assertThat(finalSnapshot.operation()).isEqualTo(DataOperations.REPLACE);
+
+    List<ManifestFile> manifests = finalSnapshot.allManifests(table.io());
+    assertThat(manifests).hasSize(3);
+
+    long rewriteSnapshotId = finalSnapshot.snapshotId();
+    validateManifestEntries(
+        manifests.get(0), ids(rewriteSnapshotId), files(FILE_C), statuses(ADDED));
+    validateManifestEntries(
+        manifests.get(1),
+        ids(s0.snapshotId(), rewriteSnapshotId),
+        files(FILE_A, FILE_B),
+        statuses(EXISTING, DELETED));
+
+    validateDeleteManifest(
+        manifests.get(2),
+        dataSeqs(dvSnapshot.sequenceNumber()),
+        fileSeqs(dvSnapshot.sequenceNumber()),
+        ids(dvSnapshot.snapshotId()),
+        files(dv),
+        statuses(ADDED));
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -1325,6 +1325,50 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testConcurrentSuccessiveDVsReportedAsConflictNotCorruption() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
+
+    Snapshot firstSnapshot = latestSnapshot(table, branch);
+
+    Expression conflictDetectionFilter = Expressions.alwaysTrue();
+
+    RowDelta rowDelta =
+        table
+            .newRowDelta()
+            .toBranch(branch)
+            .addDeletes(newDV(FILE_B))
+            .validateFromSnapshot(firstSnapshot.snapshotId())
+            .conflictDetectionFilter(conflictDetectionFilter)
+            .validateNoConflictingDeleteFiles();
+
+    DeleteFile dv1 = newDV(FILE_A);
+    commit(table, table.newRowDelta().addDeletes(dv1), branch);
+
+    Snapshot dvSnapshot = latestSnapshot(table, branch);
+
+    DeleteFile dv2 = newDV(FILE_A);
+    commit(
+        table,
+        table
+            .newRowDelta()
+            .removeDeletes(dv1)
+            .addDeletes(dv2)
+            .validateFromSnapshot(dvSnapshot.snapshotId()),
+        branch);
+
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Found new conflicting delete files that can apply to records matching true: ["
+                + dv2.location()
+                + ", "
+                + dv1.location()
+                + "]");
+  }
+
+  @TestTemplate
   public void testConcurrentConflictingRowDeltaWithoutAppendValidation() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 


### PR DESCRIPTION
## Problem

On format-v3 merge-on-read tables, compaction and other commit-time validations can fail with

    ValidationException: Can't index multiple DVs for <data file>

on a table that is not corrupt, scans succeed, and the current snapshot has exactly one live DV per data file.

`MergingSnapshotProducer.addedDeleteFiles` builds a `DeleteFileIndex` over the delete manifests added across the whole validation history between the starting snapshot and the current parent. A data file can legitimately have more than one DV in that window:

  * S0: append data file A (compactor starts here)
  * S1: writer adds DV1 for A
  * S2: writer removes DV1 and adds DV2 for A (valid MoR upsert)

Manifests are immutable: DV1 is still live in the manifest S1 wrote, DV2 in the one S2 wrote. The index reads live entries from every collected manifest, filtered only by sequence number, so it sees both. `Builder.build()` then throws from `putIfAbsent` on `dvByPath`, before validation reaches its conflict check.

The index covers the whole window and is not scoped to the data files being validated, so this rejects even a rewrite of an unrelated, delete-free file, stalling compaction on sustained-upsert workloads. The single-live-DV invariant is correct for scans, where a data file really does have at most one live DV. It does not hold across snapshots.

## Fix

Build one `DeleteFileIndex` per snapshot. `addedDeleteFileIndexes` groups the collected delete manifests by `ManifestFile.snapshotId()` and builds an index per group; all three callers check every index.

`validationHistory` collects a manifest only from the snapshot that added it, so grouping partitions the manifests: each lands in exactly one index and is still read once. Within a single snapshot a data file has at most one live DV — one superseded in the same commit is marked DELETED and dropped by `liveEntries()` — so the strict `dvByPath` invariant holds per index. Two live DVs for one data file in one snapshot is genuine corruption and still fails.

`DeleteFileIndex` is unchanged, so index semantics stay identical to scan planning: `forDataFile` still returns any global and equality-partition deletes alongside a DV and only suppresses position deletes when a DV is present.

Reconciling which DV is current instead would not work. The only evidence a DV was superseded is a DELETED entry, and two cases leave none in the window:
- `VALIDATE_ADDED_DELETE_FILES_OPERATIONS` excludes "replace", so a DV removed by delete file compaction keeps its ADDED entry; 
- and a manifest rewrite triggered by an unrelated dangling delete leaves one DV live in two manifests, where nothing was superseded at all.

Cost: N indexes instead of one, N being the validated snapshots in the window. Manifest reads are unchanged; the added cost is each index's `build()` overhead. Per-file lookups stay cheap — `forDataFile` short-circuits on an empty index, and on a non-empty one it is a few null checks and one `dvByPath` lookup.

## Tests

New regression tests across all three validation entry points (all format v3+):

