### PR TITLE
Fix #17759: REST client uses form encoding for URL path segments

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -157,6 +157,23 @@ public class RESTUtil {
   }
 
   /**
+   * Encodes a string for use in a URL path segment, as opposed to query parameters or form data.
+   *
+   * <p>Unlike {@link #encodeString(String)}, which uses {@code application/x-www-form-urlencoded}
+   * encoding where a space becomes {@code +}, this method uses percent-encoding where a space
+   * becomes {@code %20}. This is the correct encoding for path segments in REST resource URLs.
+   *
+   * <p>{@link #decodeString(String)} should be used to decode.
+   *
+   * @param toEncode string to encode
+   * @return UTF-8 percent-encoded string, suitable for use as a URL path segment
+   */
+  public static String encodePathSegment(String toEncode) {
+    Preconditions.checkArgument(toEncode != null, "Invalid string to encode: null");
+    return URLEncoder.encode(toEncode, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  /**
    * Decodes a URL-encoded string.
    *
    * <p>See also {@link #encodeString(String)} for URL encoding.
@@ -293,7 +310,7 @@ public class RESTUtil {
     String[] encodedLevels = new String[levels.length];
 
     for (int i = 0; i < levels.length; i++) {
-      encodedLevels[i] = encodeString(levels[i]);
+      encodedLevels[i] = encodePathSegment(levels[i]);
     }
 
     return Joiner.on(separator).join(encodedLevels);

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -110,7 +110,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()));
+        RESTUtil.encodePathSegment(ident.name()));
   }
 
   public String register(Namespace ns) {
@@ -128,7 +128,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(identifier.namespace()),
         "tables",
-        RESTUtil.encodeString(identifier.name()),
+        RESTUtil.encodePathSegment(identifier.name()),
         "metrics");
   }
 
@@ -139,7 +139,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(identifier.namespace()),
         "tables",
-        RESTUtil.encodeString(identifier.name()),
+        RESTUtil.encodePathSegment(identifier.name()),
         "sign");
   }
 
@@ -158,7 +158,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "views",
-        RESTUtil.encodeString(ident.name()));
+        RESTUtil.encodePathSegment(ident.name()));
   }
 
   public String renameView() {
@@ -176,7 +176,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "plan");
   }
 
@@ -187,9 +187,9 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "plan",
-        RESTUtil.encodeString(planId));
+        RESTUtil.encodePathSegment(planId));
   }
 
   public String fetchScanTasks(TableIdentifier ident) {
@@ -199,7 +199,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "tasks");
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -88,6 +88,10 @@ public class TestRESTUtil {
             String.format(
                 "dogs.and.cats%snamed%shank.or.james-westfall",
                 namespaceSeparator, namespaceSeparator),
+          },
+          new Object[] {
+            new String[] {"dogs with spaces", "named.hank"},
+            "dogs%20with%20spaces" + namespaceSeparator + "named.hank"
           }
         };
 
@@ -146,6 +150,18 @@ public class TestRESTUtil {
     String expected = "+%25%26%2B%C2%A3%E2%82%AC";
 
     assertThat(RESTUtil.encodeString(utf8)).isEqualTo(expected);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
+  public void testEncodePathSegment() {
+    // Path segments must be percent-encoded, not form-encoded: a space is %20, not '+'
+    String utf8 = "\u0020\u0025\u0026\u002B\u00A3\u20AC";
+    String expected = "%20%25%26%2B%C2%A3%E2%82%AC";
+    assertThat(RESTUtil.encodePathSegment(" ")).isEqualTo("%20");
+    assertThat(RESTUtil.encodePathSegment("my table")).isEqualTo("my%20table");
+    assertThat(RESTUtil.encodePathSegment("a/b")).isEqualTo("a%2Fb");
+    assertThat(RESTUtil.encodePathSegment(utf8)).isEqualTo(expected);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -211,6 +211,13 @@ public class TestResourcePaths {
   }
 
   @Test
+  public void testTableWithSpace() {
+    TableIdentifier ident = TableIdentifier.of("ns", "my table");
+    assertThat(withPrefix.table(ident)).isEqualTo("v1/ws/catalog/namespaces/ns/tables/my%20table");
+    assertThat(withoutPrefix.table(ident)).isEqualTo("v1/namespaces/ns/tables/my%20table");
+  }
+
+  @Test
   public void testTableWithMultipartNamespace() {
     TableIdentifier ident = TableIdentifier.of("n", "s", "table");
     assertThat(withPrefix.table(ident)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs/tables/table");
@@ -318,10 +325,11 @@ public class TestResourcePaths {
     assertThat(withoutPrefix.plan(tableId, planId))
         .isEqualTo("v1/namespaces/test_namespace/tables/test_table/plan/plan-abc-123");
 
-    // The planId contains a space which needs to be encoded
+    // The planId contains a space which needs to be encoded as %20 (percent-encoding),
+    // not '+' (which is only valid for application/x-www-form-urlencoded bodies)
     String spaceSeparatedPlanId = "plan with spaces";
     // The expected encoded version of the planId
-    String encodedPlanId = "plan+with+spaces";
+    String encodedPlanId = "plan%20with%20spaces";
 
     assertThat(withPrefix.plan(tableId, spaceSeparatedPlanId))
         .isEqualTo(


### PR DESCRIPTION
## Root cause

`RESTUtil.encodeString()` uses `java.net.URLEncoder` which implements `application/x-www-form-urlencoded` encoding where a space becomes `+`. This is correct for OAuth form bodies (`encodeFormData`) but incorrect for URL path segments. When `ResourcePaths` places namespace levels, table names, view names, or scan plan IDs into REST resource URLs, the `+` is sent as a literal character — servers like Nessie that treat it as literal break, and names containing spaces become unreachable.

## Fix

1. **`RESTUtil.java`**: Added `encodePathSegment()` that uses proper percent-encoding (space → `%20`) for URL path segments. `encodeNamespace()` now uses `encodePathSegment()` for each namespace level since its javadoc states it is "suitable for use in a URL / URI".

2. **`ResourcePaths.java`**: All `RESTUtil.encodeString()` calls for table names, view names, and scan plan IDs in resource URL paths are switched to `RESTUtil.encodePathSegment()`.

3. **Tests**: Added `testEncodePathSegment` in `TestRESTUtil.java` verifying percent-encoding. Added namespace with spaces test case to the round-trip encoding test. Added `testTableWithSpace` in `TestResourcePaths.java`. Updated `cancelPlanEndpointPath` to expect `%20` instead of the incorrect `+` encoding.

## Compatibility

`decodeString()` uses `URLDecoder.decode()` which handles both `+` and `%20` as spaces, so `decodeNamespace()` is fully backward-compatible with existing encoded data. Old clients that encoded spaces as `+` will still be decoded correctly.