### PR TITLE
Core: Extend TestRemoveSnapshots parameterization to V3

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -68,8 +68,10 @@ public class TestRemoveSnapshots extends TestBase {
     return Arrays.asList(
         new Object[] {1, true},
         new Object[] {2, true},
+        new Object[] {3, true},
         new Object[] {1, false},
-        new Object[] {2, false});
+        new Object[] {2, false},
+        new Object[] {3, false});
   }
 
   private long waitUntilAfter(long timestampMillis) {
@@ -1038,25 +1040,32 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testExpireWithDeleteFiles() {
-    assumeThat(formatVersion).as("Delete files only supported in V2 spec").isEqualTo(2);
+    // Standalone delete manifests exist in V2 (position-delete parquet files) and V3 (deletion
+    // vectors). V1 has no delete files and V4+ folds delete entries into the root manifest.
+    assumeThat(formatVersion)
+        .as("Standalone delete manifests only exist in V2 and V3 tables")
+        .isIn(2, 3);
+
+    DeleteFile fileADeletes = fileADeletes();
+    DeleteFile fileBDeletes = fileBDeletes();
 
     // Data Manifest => File_A
     table.newAppend().appendFile(FILE_A).commit();
     Snapshot firstSnapshot = table.currentSnapshot();
 
     // Data Manifest => FILE_A
-    // Delete Manifest => FILE_A_DELETES
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    // Delete Manifest => fileADeletes
+    table.newRowDelta().addDeletes(fileADeletes).commit();
     Snapshot secondSnapshot = table.currentSnapshot();
     assertThat(secondSnapshot.dataManifests(table.io())).hasSize(1);
     assertThat(secondSnapshot.deleteManifests(table.io())).hasSize(1);
 
-    // FILE_A and FILE_A_DELETES move into "DELETED" state
+    // FILE_A and fileADeletes move into "DELETED" state
     table
         .newRewrite()
         .rewriteFiles(
-            ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES), // deleted
-            ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_B_DELETES)) // added
+            ImmutableSet.of(FILE_A), ImmutableSet.of(fileADeletes), // deleted
+            ImmutableSet.of(FILE_B), ImmutableSet.of(fileBDeletes)) // added
         .validateFromSnapshot(secondSnapshot.snapshotId())
         .commit();
     Snapshot thirdSnapshot = table.currentSnapshot();
@@ -1081,7 +1090,7 @@ public class TestRemoveSnapshots extends TestBase {
         .isEqualTo(
             ImmutableSet.builder()
                 .add(FILE_A.location())
-                .add(FILE_A_DELETES.location())
+                .add(fileADeletes.location())
                 .add(firstSnapshot.manifestListLocation())
                 .add(secondSnapshot.manifestListLocation())
                 .add(thirdSnapshot.manifestListLocation())


### PR DESCRIPTION
## Summary

Extend `TestRemoveSnapshots` to run every test against format version 3 in addition to V1 and V2, and make `testExpireWithDeleteFiles` version-agnostic so it exercises both V2 position-delete parquet files and V3 deletion vectors.

## Motivation

Follow-up to reviewer feedback on #17745 asking for expanded V3 coverage in `TestRemoveSnapshots`. V3 has been the default table format for new writes in recent releases but the snapshot-expiration test class only exercised V1 and V2. This closes that gap for the whole class, not just the delete-file test.

## Changes

- `@Parameters` matrix gains `{3, true}` and `{3, false}` entries, so every `@TestTemplate` in the class runs against V3 for both the incremental and reachable cleanup strategies.
- `testExpireWithDeleteFiles` now uses the existing `fileADeletes()` / `fileBDeletes()` helpers from `TestBase` (which return position deletes for V2 and DVs for V3) instead of hardcoded `FILE_A_DELETES` / `FILE_B_DELETES`. Version guard widened from `isEqualTo(2)` to `isIn(2, 3)`.

V1 has no delete files and V4+ folds delete entries into the root manifest, so V2 and V3 remain the only versions that carry standalone delete manifests.

## Test plan

- [x] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestRemoveSnapshots"` passes for all six parameter combinations (V1/V2/V3 × incremental/reachable).

---
**AI Disclosure**
- Platform/Tool: Cursor