### PR TITLE
core: retry REST OAuth2 token refresh after transient failure

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -416,6 +416,7 @@ public class OAuth2Util {
     private static int tokenRefreshNumRetries = 5;
     private static final long MAX_REFRESH_WINDOW_MILLIS = 300_000; // 5 minutes
     private static final long MIN_REFRESH_WAIT_MILLIS = 10;
+    private static final long FAILED_REFRESH_RETRY_WAIT_MILLIS = 60_000; // 1 minute
     private volatile Map<String, String> headers;
     private volatile AuthConfig config;
 
@@ -600,6 +601,16 @@ public class OAuth2Util {
                   executor,
                   session,
                   refreshStartTime + expiration.second().toMillis(expiration.first()));
+            } else if (session.config().keepRefreshed()) {
+              // the refresh failed, but the session is still active; schedule a bounded
+              // retry so a transient token endpoint failure does not permanently stop
+              // the refresh chain. If the session has been closed (stopRefreshing or
+              // close called), keepRefreshed is false, and no further refresh is scheduled.
+              scheduleTokenRefresh(
+                  client,
+                  executor,
+                  session,
+                  refreshStartTime + FAILED_REFRESH_RETRY_WAIT_MILLIS);
             }
           },
           timeToWait,
@@ -636,8 +647,13 @@ public class OAuth2Util {
             // otherwise use the expiration time from the token response
             expiresAtMillis = startTimeMillis + expiration.second().toMillis(expiration.first());
           }
+        } else if (session.config().keepRefreshed()) {
+          // token refresh failed, but the session is still active; schedule a bounded
+          // retry so a temporary token endpoint failure does not permanently stop
+          // refresh for this session
+          expiresAtMillis = startTimeMillis + FAILED_REFRESH_RETRY_WAIT_MILLIS;
         } else {
-          // token refresh failed, don't reattempt with the original expiration
+          // token refresh failed and refresh has been disabled; don't reattempt
           expiresAtMillis = null;
         }
       } else if (null == expiresAtMillis && defaultExpiresAtMillis != null) {

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -30,12 +30,14 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class TestOAuth2Util {
@@ -264,6 +266,102 @@ public class TestOAuth2Util {
     AuthSession parent = new AuthSession(Map.of(), parentConfig);
     assertThat(parent.expiresAtMillis()).isEqualTo(TimeUnit.SECONDS.toMillis(expSeconds));
     return parent;
+  }
+
+  /** A keep-refreshing parent session used to exercise the scheduled refresh chain. */
+  private static AuthSession refreshingParentSession() {
+    AuthConfig parentConfig =
+        AuthConfig.builder()
+            .token("parent_token")
+            .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+            .keepRefreshed(true)
+            .credential("testClientId:testClientSecret")
+            .oauth2ServerUri("/v1/token")
+            .build();
+    return new AuthSession(Map.of(), parentConfig);
+  }
+
+  @Test
+  void failedRefreshSchedulesBoundedRetryWhileSessionStaysActive() throws IOException {
+    AuthSession parent = refreshingParentSession();
+    String childToken =
+        tokenWithExp(
+            TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 3600); // not yet expired
+
+    RESTClient client = Mockito.mock(RESTClient.class);
+    // token endpoint is temporarily unavailable: refresh fails after retries
+    Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any()))
+        .thenAnswer(inv -> { throw new RuntimeException("token endpoint unavailable"); });
+
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+
+    // a non-expired token is scheduled for refresh without attempting a refresh now
+    AuthSession.fromAccessToken(client, executor, childToken, null, parent);
+
+    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+    Mockito.verify(executor, Mockito.times(1))
+        .schedule(taskCaptor.capture(), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
+
+    // run the scheduled refresh: it fails, but the session is still active, so a bounded
+    // retry must be scheduled instead of silently stopping the refresh chain
+    taskCaptor.getValue().run();
+
+    ArgumentCaptor<Long> retryDelay = ArgumentCaptor.forClass(Long.class);
+    Mockito.verify(executor, Mockito.times(2))
+        .schedule(Mockito.any(Runnable.class), retryDelay.capture(), Mockito.eq(TimeUnit.MILLISECONDS));
+
+    assertThat(retryDelay.getValue())
+        .as("failed refresh should schedule a bounded retry")
+        .isBetween(50_000L, 60_000L);
+  }
+
+  @Test
+  void closedSessionDoesNotRescheduleAfterFailedRefresh() throws IOException {
+    AuthSession parent = refreshingParentSession();
+    String childToken =
+        tokenWithExp(
+            TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 3600); // not yet expired
+
+    RESTClient client = Mockito.mock(RESTClient.class);
+    Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any()))
+        .thenAnswer(inv -> { throw new RuntimeException("token endpoint unavailable"); });
+
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+
+    AuthSession child = AuthSession.fromAccessToken(client, executor, childToken, null, parent);
+
+    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+    Mockito.verify(executor, Mockito.times(1))
+        .schedule(taskCaptor.capture(), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
+
+    // close the session before the scheduled refresh runs: the refresh chain must stop
+    child.close();
+
+    taskCaptor.getValue().run();
+
+    Mockito.verify(executor, Mockito.times(1))
+        .schedule(Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  void initialRefreshFailureSchedulesBoundedRetryWhenSessionStaysActive() {
+    AuthSession parent = refreshingParentSession();
+    String expiredToken =
+        tokenWithExp(
+            TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) - 3600); // already expired
+
+    RESTClient client = Mockito.mock(RESTClient.class);
+    Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any()))
+        .thenAnswer(inv -> { throw new RuntimeException("token endpoint unavailable"); });
+
+    ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+
+    // the expired token is refreshed immediately in fromAccessToken; when that fails and
+    // the session is still active, a bounded retry must be scheduled rather than dropped
+    AuthSession.fromAccessToken(client, executor, expiredToken, null, parent);
+
+    Mockito.verify(executor, Mockito.times(1))
+        .schedule(Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
   }
 
   private static OAuthTokenResponse childTokenResponse(String token, int expiresInSeconds) {


### PR DESCRIPTION
Fixes #17756

## Problem

One failed background OAuth2 token refresh permanently stops refresh for that `AuthSession`.

`scheduleTokenRefresh` chains one-shot scheduled tasks: a successful `AuthSession.refresh(client)` returns the next expiration, which schedules the following task. When refresh fails (retries exhausted + credential fallback fails), `refresh` returns `null`, and the chain simply ends — no manager or request path re-arms it:

- `authenticate` keeps attaching the stale token already stored in the session.
- After the token expires, requests receive 401s for the remaining lifetime of the catalog object even after the token endpoint recovers.

Reproduced by the issue: a token endpoint down for ~8s at refresh time (6 `Tasks` attempts + 1 credential fallback, ~3.1s of sleep) permanently disabled refresh. StarRocks reports the same production failure (StarRocks/starrocks#76438).

## Fix

Distinguish the three outcomes the scheduling chain needs:

1. **Refresh succeeded** → schedule from the new expiration (unchanged).
2. **Refresh failed temporarily** → schedule a bounded retry (60s) so a transient endpoint outage delays refresh instead of permanently disabling it.
3. **Session closed** (`stopRefreshing()`/`close()`, i.e. `keepRefreshed == false`) → do not schedule again.

- `scheduleTokenRefresh`: when `refresh()` returns `null` but `session.config().keepRefreshed()` is still `true`, reschedule with a fixed 60s bounded wait instead of dropping the chain.
- `fromAccessToken` initial-refresh path: when the initial refresh of an already-expired token fails while the session stays active, schedule the same bounded retry instead of leaving `expiresAtMillis` null (which skipped scheduling entirely).

A fixed bounded retry avoids hammering an unavailable token endpoint while still allowing recovery, and it automatically stops for closed sessions (no unconditional `null`-rescheduling loop).

## Tests

Three new tests in `TestOAuth2Util`:

- `failedRefreshSchedulesBoundedRetryWhileSessionStaysActive` — a scheduled refresh that fails (token endpoint down) reschedules with a ~60s delay.
- `closedSessionDoesNotRescheduleAfterFailedRefresh` — after `close()`, a failed refresh does not reschedule.
- `initialRefreshFailureSchedulesBoundedRetryWhenSessionStaysActive` — an already-expired token whose initial refresh fails still schedules the bounded retry.

All 12 tests in `TestOAuth2Util` pass.
