### PR TITLE
Core: Fix REST path encoding to use %20 instead of +

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -143,9 +143,25 @@ public class RESTUtil {
   }
 
   /**
+   * Encodes a string for use as a single URL path segment.
+   *
+   * <p>Unlike {@link #encodeString(String)}, which encodes for application/x-www-form-urlencoded
+   * and represents a space as '+', this represents a space as %20. A '+' in the input is escaped to
+   * %2B, so the two cannot be confused.
+   *
+   * @param toEncode string to encode
+   * @return UTF-8 encoded string, suitable for use as a URL path segment
+   */
+  public static String encodePathSegment(String toEncode) {
+    Preconditions.checkArgument(toEncode != null, "Invalid string to encode: null");
+    return URLEncoder.encode(toEncode, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  /**
    * Decodes a URL-encoded string.
    *
-   * <p>See also {@link #encodeString(String)} for URL encoding.
+   * <p>See also {@link #encodeString(String)} for URL parameter encoding, or {@link
+   * #encodePathSegment(String)} for URL path segment encoding.
    *
    * @param encoded a string to decode
    * @return a decoded string
@@ -249,7 +265,7 @@ public class RESTUtil {
    * @param namespace namespace to encode
    * @param separator The namespace separator to be used for encoding. The separator will be used
    *     as-is and won't be UTF-8 encoded.
-   * @return UTF-8 encoded string representing the namespace, suitable for use as a URL parameter
+   * @return UTF-8 encoded string representing the namespace, suitable for use in a URL path
    */
   public static String encodeNamespace(Namespace namespace, String separator) {
     Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
@@ -259,7 +275,7 @@ public class RESTUtil {
     String[] encodedLevels = new String[levels.length];
 
     for (int i = 0; i < levels.length; i++) {
-      encodedLevels[i] = encodeString(levels[i]);
+      encodedLevels[i] = encodePathSegment(levels[i]);
     }
 
     return Joiner.on(separator).join(encodedLevels);

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -101,7 +101,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()));
+        RESTUtil.encodePathSegment(ident.name()));
   }
 
   public String register(Namespace ns) {
@@ -119,7 +119,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(identifier.namespace()),
         "tables",
-        RESTUtil.encodeString(identifier.name()),
+        RESTUtil.encodePathSegment(identifier.name()),
         "metrics");
   }
 
@@ -130,7 +130,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(identifier.namespace()),
         "tables",
-        RESTUtil.encodeString(identifier.name()),
+        RESTUtil.encodePathSegment(identifier.name()),
         "sign");
   }
 
@@ -149,7 +149,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "views",
-        RESTUtil.encodeString(ident.name()));
+        RESTUtil.encodePathSegment(ident.name()));
   }
 
   public String renameView() {
@@ -167,7 +167,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "plan");
   }
 
@@ -178,9 +178,9 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "plan",
-        RESTUtil.encodeString(planId));
+        RESTUtil.encodePathSegment(planId));
   }
 
   public String fetchScanTasks(TableIdentifier ident) {
@@ -190,7 +190,7 @@ public class ResourcePaths {
         "namespaces",
         pathEncode(ident.namespace()),
         "tables",
-        RESTUtil.encodeString(ident.name()),
+        RESTUtil.encodePathSegment(ident.name()),
         "tasks");
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
@@ -88,7 +88,16 @@ class TestHTTPRequest {
                 // absolute path with trailing slash: should be preserved
                 .path("http://authserver.com/token/")
                 .build(),
-            URI.create("http://authserver.com/token/")));
+            URI.create("http://authserver.com/token/")),
+        Arguments.of(
+            ImmutableHTTPRequest.builder()
+                .baseUri(URI.create("http://localhost:8080"))
+                .method(HTTPRequest.HTTPMethod.GET)
+                // percent-escaped segments remain unchanged in the request URI
+                .path("v1/main%7Cwarehouse/namespaces/sales%20report/tables/q1%20results")
+                .build(),
+            URI.create(
+                "http://localhost:8080/v1/main%7Cwarehouse/namespaces/sales%20report/tables/q1%20results")));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -88,6 +88,12 @@ public class TestRESTUtil {
             String.format(
                 "dogs.and.cats%snamed%shank.or.james-westfall",
                 namespaceSeparator, namespaceSeparator),
+          },
+          new Object[] {new String[] {"sales report"}, "sales%20report"},
+          new Object[] {new String[] {"my+name with+spaces"}, "my%2Bname%20with%2Bspaces"},
+          new Object[] {
+            new String[] {"sales report", "monthly results"},
+            String.format("sales%%20report%smonthly%%20results", namespaceSeparator),
           }
         };
 
@@ -139,6 +145,28 @@ public class TestRESTUtil {
         .isThrownBy(
             () -> RESTUtil.decodeNamespace(null, RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8))
         .withMessage("Invalid namespace: null");
+  }
+
+  @Test
+  public void encodePathSegmentForPathUse() {
+    assertThat(RESTUtil.encodePathSegment("sales report")).isEqualTo("sales%20report");
+    assertThat(RESTUtil.encodePathSegment("a+b")).isEqualTo("a%2Bb");
+    assertThat(RESTUtil.encodePathSegment("my+name with+spaces"))
+        .isEqualTo("my%2Bname%20with%2Bspaces");
+    assertThat(RESTUtil.encodePathSegment("a/b")).isEqualTo("a%2Fb");
+
+    assertThatThrownBy(() -> RESTUtil.encodePathSegment(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid string to encode: null");
+  }
+
+  @Test
+  public void legacyEncodedValuesStillDecode() {
+    Namespace singleLevel = Namespace.of("my namespace");
+    String legacyEncoded = "my+namespace";
+
+    assertThat(RESTUtil.decodeNamespace(legacyEncoded, "%1F")).isEqualTo(singleLevel);
+    assertThat(RESTUtil.decodeString("my%2Bname+with%2Bspaces")).isEqualTo("my+name with+spaces");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -219,6 +219,81 @@ public class TestResourcePaths {
   }
 
   @Test
+  public void tablePathWithSpaceAndPlusInNames() {
+    TableIdentifier ident = TableIdentifier.of("sales report", "q1 results");
+    assertThat(withPrefix.table(ident))
+        .isEqualTo("v1/ws/catalog/namespaces/sales%20report/tables/q1%20results");
+    assertThat(withoutPrefix.table(ident))
+        .isEqualTo("v1/namespaces/sales%20report/tables/q1%20results");
+
+    TableIdentifier plusIdent = TableIdentifier.of("ns", "my+name with+spaces");
+    assertThat(withPrefix.table(plusIdent))
+        .isEqualTo("v1/ws/catalog/namespaces/ns/tables/my%2Bname%20with%2Bspaces");
+    assertThat(withoutPrefix.table(plusIdent))
+        .isEqualTo("v1/namespaces/ns/tables/my%2Bname%20with%2Bspaces");
+  }
+
+  @Test
+  public void namespaceRoutesWithSpace() {
+    Namespace ns = Namespace.of("sales report");
+    String encoded = "namespaces/sales%20report";
+
+    assertThat(withPrefix.namespace(ns)).isEqualTo("v1/ws/catalog/" + encoded);
+    assertThat(withoutPrefix.namespace(ns)).isEqualTo("v1/" + encoded);
+    assertThat(withPrefix.namespaceProperties(ns))
+        .isEqualTo("v1/ws/catalog/" + encoded + "/properties");
+    assertThat(withoutPrefix.namespaceProperties(ns)).isEqualTo("v1/" + encoded + "/properties");
+    assertThat(withPrefix.tables(ns)).isEqualTo("v1/ws/catalog/" + encoded + "/tables");
+    assertThat(withoutPrefix.tables(ns)).isEqualTo("v1/" + encoded + "/tables");
+    assertThat(withPrefix.register(ns)).isEqualTo("v1/ws/catalog/" + encoded + "/register");
+    assertThat(withoutPrefix.register(ns)).isEqualTo("v1/" + encoded + "/register");
+    assertThat(withPrefix.views(ns)).isEqualTo("v1/ws/catalog/" + encoded + "/views");
+    assertThat(withoutPrefix.views(ns)).isEqualTo("v1/" + encoded + "/views");
+    assertThat(withPrefix.registerView(ns))
+        .isEqualTo("v1/ws/catalog/" + encoded + "/register-view");
+    assertThat(withoutPrefix.registerView(ns)).isEqualTo("v1/" + encoded + "/register-view");
+  }
+
+  @Test
+  public void metricsAndSignPathsWithSpaceAndPlusInNames() {
+    TableIdentifier ident = TableIdentifier.of("sales report", "my+name with+spaces");
+    String encoded = "namespaces/sales%20report/tables/my%2Bname%20with%2Bspaces";
+    assertThat(withPrefix.metrics(ident)).isEqualTo("v1/ws/catalog/" + encoded + "/metrics");
+    assertThat(withoutPrefix.metrics(ident)).isEqualTo("v1/" + encoded + "/metrics");
+    assertThat(withPrefix.remoteSign(ident)).isEqualTo("v1/ws/catalog/" + encoded + "/sign");
+    assertThat(withoutPrefix.remoteSign(ident)).isEqualTo("v1/" + encoded + "/sign");
+  }
+
+  @Test
+  public void viewPathWithSpaceAndPlusInNames() {
+    TableIdentifier ident = TableIdentifier.of("sales report", "my+name with+spaces");
+    assertThat(withPrefix.view(ident))
+        .isEqualTo("v1/ws/catalog/namespaces/sales%20report/views/my%2Bname%20with%2Bspaces");
+    assertThat(withoutPrefix.view(ident))
+        .isEqualTo("v1/namespaces/sales%20report/views/my%2Bname%20with%2Bspaces");
+  }
+
+  @Test
+  public void planningAndTaskPathsWithSpaceAndPlusInNames() {
+    TableIdentifier ident = TableIdentifier.of("sales report", "q1 results");
+    assertThat(withPrefix.planTableScan(ident))
+        .isEqualTo("v1/ws/catalog/namespaces/sales%20report/tables/q1%20results/plan");
+    assertThat(withoutPrefix.planTableScan(ident))
+        .isEqualTo("v1/namespaces/sales%20report/tables/q1%20results/plan");
+
+    assertThat(withPrefix.plan(ident, "plan with+spaces"))
+        .isEqualTo(
+            "v1/ws/catalog/namespaces/sales%20report/tables/q1%20results/plan/plan%20with%2Bspaces");
+    assertThat(withoutPrefix.plan(ident, "plan with+spaces"))
+        .isEqualTo("v1/namespaces/sales%20report/tables/q1%20results/plan/plan%20with%2Bspaces");
+
+    assertThat(withPrefix.fetchScanTasks(ident))
+        .isEqualTo("v1/ws/catalog/namespaces/sales%20report/tables/q1%20results/tasks");
+    assertThat(withoutPrefix.fetchScanTasks(ident))
+        .isEqualTo("v1/namespaces/sales%20report/tables/q1%20results/tasks");
+  }
+
+  @Test
   public void testRegister() {
     Namespace ns = Namespace.of("ns");
     assertThat(withPrefix.register(ns)).isEqualTo("v1/ws/catalog/namespaces/ns/register");
@@ -319,10 +394,10 @@ public class TestResourcePaths {
     assertThat(withoutPrefix.plan(tableId, planId))
         .isEqualTo("v1/namespaces/test_namespace/tables/test_table/plan/plan-abc-123");
 
-    // The planId contains a space which needs to be encoded
+    // The planId contains a space
     String spaceSeparatedPlanId = "plan with spaces";
     // The expected encoded version of the planId
-    String encodedPlanId = "plan+with+spaces";
+    String encodedPlanId = "plan%20with%20spaces";
 
     assertThat(withPrefix.plan(tableId, spaceSeparatedPlanId))
         .isEqualTo(


### PR DESCRIPTION
## Problem

The Java REST client form-encodes URL path segments. `RESTUtil.encodeString` wraps `java.net.URLEncoder`, which implements `application/x-www-form-urlencoded` and represents a space as `+`. `ResourcePaths` used that output to build request paths, so any namespace level, table or view name, or scan plan ID containing a space was sent with a literal `+` in its path.

## Impact

Catalogs that decode path segments per RFC 3986 cannot match such names. Reproduced against Nessie, where both objects were created through the catalog API first:

| request path suffix | status |
|---|---|
| `namespaces/sales%20report/tables/q1%20results` | 200 |
| `namespaces/sales+report/tables/q1+results` | 404 |

- Listing such a namespace fails with `NoSuchNamespaceException`; catalogs that answer 200 for unknown namespaces instead report it as empty, which reads as "no tables".
- Loading such a table fails with a not-found error naming `sales+report.q1+results`, a name the user never typed.

## Change

Add `RESTUtil.encodePathSegment`, which represents a space as `%20` while keeping every other
`URLEncoder` escape: a literal `+` becomes `%2B`, `/` stays `%2F`. Use it for all path construction:

- namespace levels in `RESTUtil.encodeNamespace`
- table names in the table, metrics, remote-signing, planning and task paths built by `ResourcePaths`
- view names and scan plan IDs in `ResourcePaths`

`encodeFormData` keeps `application/x-www-form-urlencoded`, which is correct for OAuth token requests and leaves them unchanged.

## Compatibility

- **Decoding unchanged.** `URLDecoder` reads both `%20` and `+`, so values produced by older clients still round-trip through `decodeString` and `decodeNamespace`. That leniency is deliberate, mirroring how servers already accept both advertised namespace separators per the spec's own compatibility rule.
- **Literal plus signs never meant anything else.** `a+b` encodes as `a%2Bb` before and after.
- **No server that works today breaks.** The old encoder already emitted `%2F`, `%26` and non-ASCII escapes on exactly these paths, so any working catalog already percent-decodes path segments; `%20` rides the same code path.
- A prior discussion concluded `encodeString` was acceptable for plan IDs (#13400); that conclusion predates the reproductions above and is reversed here.

## Testing

New cases in `TestRESTUtil`, `TestResourcePaths` and `TestHTTPRequest` cover:

- table, metrics, sign, view, plan and task paths with spaces and literal pluses in names
- all six namespace-only routes with a spaced namespace
- multipart namespaces whose levels contain spaces
- legacy decoding (`my+namespace`) and the mixed case (`my%2Bname+with%2Bspaces`)
- percent-escaped segments passing through request URI construction unmodified

Each new `ResourcePaths` assertion fails against unpatched main. The existing OAuth form-encoding tests are untouched and still pass.

Fixes #17759
Related: #12308, #14263, review discussion in #15948

---
**AI Disclosure**
- Model: ox-alpha
- Platform/Tool: opencode CLI
- Human Oversight: fully reviewed
- Prompt Summary: Drafted the fix and tests for issue #17759 following the review guidance from #15948: add a path-segment encoder, use it across ResourcePaths and encodeNamespace, keep OAuth form encoding, add regression tests including legacy decoding.