### PR TITLE
Spec: Forbid writing new equality deletes in v4

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1417,7 +1417,7 @@ The rows in the delete file must be sorted by `file_path` then `pos` to optimize
 
 Equality delete files identify deleted rows in a collection of data files by one or more column values, and may optionally contain additional columns of the deleted row.
 
-Equality delete files must not be added to v4 tables. Equality delete files referenced by metadata upgraded to v4 must still be applied. Moving entries covered by an equality delete to a v4 manifest requires applying the deletes and writing a new data file entry.
+Equality delete files must not be added to v4 tables and v4 manifests must not reference equality delete files. Equality delete files referenced by v2 or v3 delete manifests must still be applied in a v4 table. Moving entries covered by an equality delete to a v4 manifest requires applying the deletes and writing a new data file entry.
 
 Equality delete files store any subset of a table's columns and use the table's field ids. The _delete columns_ are the columns of the delete file used to match data rows. Delete columns are identified by id in the delete file [metadata column `equality_ids`](#manifests). The column restrictions for columns used in equality delete files are the same as those for [identifier fields](#identifier-field-ids) with the exception that optional columns and columns nested under optional structs are allowed (if a parent struct column is null it implies the leaf column is null).
 
@@ -1918,7 +1918,7 @@ Reading v4 metadata:
 
 Row-level delete changes:
 
-* Equality delete files must not be added to v4 tables
+* Equality delete files must not be added to v4 tables and v4 manifests must not reference equality delete files
 * Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
 * Upgrading a v2 or v3 table to v4 is metadata-only and does not rewrite data or delete files
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -62,6 +62,7 @@ The full set of changes are listed in [Appendix E](#version-3).
 Version 4 of the Iceberg spec restructures metadata for improved performance and new capabilities:
 
 * Support for [relative locations](#file-locations-in-metadata) in metadata fields
+* Writing new [equality deletes](#equality-delete-files) is no longer allowed
 
 The full set of changes are listed in [Appendix E](#version-4).
 
@@ -113,7 +114,7 @@ There are two types of row-level deletes:
 
 * **Position deletes** -- Mark a row deleted by data file path and the row position in the data file. Position deletes are encoded in a [_position delete file_](#position-delete-files) (V2) or [_deletion vector_](#deletion-vectors) (V3 or above).
 
-* **Equality deletes** -- Mark a row deleted by one or more column values, like id = 5. Equality deletes are encoded in [_equality delete file_](#equality-delete-files).
+* **Equality deletes** -- Mark a row deleted by one or more column values, like id = 5. Equality deletes are encoded in [_equality delete file_](#equality-delete-files) (V2 and V3). Existing equality deletes remain valid in V4 tables, but new equality deletes must not be written.
 
 Like data files, delete files are tracked by partition. In general, a delete file must be applied to older data files with the same partition; see [Scan Planning](#scan-planning) for details. Column metrics can be used to determine whether a delete file's rows overlap the contents of a data file or a scan range.
 
@@ -1352,13 +1353,13 @@ Notes:
 
 ### Delete Formats
 
-This section details how to encode row-level deletes in Iceberg delete files. Row-level deletes are added by v2 and are not supported in v1. Deletion vectors are added in v3 and are not supported in v2 or earlier. Position delete files must not be added to v3 tables, but existing position delete files are valid.
+This section details how to encode row-level deletes in Iceberg delete files. Row-level deletes are added by v2 and are not supported in v1. Deletion vectors are added in v3 and are not supported in v2 or earlier. Position delete files must not be added to v3 tables, but existing position delete files are valid. Equality delete files must not be added to v4 tables, but existing equality delete files are valid.
 
 There are different formats for encoding row-level deletes:
 
 * Deletion vectors (DVs) identify deleted rows within a single referenced data file by position in a bitmap
 * Position delete files identify deleted rows by file location and row position (**deprecated** in v3)
-* Equality delete files identify deleted rows by the value of one or more columns
+* Equality delete files identify deleted rows by the value of one or more columns (**deprecated** in v4)
 
 Deletion vectors are a binary representation of deletes for a single data file that is more efficient at execution time than position delete files. Unlike equality or position delete files, there can be at most one deletion vector for a given data file in a snapshot. Writers must ensure that there is at most one deletion vector per data file and must merge new deletes with existing vectors or position delete files.
 When removing a data file, writers must also remove any deletion vector that applies to that data file from delete manifests. Writers are not required to rewrite Puffin files that contain the removed deletion vectors.
@@ -1415,6 +1416,8 @@ The rows in the delete file must be sorted by `file_path` then `pos` to optimize
 #### Equality Delete Files
 
 Equality delete files identify deleted rows in a collection of data files by one or more column values, and may optionally contain additional columns of the deleted row.
+
+Equality deletes are not an allowed entry type in v4 metadata, so new equality deletes must not be written to v4 tables. Equality deletes carried over from v2 or v3 remain in the delete manifests that already track them and must still be applied when reading. Converting them to [deletion vectors](#deletion-vectors) is a separate, optional maintenance action.
 
 Equality delete files store any subset of a table's columns and use the table's field ids. The _delete columns_ are the columns of the delete file used to match data rows. Delete columns are identified by id in the delete file [metadata column `equality_ids`](#manifests). The column restrictions for columns used in equality delete files are the same as those for [identifier fields](#identifier-field-ids) with the exception that optional columns and columns nested under optional structs are allowed (if a parent struct column is null it implies the leaf column is null).
 
@@ -1912,6 +1915,15 @@ Reading v4 metadata:
 * Readers must check whether location fields contain a URI scheme to determine if a path is absolute or relative
 * Relative paths must be resolved against the table location before use (see [Path Resolution](#path-resolution))
 * When `location` is omitted, the table location must be provided (see [Table Location Specification](#table-location-specification))
+
+Row-level delete changes:
+
+* Equality deletes are not an allowed entry type in v4 metadata
+    * Writers must not write new equality deletes to v4 tables
+    * Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
+* Upgrading a v2 or v3 table to v4 is metadata-only and does not rewrite data or delete files
+    * Equality deletes remain in the carried-over v2 or v3 delete manifests that already track them
+    * Converting equality deletes to DVs is a separate, optional maintenance action
 
 ### Version 3
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1359,7 +1359,7 @@ There are different formats for encoding row-level deletes:
 
 * Deletion vectors (DVs) identify deleted rows within a single referenced data file by position in a bitmap
 * Position delete files identify deleted rows by file location and row position (**deprecated** in v3)
-* Equality delete files identify deleted rows by the value of one or more columns (**deprecated** in v4)
+* Equality delete files identify deleted rows by the value of one or more columns (**prohibited** in v4)
 
 Deletion vectors are a binary representation of deletes for a single data file that is more efficient at execution time than position delete files. Unlike equality or position delete files, there can be at most one deletion vector for a given data file in a snapshot. Writers must ensure that there is at most one deletion vector per data file and must merge new deletes with existing vectors or position delete files.
 When removing a data file, writers must also remove any deletion vector that applies to that data file from delete manifests. Writers are not required to rewrite Puffin files that contain the removed deletion vectors.
@@ -1417,7 +1417,7 @@ The rows in the delete file must be sorted by `file_path` then `pos` to optimize
 
 Equality delete files identify deleted rows in a collection of data files by one or more column values, and may optionally contain additional columns of the deleted row.
 
-Equality delete files must not be added to v4 tables. Equality deletes carried over from v2 or v3 remain in the delete manifests that already track them and readers must still apply them. Converting them to [deletion vectors](#deletion-vectors) is a separate, optional maintenance action.
+Equality delete files must not be added to v4 tables. Equality delete files referenced by metadata upgraded to v4 must still be applied. Moving entries covered by an equality delete to a v4 manifest requires applying the deletes and writing a new data file entry.
 
 Equality delete files store any subset of a table's columns and use the table's field ids. The _delete columns_ are the columns of the delete file used to match data rows. Delete columns are identified by id in the delete file [metadata column `equality_ids`](#manifests). The column restrictions for columns used in equality delete files are the same as those for [identifier fields](#identifier-field-ids) with the exception that optional columns and columns nested under optional structs are allowed (if a parent struct column is null it implies the leaf column is null).
 
@@ -1921,8 +1921,6 @@ Row-level delete changes:
 * Equality delete files must not be added to v4 tables
 * Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
 * Upgrading a v2 or v3 table to v4 is metadata-only and does not rewrite data or delete files
-    * Equality deletes remain in the carried-over v2 or v3 delete manifests that already track them
-    * Converting equality deletes to DVs is a separate, optional maintenance action
 
 ### Version 3
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1417,7 +1417,7 @@ The rows in the delete file must be sorted by `file_path` then `pos` to optimize
 
 Equality delete files identify deleted rows in a collection of data files by one or more column values, and may optionally contain additional columns of the deleted row.
 
-Equality deletes are not an allowed entry type in v4 metadata, so new equality deletes must not be written to v4 tables. Equality deletes carried over from v2 or v3 remain in the delete manifests that already track them and must still be applied when reading. Converting them to [deletion vectors](#deletion-vectors) is a separate, optional maintenance action.
+Equality delete files must not be added to v4 tables. Equality deletes carried over from v2 or v3 remain in the delete manifests that already track them and readers must still apply them. Converting them to [deletion vectors](#deletion-vectors) is a separate, optional maintenance action.
 
 Equality delete files store any subset of a table's columns and use the table's field ids. The _delete columns_ are the columns of the delete file used to match data rows. Delete columns are identified by id in the delete file [metadata column `equality_ids`](#manifests). The column restrictions for columns used in equality delete files are the same as those for [identifier fields](#identifier-field-ids) with the exception that optional columns and columns nested under optional structs are allowed (if a parent struct column is null it implies the leaf column is null).
 
@@ -1918,9 +1918,8 @@ Reading v4 metadata:
 
 Row-level delete changes:
 
-* Equality deletes are not an allowed entry type in v4 metadata
-    * Writers must not write new equality deletes to v4 tables
-    * Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
+* Equality delete files must not be added to v4 tables
+* Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
 * Upgrading a v2 or v3 table to v4 is metadata-only and does not rewrite data or delete files
     * Equality deletes remain in the carried-over v2 or v3 delete manifests that already track them
     * Converting equality deletes to DVs is a separate, optional maintenance action

--- a/format/spec.md
+++ b/format/spec.md
@@ -114,7 +114,7 @@ There are two types of row-level deletes:
 
 * **Position deletes** -- Mark a row deleted by data file path and the row position in the data file. Position deletes are encoded in a [_position delete file_](#position-delete-files) (V2) or [_deletion vector_](#deletion-vectors) (V3 or above).
 
-* **Equality deletes** -- Mark a row deleted by one or more column values, like id = 5. Equality deletes are encoded in [_equality delete file_](#equality-delete-files) (V2 and V3). Existing equality deletes remain valid in V4 tables, but new equality deletes must not be written.
+* **Equality deletes** -- Mark a row deleted by one or more column values, like id = 5. Equality deletes are encoded in [_equality delete file_](#equality-delete-files) (May be created in V2 and V3 Tables Only).
 
 Like data files, delete files are tracked by partition. In general, a delete file must be applied to older data files with the same partition; see [Scan Planning](#scan-planning) for details. Column metrics can be used to determine whether a delete file's rows overlap the contents of a data file or a scan range.
 
@@ -1417,7 +1417,7 @@ The rows in the delete file must be sorted by `file_path` then `pos` to optimize
 
 Equality delete files identify deleted rows in a collection of data files by one or more column values, and may optionally contain additional columns of the deleted row.
 
-Equality delete files must not be added to v4 tables and v4 manifests must not reference equality delete files. Equality delete files referenced by v2 or v3 delete manifests must still be applied in a v4 table. Moving entries covered by an equality delete to a v4 manifest requires applying the deletes and writing a new data file entry.
+Equality delete files must not be added to v4 tables. Equality deletes cannot be added as an entry to a v4 manifest. Equality delete files referenced by v2 or v3 delete manifests must still be applied in a v4 table. Moving entries covered by an equality delete to a v4 manifest requires applying the deletes and writing a new data file entry.
 
 Equality delete files store any subset of a table's columns and use the table's field ids. The _delete columns_ are the columns of the delete file used to match data rows. Delete columns are identified by id in the delete file [metadata column `equality_ids`](#manifests). The column restrictions for columns used in equality delete files are the same as those for [identifier fields](#identifier-field-ids) with the exception that optional columns and columns nested under optional structs are allowed (if a parent struct column is null it implies the leaf column is null).
 
@@ -1918,7 +1918,7 @@ Reading v4 metadata:
 
 Row-level delete changes:
 
-* Equality delete files must not be added to v4 tables and v4 manifests must not reference equality delete files
+* Equality delete files must not be added to v4 tables and equality deletes cannot be added as an entry to a v4 manifest
 * Readers must continue to apply equality deletes for v2 and v3 tables and for equality deletes carried over into upgraded v4 tables
 * Upgrading a v2 or v3 table to v4 is metadata-only and does not rewrite data or delete files
 


### PR DESCRIPTION
This PR updates the table spec for v4 equality deletes. V4 writers must not write new equality deletes, but readers must still apply existing ones from v2/v3 tables.