### PR TITLE
GCP, Azure: ignore null values for optional numeric properties

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -119,10 +119,12 @@ public class AzureProperties implements Serializable {
     }
 
     if (properties.containsKey(ADLS_READ_BLOCK_SIZE)) {
-      this.adlsReadBlockSize = Integer.parseInt(properties.get(ADLS_READ_BLOCK_SIZE));
+      this.adlsReadBlockSize =
+          PropertyUtil.propertyAsNullableInt(properties, ADLS_READ_BLOCK_SIZE);
     }
     if (properties.containsKey(ADLS_WRITE_BLOCK_SIZE)) {
-      this.adlsWriteBlockSize = Long.parseLong(properties.get(ADLS_WRITE_BLOCK_SIZE));
+      this.adlsWriteBlockSize =
+          PropertyUtil.propertyAsNullableLong(properties, ADLS_WRITE_BLOCK_SIZE);
     }
     this.adlsRefreshCredentialsEndpoint =
         RESTUtil.resolveEndpoint(

--- a/azure/src/test/java/org/apache/iceberg/azure/TestAzureProperties.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/TestAzureProperties.java
@@ -47,6 +47,7 @@ import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.CatalogProperties;
@@ -317,5 +318,16 @@ public class TestAzureProperties {
     public void initialize(Map<String, String> credentialProperties) {
       properties = credentialProperties;
     }
+  }
+
+  @Test
+  public void testNullBlockSizesAreIgnored() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(ADLS_READ_BLOCK_SIZE, null);
+    properties.put(ADLS_WRITE_BLOCK_SIZE, null);
+
+    AzureProperties props = new AzureProperties(properties);
+    assertThat(props.adlsReadBlockSize()).isNotPresent();
+    assertThat(props.adlsWriteBlockSize()).isNotPresent();
   }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -154,17 +154,22 @@ public class GCPProperties implements Serializable {
     gcsUserProject = properties.get(GCS_USER_PROJECT);
 
     if (properties.containsKey(GCS_CHANNEL_READ_CHUNK_SIZE)) {
-      gcsChannelReadChunkSize = Integer.parseInt(properties.get(GCS_CHANNEL_READ_CHUNK_SIZE));
+      gcsChannelReadChunkSize =
+          PropertyUtil.propertyAsNullableInt(properties, GCS_CHANNEL_READ_CHUNK_SIZE);
     }
 
     if (properties.containsKey(GCS_CHANNEL_WRITE_CHUNK_SIZE)) {
-      gcsChannelWriteChunkSize = Integer.parseInt(properties.get(GCS_CHANNEL_WRITE_CHUNK_SIZE));
+      gcsChannelWriteChunkSize =
+          PropertyUtil.propertyAsNullableInt(properties, GCS_CHANNEL_WRITE_CHUNK_SIZE);
     }
 
     gcsOAuth2Token = properties.get(GCS_OAUTH2_TOKEN);
     if (properties.containsKey(GCS_OAUTH2_TOKEN_EXPIRES_AT)) {
-      gcsOAuth2TokenExpiresAt =
-          new Date(Long.parseLong(properties.get(GCS_OAUTH2_TOKEN_EXPIRES_AT)));
+      Long tokenExpiresAt =
+          PropertyUtil.propertyAsNullableLong(properties, GCS_OAUTH2_TOKEN_EXPIRES_AT);
+      if (tokenExpiresAt != null) {
+        gcsOAuth2TokenExpiresAt = new Date(tokenExpiresAt);
+      }
     }
 
     gcsOauth2RefreshCredentialsEndpoint =

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
@@ -18,13 +18,18 @@
  */
 package org.apache.iceberg.gcp;
 
+import static org.apache.iceberg.gcp.GCPProperties.GCS_CHANNEL_READ_CHUNK_SIZE;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_CHANNEL_WRITE_CHUNK_SIZE;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
@@ -76,5 +81,18 @@ public class TestGCPProperties {
         .isPresent()
         .get()
         .isEqualTo("/v1/credentials");
+  }
+
+  @Test
+  public void testNullNumericPropertiesAreIgnored() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(GCS_CHANNEL_READ_CHUNK_SIZE, null);
+    properties.put(GCS_CHANNEL_WRITE_CHUNK_SIZE, null);
+    properties.put(GCS_OAUTH2_TOKEN_EXPIRES_AT, null);
+
+    GCPProperties gcpProperties = new GCPProperties(properties);
+    assertThat(gcpProperties.channelReadChunkSize()).isNotPresent();
+    assertThat(gcpProperties.channelWriteChunkSize()).isNotPresent();
+    assertThat(gcpProperties.oauth2TokenExpiresAt()).isNotPresent();
   }
 }


### PR DESCRIPTION
### Problem

`GCPProperties` and `AzureProperties` throw `NumberFormatException` when optional numeric properties exist in the properties map with `null` values.

`properties.containsKey(...)` returns `true` for null-valued entries, but `Integer.parseInt(null)` / `Long.parseLong(null)` raises `NumberFormatException: Cannot parse null string`.

### Changes

- **GCPProperties.java**: Replaced `Integer.parseInt(properties.get(...))` with `PropertyUtil.propertyAsNullableInt` for `GCS_CHANNEL_READ_CHUNK_SIZE` and `GCS_CHANNEL_WRITE_CHUNK_SIZE`. Replaced `Long.parseLong(properties.get(...))` with `PropertyUtil.propertyAsNullableLong` for `GCS_OAUTH2_TOKEN_EXPIRES_AT`, with a null guard before the `new Date(...)` call.

- **AzureProperties.java**: Replaced `Integer.parseInt(properties.get(...))` with `PropertyUtil.propertyAsNullableInt` for `ADLS_READ_BLOCK_SIZE`. Replaced `Long.parseLong(properties.get(...))` with `PropertyUtil.propertyAsNullableLong` for `ADLS_WRITE_BLOCK_SIZE`.

- **TestGCPProperties.java**: Added `testNullNumericPropertiesAreIgnored` to verify null values are treated as absent.

- **TestAzureProperties.java**: Added `testNullBlockSizesAreIgnored` to verify null values are treated as absent.

Fixes #17771