### PR TITLE
Core: Interleave Z-order bits a byte at a time with a lookup table

### DIFF
--- a/core/src/jmh/java/org/apache/iceberg/util/ZOrderByteUtilsBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/util/ZOrderByteUtilsBenchmark.java
@@ -31,10 +31,12 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 @Fork(1)
 @State(Scope.Benchmark)
+@Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @BenchmarkMode(Mode.SingleShotTime)
 @Timeout(time = 1000, timeUnit = TimeUnit.HOURS)

--- a/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
+++ b/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
@@ -44,7 +44,39 @@ public class ZOrderByteUtils {
 
   public static final int PRIMITIVE_BUFFER_SIZE = 8;
 
+  /**
+   * The most columns the table based interleaving supports. Interleaving N columns spreads the 8
+   * bits of a source byte over 8 * N bits, which has to fit in the long holding one output group.
+   */
+  private static final int MAX_TABLE_COLUMNS = Long.SIZE / Byte.SIZE;
+
+  /**
+   * SPREAD[n][b] holds the bits of the byte b spread n positions apart, the highest order bit of b
+   * first, so that OR-ing the spread bytes of n columns interleaves them. Only the low order n
+   * bytes are used.
+   */
+  private static final long[][] SPREAD = buildSpreadTables();
+
   private ZOrderByteUtils() {}
+
+  private static long[][] buildSpreadTables() {
+    long[][] tables = new long[MAX_TABLE_COLUMNS + 1][];
+    for (int numColumns = 1; numColumns <= MAX_TABLE_COLUMNS; numColumns += 1) {
+      long[] table = new long[1 << Byte.SIZE];
+      for (int value = 0; value < table.length; value += 1) {
+        long spread = 0L;
+        for (int bit = 0; bit < Byte.SIZE; bit += 1) {
+          if ((value & (1 << (Byte.SIZE - 1 - bit))) != 0) {
+            spread |= 1L << (Byte.SIZE * numColumns - 1 - bit * numColumns);
+          }
+        }
+        table[value] = spread;
+      }
+      tables[numColumns] = table;
+    }
+
+    return tables;
+  }
 
   static ByteBuffer allocatePrimitiveBuffer() {
     return ByteBuffer.allocate(PRIMITIVE_BUFFER_SIZE);
@@ -155,21 +187,116 @@ public class ZOrderByteUtils {
   }
 
   /**
-   * Interleave bits using a naive loop. Variable length inputs are allowed but to get a consistent
-   * ordering it is required that every column contribute the same number of bytes in each
-   * invocation. Bits are interleaved from all columns that have a bit available at that position.
-   * Once a Column has no more bits to produce it is skipped in the interleaving.
+   * Interleave bits from the given columns. Variable length inputs are allowed but to get a
+   * consistent ordering it is required that every column contribute the same number of bytes in
+   * each invocation. Bits are interleaved from all columns that have a bit available at that
+   * position. Once a Column has no more bits to produce it is skipped in the interleaving.
+   *
+   * <p>When every column contributes the same number of bytes, which is what all callers of this
+   * method produce, the interleaving is a fixed permutation of the source bits and is computed a
+   * byte at a time through {@link #SPREAD}. Any other input falls back to interleaving one bit at a
+   * time.
    *
    * @param columnsBinary an array of ordered byte representations of the columns being ZOrdered
    * @param interleavedSize the number of bytes to use in the output
    * @return the columnbytes interleaved
    */
-  // NarrowingCompoundAssignment is intended here. See
-  // https://github.com/apache/iceberg/pull/5200#issuecomment-1176226163
-  @SuppressWarnings({"ByteBufferBackingArray", "NarrowingCompoundAssignment"})
+  @SuppressWarnings("ByteBufferBackingArray")
   public static byte[] interleaveBits(
       byte[][] columnsBinary, int interleavedSize, ByteBuffer reuse) {
     byte[] interleavedBytes = reuse.array();
+    int uniformColumnLength = uniformColumnLength(columnsBinary);
+    if (uniformColumnLength > 0 && interleavedSize <= uniformColumnLength * columnsBinary.length) {
+      return interleaveUniformColumns(columnsBinary, interleavedSize, interleavedBytes);
+    }
+
+    return interleaveBitwise(columnsBinary, interleavedSize, interleavedBytes);
+  }
+
+  /**
+   * Returns the shared length of the given columns if the table based interleaving applies to them,
+   * and 0 otherwise. It applies when there is at least one column and at most {@link
+   * #MAX_TABLE_COLUMNS} of them, and all of them are of the same non-zero length.
+   */
+  private static int uniformColumnLength(byte[][] columnsBinary) {
+    if (columnsBinary.length < 1 || columnsBinary.length > MAX_TABLE_COLUMNS) {
+      return 0;
+    }
+
+    int columnLength = columnsBinary[0].length;
+    for (int column = 1; column < columnsBinary.length; column += 1) {
+      if (columnsBinary[column].length != columnLength) {
+        return 0;
+      }
+    }
+
+    return columnLength;
+  }
+
+  /**
+   * Interleave columns that all contribute the same number of bytes.
+   *
+   * <p>With N columns, the N bytes of output starting at offset {@code index * N} are produced
+   * entirely from byte {@code index} of each column: bit {@code bit} of that source byte, counted
+   * from the most significant one, lands at bit {@code bit * N + column} of that output group. That
+   * permutation depends only on the source byte and on N, so it is read from {@link #SPREAD} rather
+   * than being applied a bit at a time. Shifting the spread bits right by the column index puts
+   * each column at its offset within the group.
+   *
+   * <p>Every output byte is written, so unlike {@link #interleaveBitwise} this does not need to
+   * zero the output first. An interleavedSize smaller than the full interleaving truncates the last
+   * group: no column is exhausted before another one here, so the leading bytes of the interleaving
+   * do not depend on where it is cut off.
+   */
+  private static byte[] interleaveUniformColumns(
+      byte[][] columnsBinary, int interleavedSize, byte[] interleavedBytes) {
+    int numColumns = columnsBinary.length;
+    long[] spread = SPREAD[numColumns];
+    int completeGroups = interleavedSize / numColumns;
+
+    int interleaveByte = 0;
+    for (int sourceByte = 0; sourceByte < completeGroups; sourceByte += 1) {
+      long group = interleaveGroup(columnsBinary, spread, sourceByte);
+      for (int groupByte = numColumns - 1; groupByte >= 0; groupByte -= 1) {
+        interleavedBytes[interleaveByte] = (byte) (group >>> (Byte.SIZE * groupByte));
+        interleaveByte += 1;
+      }
+    }
+
+    // The output can end in the middle of a group, in which case only its leading bytes are kept
+    if (interleaveByte < interleavedSize) {
+      long group = interleaveGroup(columnsBinary, spread, completeGroups);
+      for (int groupByte = numColumns - 1; interleaveByte < interleavedSize; groupByte -= 1) {
+        interleavedBytes[interleaveByte] = (byte) (group >>> (Byte.SIZE * groupByte));
+        interleaveByte += 1;
+      }
+    }
+
+    return interleavedBytes;
+  }
+
+  /**
+   * Interleaves the given byte of every column into a single group of {@code columnsBinary.length}
+   * bytes, held in the low order bytes of the returned long.
+   */
+  private static long interleaveGroup(byte[][] columnsBinary, long[] spread, int sourceByte) {
+    long group = 0L;
+    for (int column = 0; column < columnsBinary.length; column += 1) {
+      group |= spread[columnsBinary[column][sourceByte] & 0xFF] >>> column;
+    }
+
+    return group;
+  }
+
+  /**
+   * Interleave bits using a naive loop, one output bit at a time. This handles columns of differing
+   * lengths, where a column that has run out of bytes is skipped by the interleaving.
+   */
+  // NarrowingCompoundAssignment is intended here. See
+  // https://github.com/apache/iceberg/pull/5200#issuecomment-1176226163
+  @SuppressWarnings("NarrowingCompoundAssignment")
+  private static byte[] interleaveBitwise(
+      byte[][] columnsBinary, int interleavedSize, byte[] interleavedBytes) {
     Arrays.fill(interleavedBytes, 0, interleavedSize, (byte) 0x00);
 
     int sourceColumn = 0;

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -134,6 +134,92 @@ public class TestZOrderByteUtil {
     }
   }
 
+  /**
+   * The uniform case, where every column contributes the same number of bytes, is what all
+   * production callers produce and is the case the lookup table optimizes. Column counts up to 9
+   * exercise both the table and the fallback used beyond its supported width.
+   */
+  @Test
+  public void testInterleaveUniformColumns() {
+    for (int numColumns = 1; numColumns <= 9; numColumns++) {
+      for (int colLength = 1; colLength <= 9; colLength++) {
+        byte[][] testBytes = new byte[numColumns][];
+        String[] testStrings = new String[numColumns];
+        for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {
+          testBytes[columnIndex] = generateRandomBytes(colLength);
+          testStrings[columnIndex] = bytesToString(testBytes[columnIndex]);
+        }
+
+        byte[] byteResult = ZOrderByteUtils.interleaveBits(testBytes, numColumns * colLength);
+
+        assertThat(bytesToString(byteResult))
+            .as("String interleave didn't match byte interleave")
+            .isEqualTo(interleaveStrings(testStrings));
+      }
+    }
+  }
+
+  /**
+   * A requested output smaller than the full interleaving must produce exactly the prefix of the
+   * full interleaving, for every truncation point.
+   */
+  @Test
+  public void testInterleaveUniformColumnsTruncatedOutput() {
+    for (int numColumns = 1; numColumns <= 9; numColumns++) {
+      int colLength = 8;
+      byte[][] testBytes = new byte[numColumns][];
+      String[] testStrings = new String[numColumns];
+      for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {
+        testBytes[columnIndex] = generateRandomBytes(colLength);
+        testStrings[columnIndex] = bytesToString(testBytes[columnIndex]);
+      }
+      String fullResult = interleaveStrings(testStrings);
+
+      for (int outputSize = 1; outputSize <= numColumns * colLength; outputSize++) {
+        byte[] byteResult = ZOrderByteUtils.interleaveBits(testBytes, outputSize);
+
+        assertThat(bytesToString(byteResult))
+            .as("Truncated interleave should be a prefix of the full interleave")
+            .isEqualTo(fullResult.substring(0, outputSize * 8));
+      }
+    }
+  }
+
+  /** Columns of differing lengths drop out of the interleaving once exhausted. */
+  @Test
+  public void testInterleaveRaggedColumns() {
+    for (int test = 0; test < NUM_INTERLEAVE_TESTS; test++) {
+      int numColumns = random.nextInt(9) + 1;
+      byte[][] testBytes = new byte[numColumns][];
+      String[] testStrings = new String[numColumns];
+      for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {
+        testBytes[columnIndex] = generateRandomBytes(random.nextInt(8) + 1);
+        testStrings[columnIndex] = bytesToString(testBytes[columnIndex]);
+      }
+
+      int zOrderSize = Arrays.stream(testBytes).mapToInt(column -> column.length).sum();
+      byte[] byteResult = ZOrderByteUtils.interleaveBits(testBytes, zOrderSize);
+
+      assertThat(bytesToString(byteResult))
+          .as("String interleave didn't match byte interleave")
+          .isEqualTo(interleaveStrings(testStrings));
+    }
+  }
+
+  /** A zero-length column contributes nothing and must not disturb the other columns. */
+  @Test
+  public void testInterleaveWithEmptyColumn() {
+    byte[][] test = new byte[3][];
+    test[0] = new byte[] {IOIOIOIO, OIOIOIOI};
+    test[1] = new byte[0];
+    test[2] = new byte[] {OIOIOIOI, IOIOIOIO};
+    String[] testStrings = {bytesToString(test[0]), "", bytesToString(test[2])};
+
+    assertThat(bytesToString(ZOrderByteUtils.interleaveBits(test, 4)))
+        .as("Empty column should be skipped")
+        .isEqualTo(interleaveStrings(testStrings));
+  }
+
   @Test
   public void testInterleaveEmptyBits() {
     byte[][] test = new byte[4][10];

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -140,7 +140,7 @@ public class TestZOrderByteUtil {
    * exercise both the table and the fallback used beyond its supported width.
    */
   @Test
-  public void testInterleaveUniformColumns() {
+  public void interleaveUniformColumns() {
     for (int numColumns = 1; numColumns <= 9; numColumns++) {
       for (int colLength = 1; colLength <= 9; colLength++) {
         byte[][] testBytes = new byte[numColumns][];
@@ -164,7 +164,7 @@ public class TestZOrderByteUtil {
    * full interleaving, for every truncation point.
    */
   @Test
-  public void testInterleaveUniformColumnsTruncatedOutput() {
+  public void interleaveUniformColumnsTruncatedOutput() {
     for (int numColumns = 1; numColumns <= 9; numColumns++) {
       int colLength = 8;
       byte[][] testBytes = new byte[numColumns][];
@@ -187,7 +187,7 @@ public class TestZOrderByteUtil {
 
   /** Columns of differing lengths drop out of the interleaving once exhausted. */
   @Test
-  public void testInterleaveRaggedColumns() {
+  public void interleaveRaggedColumns() {
     for (int test = 0; test < NUM_INTERLEAVE_TESTS; test++) {
       int numColumns = random.nextInt(9) + 1;
       byte[][] testBytes = new byte[numColumns][];
@@ -208,7 +208,7 @@ public class TestZOrderByteUtil {
 
   /** A zero-length column contributes nothing and must not disturb the other columns. */
   @Test
-  public void testInterleaveWithEmptyColumn() {
+  public void interleaveWithEmptyColumn() {
     byte[][] test = new byte[3][];
     test[0] = new byte[] {IOIOIOIO, OIOIOIOI};
     test[1] = new byte[0];


### PR DESCRIPTION
interleaveBits moves one bit per loop iteration, and each iteration searches for the next source column, so the cost is 8 * interleavedSize iterations of a loop the hardware cannot pipeline. With four Z-ordered columns and an 8 byte contribution each, that is 256 iterations per row.

When every column contributes the same number of bytes, which is what all callers produce, the interleaving is a fixed permutation of the source bits that depends only on the source byte and the column count. Tabulate it: SPREAD[n][b] holds the bits of byte b spread n positions apart, so OR-ing the spread bytes of n columns, each shifted right by its column index, yields the n output bytes for that source offset.

Columns of differing lengths, which no caller produces but the method accepts, keep using the existing bit at a time loop. The output is unchanged for every input.

The tables cost 16680 bytes of heap once per JVM, and only the 2 KB row for the column count in use is read. Nothing is allocated per row, by either implementation.

ZOrderByteUtilsBenchmark also gained warmup iterations, without which it was timing largely uncompiled code.

JMH, 10M rows per op, JDK 17, i7-13700H:

  fourColumns             7.379 ± 0.563 -> 0.787 ± 0.277 s/op
  fourColumns8ByteOutput  1.828 ± 0.459 -> 0.259 ± 0.038 s/op
  threeColumns            5.601 ± 0.915 -> 0.685 ± 0.373 s/op
  twoColumns              3.668 ± 0.530 -> 0.456 ± 0.033 s/op

gc.alloc.rate.norm is unchanged to the byte (5848, 5824, 5840, 5832 B/op, all of it the benchmark's own buffer and JMH infrastructure) and gc.count is 0 in every case, before and after.

Closes #17758

Numerical example with 3 columns: https://github.com/apache/iceberg/pull/17774#issuecomment-5382755566