### PR TITLE
AWS: Cache LakeFormation vended credentials to prevent rate exceeded errors

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -183,22 +183,12 @@ public class AwsProperties implements Serializable {
   public static final String LAKE_FORMATION_DB_NAME = "lakeformation.db-name";
 
   /**
-   * If set to {@code false}, LakeFormation vended credentials are fetched on every S3/KMS client
-   * call instead of being cached. Caching is enabled by default to prevent {@code
-   * LakeFormationException: Rate exceeded} errors at high executor counts.
+   * The number of seconds Lake Formation credential providers are retained after their last use.
    */
-  public static final String LAKE_FORMATION_CACHE_ENABLED = "lakeformation.cache.enabled";
+  public static final String LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS =
+      "lakeformation.credential-cache.expiration-seconds";
 
-  public static final boolean LAKE_FORMATION_CACHE_ENABLED_DEFAULT = true;
-
-  /**
-   * Milliseconds before credential expiry at which the credential cache is proactively refreshed.
-   * Only applies when {@link #LAKE_FORMATION_CACHE_ENABLED} is {@code true}.
-   */
-  public static final String LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS =
-      "lakeformation.cache.refresh-lead-time-ms";
-
-  public static final long LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT = 60_000L;
+  public static final long LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS_DEFAULT = 60L;
 
   /** Region to be used by the SigV4 protocol for signing requests. */
   public static final String REST_SIGNER_REGION = "rest.signing-region";

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -182,6 +182,24 @@ public class AwsProperties implements Serializable {
    */
   public static final String LAKE_FORMATION_DB_NAME = "lakeformation.db-name";
 
+  /**
+   * If set to {@code false}, LakeFormation vended credentials are fetched on every S3/KMS client
+   * call instead of being cached. Caching is enabled by default to prevent {@code
+   * LakeFormationException: Rate exceeded} errors at high executor counts.
+   */
+  public static final String LAKE_FORMATION_CACHE_ENABLED = "lakeformation.cache.enabled";
+
+  public static final boolean LAKE_FORMATION_CACHE_ENABLED_DEFAULT = true;
+
+  /**
+   * Milliseconds before credential expiry at which the credential cache is proactively refreshed.
+   * Only applies when {@link #LAKE_FORMATION_CACHE_ENABLED} is {@code true}.
+   */
+  public static final String LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS =
+      "lakeformation.cache.refresh-lead-time-ms";
+
+  public static final long LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT = 60_000L;
+
   /** Region to be used by the SigV4 protocol for signing requests. */
   public static final String REST_SIGNER_REGION = "rest.signing-region";
 

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.aws.AssumeRoleAwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -77,7 +76,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   @Override
   public void initialize(Map<String, String> properties) {
     super.initialize(properties);
-    this.catalogProperties = ImmutableMap.copyOf(properties);
+    this.catalogProperties = Maps.newHashMap(properties);
     Preconditions.checkArgument(
         awsProperties().stsClientAssumeRoleTags().stream()
             .anyMatch(t -> LF_AUTHORIZED_CALLER.equals(t.key())),
@@ -193,7 +192,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
       long idleTimeoutMs,
       Supplier<LakeFormationClient> clientSupplier) {
     return new CachedLakeFormationCredentialsProvider(
-        new CredentialCacheKey(tableArn, ImmutableMap.copyOf(properties)),
+        new CredentialCacheKey(tableArn, Maps.newHashMap(properties)),
         idleTimeoutMs,
         clientSupplier);
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aws.lakeformation;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -29,6 +28,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -63,7 +63,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   public static final String LF_AUTHORIZED_CALLER = "LakeFormationAuthorizedCaller";
   private static final long CREDENTIAL_PREFETCH_SECONDS = 60L;
   private static final ConcurrentMap<CredentialCacheKey, CredentialCacheEntry> CREDENTIAL_CACHES =
-      new ConcurrentHashMap<>();
+      Maps.newConcurrentMap();
 
   private String dbName;
   private String tableName;
@@ -75,22 +75,22 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   public LakeFormationAwsClientFactory() {}
 
   @Override
-  public void initialize(Map<String, String> catalogProperties) {
-    super.initialize(catalogProperties);
-    this.catalogProperties = ImmutableMap.copyOf(catalogProperties);
+  public void initialize(Map<String, String> properties) {
+    super.initialize(properties);
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     Preconditions.checkArgument(
         awsProperties().stsClientAssumeRoleTags().stream()
             .anyMatch(t -> LF_AUTHORIZED_CALLER.equals(t.key())),
         "STS assume role session tag %s must be set using %s to use LakeFormation client factory",
         LF_AUTHORIZED_CALLER,
         AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX);
-    this.dbName = catalogProperties.get(AwsProperties.LAKE_FORMATION_DB_NAME);
-    this.tableName = catalogProperties.get(AwsProperties.LAKE_FORMATION_TABLE_NAME);
-    this.glueCatalogId = catalogProperties.get(AwsProperties.GLUE_CATALOG_ID);
-    this.glueAccountId = catalogProperties.get(AwsProperties.GLUE_ACCOUNT_ID);
+    this.dbName = properties.get(AwsProperties.LAKE_FORMATION_DB_NAME);
+    this.tableName = properties.get(AwsProperties.LAKE_FORMATION_TABLE_NAME);
+    this.glueCatalogId = properties.get(AwsProperties.GLUE_CATALOG_ID);
+    this.glueAccountId = properties.get(AwsProperties.GLUE_ACCOUNT_ID);
     long credentialCacheExpirationSeconds =
         PropertyUtil.propertyAsLong(
-            catalogProperties,
+            properties,
             AwsProperties.LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS,
             AwsProperties.LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS_DEFAULT);
     Preconditions.checkArgument(

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.iceberg.aws.AssumeRoleAwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -35,6 +36,8 @@ import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTable
 import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsResponse;
 import software.amazon.awssdk.services.lakeformation.model.PermissionType;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.utils.cache.CachedSupplier;
+import software.amazon.awssdk.utils.cache.RefreshResult;
 
 /**
  * This implementation of AwsClientFactory is used by default if {@link
@@ -56,6 +59,8 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   private String tableName;
   private String glueCatalogId;
   private String glueAccountId;
+  private boolean cacheEnabled;
+  private long cacheRefreshLeadTimeMs;
 
   public LakeFormationAwsClientFactory() {}
 
@@ -72,6 +77,16 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
     this.tableName = catalogProperties.get(AwsProperties.LAKE_FORMATION_TABLE_NAME);
     this.glueCatalogId = catalogProperties.get(AwsProperties.GLUE_CATALOG_ID);
     this.glueAccountId = catalogProperties.get(AwsProperties.GLUE_ACCOUNT_ID);
+    this.cacheEnabled =
+        PropertyUtil.propertyAsBoolean(
+            catalogProperties,
+            AwsProperties.LAKE_FORMATION_CACHE_ENABLED,
+            AwsProperties.LAKE_FORMATION_CACHE_ENABLED_DEFAULT);
+    this.cacheRefreshLeadTimeMs =
+        PropertyUtil.propertyAsLong(
+            catalogProperties,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
   }
 
   @Override
@@ -84,7 +99,8 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .applyMutation(s3FileIOProperties()::applyServiceConfigurations)
           .applyMutation(s3FileIOProperties()::applyRetryConfigurations)
           .credentialsProvider(
-              new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))
+              new LakeFormationCredentialsProvider(
+                  lakeFormation(), buildTableArn(), cacheEnabled, cacheRefreshLeadTimeMs))
           .region(Region.of(region()))
           .build();
     } else {
@@ -99,7 +115,8 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
           .applyMutation(awsClientProperties()::applyRetryConfigurations)
           .credentialsProvider(
-              new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))
+              new LakeFormationCredentialsProvider(
+                  lakeFormation(), buildTableArn(), cacheEnabled, cacheRefreshLeadTimeMs))
           .region(Region.of(region()))
           .build();
     } else {
@@ -144,26 +161,40 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   static class LakeFormationCredentialsProvider implements AwsCredentialsProvider {
     private final LakeFormationClient client;
     private final String tableArn;
+    private final long refreshLeadTimeMs;
+    private final CachedSupplier<AwsCredentials> cache;
 
-    LakeFormationCredentialsProvider(LakeFormationClient lakeFormationClient, String tableArn) {
+    LakeFormationCredentialsProvider(
+        LakeFormationClient lakeFormationClient,
+        String tableArn,
+        boolean cacheEnabled,
+        long refreshLeadTimeMs) {
       this.client = lakeFormationClient;
       this.tableArn = tableArn;
+      this.refreshLeadTimeMs = refreshLeadTimeMs;
+      this.cache = cacheEnabled ? CachedSupplier.builder(this::fetchCredentials).build() : null;
     }
 
     @Override
     public AwsCredentials resolveCredentials() {
-      GetTemporaryGlueTableCredentialsRequest getTemporaryGlueTableCredentialsRequest =
-          GetTemporaryGlueTableCredentialsRequest.builder()
-              .tableArn(tableArn)
-              // Now only two permission types (COLUMN_PERMISSION and CELL_FILTER_PERMISSION) are
-              // supported
-              // and Iceberg only supports COLUMN_PERMISSION at this time
-              .supportedPermissionTypes(PermissionType.COLUMN_PERMISSION)
-              .build();
+      return cache != null ? cache.get() : fetchCredentials().value();
+    }
+
+    private RefreshResult<AwsCredentials> fetchCredentials() {
       GetTemporaryGlueTableCredentialsResponse response =
-          client.getTemporaryGlueTableCredentials(getTemporaryGlueTableCredentialsRequest);
-      return AwsSessionCredentials.create(
-          response.accessKeyId(), response.secretAccessKey(), response.sessionToken());
+          client.getTemporaryGlueTableCredentials(
+              GetTemporaryGlueTableCredentialsRequest.builder()
+                  .tableArn(tableArn)
+                  // Now only two permission types (COLUMN_PERMISSION and CELL_FILTER_PERMISSION)
+                  // are supported and Iceberg only supports COLUMN_PERMISSION at this time
+                  .supportedPermissionTypes(PermissionType.COLUMN_PERMISSION)
+                  .build());
+      AwsCredentials credentials =
+          AwsSessionCredentials.create(
+              response.accessKeyId(), response.secretAccessKey(), response.sessionToken());
+      return RefreshResult.builder(credentials)
+          .staleTime(response.expiration().minusMillis(refreshLeadTimeMs))
+          .build();
     }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -18,10 +18,17 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.apache.iceberg.aws.AssumeRoleAwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -54,19 +61,23 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
 public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
 
   public static final String LF_AUTHORIZED_CALLER = "LakeFormationAuthorizedCaller";
+  private static final long CREDENTIAL_PREFETCH_SECONDS = 60L;
+  private static final ConcurrentMap<CredentialCacheKey, CredentialCacheEntry> CREDENTIAL_CACHES =
+      new ConcurrentHashMap<>();
 
   private String dbName;
   private String tableName;
   private String glueCatalogId;
   private String glueAccountId;
-  private boolean cacheEnabled;
-  private long cacheRefreshLeadTimeMs;
+  private Map<String, String> catalogProperties;
+  private long credentialCacheExpirationMs;
 
   public LakeFormationAwsClientFactory() {}
 
   @Override
   public void initialize(Map<String, String> catalogProperties) {
     super.initialize(catalogProperties);
+    this.catalogProperties = ImmutableMap.copyOf(catalogProperties);
     Preconditions.checkArgument(
         awsProperties().stsClientAssumeRoleTags().stream()
             .anyMatch(t -> LF_AUTHORIZED_CALLER.equals(t.key())),
@@ -77,16 +88,16 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
     this.tableName = catalogProperties.get(AwsProperties.LAKE_FORMATION_TABLE_NAME);
     this.glueCatalogId = catalogProperties.get(AwsProperties.GLUE_CATALOG_ID);
     this.glueAccountId = catalogProperties.get(AwsProperties.GLUE_ACCOUNT_ID);
-    this.cacheEnabled =
-        PropertyUtil.propertyAsBoolean(
-            catalogProperties,
-            AwsProperties.LAKE_FORMATION_CACHE_ENABLED,
-            AwsProperties.LAKE_FORMATION_CACHE_ENABLED_DEFAULT);
-    this.cacheRefreshLeadTimeMs =
+    long credentialCacheExpirationSeconds =
         PropertyUtil.propertyAsLong(
             catalogProperties,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+            AwsProperties.LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS,
+            AwsProperties.LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS_DEFAULT);
+    Preconditions.checkArgument(
+        credentialCacheExpirationSeconds > 0,
+        "Invalid Lake Formation credential cache expiration: %s",
+        credentialCacheExpirationSeconds);
+    this.credentialCacheExpirationMs = TimeUnit.SECONDS.toMillis(credentialCacheExpirationSeconds);
   }
 
   @Override
@@ -98,9 +109,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .applyMutation(s3FileIOProperties()::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties()::applyServiceConfigurations)
           .applyMutation(s3FileIOProperties()::applyRetryConfigurations)
-          .credentialsProvider(
-              new LakeFormationCredentialsProvider(
-                  lakeFormation(), buildTableArn(), cacheEnabled, cacheRefreshLeadTimeMs))
+          .credentialsProvider(lakeFormationCredentialsProvider())
           .region(Region.of(region()))
           .build();
     } else {
@@ -114,9 +123,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
       return KmsClient.builder()
           .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
           .applyMutation(awsClientProperties()::applyRetryConfigurations)
-          .credentialsProvider(
-              new LakeFormationCredentialsProvider(
-                  lakeFormation(), buildTableArn(), cacheEnabled, cacheRefreshLeadTimeMs))
+          .credentialsProvider(lakeFormationCredentialsProvider())
           .region(Region.of(region()))
           .build();
     } else {
@@ -141,7 +148,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
     return response.table().isRegisteredWithLakeFormation();
   }
 
-  private String buildTableArn() {
+  protected String buildTableArn() {
     Preconditions.checkArgument(
         glueAccountId != null && !glueAccountId.isEmpty(),
         "%s can not be empty",
@@ -151,36 +158,61 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
         "arn:%s:glue:%s:%s:table/%s/%s", partitionName, region(), glueAccountId, dbName, tableName);
   }
 
-  private LakeFormationClient lakeFormation() {
+  protected LakeFormationClient lakeFormation() {
     return LakeFormationClient.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
         .build();
   }
 
+  /**
+   * Returns the provider used by S3 and KMS clients for tables registered with Lake Formation.
+   * Subclasses can override this method to use {@link #directLakeFormationCredentialsProvider()} or
+   * another provider with a different caching policy.
+   */
+  protected AwsCredentialsProvider lakeFormationCredentialsProvider() {
+    return cachedCredentialsProvider(
+        buildTableArn(), catalogProperties, credentialCacheExpirationMs, this::lakeFormation);
+  }
+
+  /** Returns a provider that requests Lake Formation credentials for every resolution. */
+  protected AwsCredentialsProvider directLakeFormationCredentialsProvider() {
+    return new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn());
+  }
+
+  @VisibleForTesting
+  static void clearCredentialCaches() {
+    CREDENTIAL_CACHES.values().forEach(CredentialCacheEntry::close);
+    CREDENTIAL_CACHES.clear();
+  }
+
+  @VisibleForTesting
+  static AwsCredentialsProvider cachedCredentialsProvider(
+      String tableArn,
+      Map<String, String> properties,
+      long idleTimeoutMs,
+      Supplier<LakeFormationClient> clientSupplier) {
+    return new CachedLakeFormationCredentialsProvider(
+        new CredentialCacheKey(tableArn, ImmutableMap.copyOf(properties)),
+        idleTimeoutMs,
+        clientSupplier);
+  }
+
   static class LakeFormationCredentialsProvider implements AwsCredentialsProvider {
     private final LakeFormationClient client;
     private final String tableArn;
-    private final long refreshLeadTimeMs;
-    private final CachedSupplier<AwsCredentials> cache;
 
-    LakeFormationCredentialsProvider(
-        LakeFormationClient lakeFormationClient,
-        String tableArn,
-        boolean cacheEnabled,
-        long refreshLeadTimeMs) {
+    LakeFormationCredentialsProvider(LakeFormationClient lakeFormationClient, String tableArn) {
       this.client = lakeFormationClient;
       this.tableArn = tableArn;
-      this.refreshLeadTimeMs = refreshLeadTimeMs;
-      this.cache = cacheEnabled ? CachedSupplier.builder(this::fetchCredentials).build() : null;
     }
 
     @Override
     public AwsCredentials resolveCredentials() {
-      return cache != null ? cache.get() : fetchCredentials().value();
+      return refreshCredentials().value();
     }
 
-    private RefreshResult<AwsCredentials> fetchCredentials() {
+    RefreshResult<AwsCredentials> refreshCredentials() {
       GetTemporaryGlueTableCredentialsResponse response =
           client.getTemporaryGlueTableCredentials(
               GetTemporaryGlueTableCredentialsRequest.builder()
@@ -189,12 +221,133 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
                   // are supported and Iceberg only supports COLUMN_PERMISSION at this time
                   .supportedPermissionTypes(PermissionType.COLUMN_PERMISSION)
                   .build());
+      Instant expiration = response.expiration();
       AwsCredentials credentials =
-          AwsSessionCredentials.create(
-              response.accessKeyId(), response.secretAccessKey(), response.sessionToken());
+          AwsSessionCredentials.builder()
+              .accessKeyId(response.accessKeyId())
+              .secretAccessKey(response.secretAccessKey())
+              .sessionToken(response.sessionToken())
+              .expirationTime(expiration)
+              .build();
       return RefreshResult.builder(credentials)
-          .staleTime(response.expiration().minusMillis(refreshLeadTimeMs))
+          .staleTime(expiration)
+          .prefetchTime(expiration.minusSeconds(CREDENTIAL_PREFETCH_SECONDS))
           .build();
+    }
+  }
+
+  private static class CachedLakeFormationCredentialsProvider implements AwsCredentialsProvider {
+    private final CredentialCacheKey cacheKey;
+    private final long idleTimeoutMs;
+    private final Supplier<LakeFormationClient> clientSupplier;
+
+    private CachedLakeFormationCredentialsProvider(
+        CredentialCacheKey cacheKey,
+        long idleTimeoutMs,
+        Supplier<LakeFormationClient> clientSupplier) {
+      this.cacheKey = cacheKey;
+      this.idleTimeoutMs = idleTimeoutMs;
+      this.clientSupplier = clientSupplier;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+      long now = System.currentTimeMillis();
+      evictIdleCredentialCaches(now);
+      CredentialCacheEntry entry =
+          CREDENTIAL_CACHES.compute(
+              cacheKey,
+              (ignored, existing) -> {
+                if (existing == null || existing.isIdle(now, idleTimeoutMs)) {
+                  if (existing != null) {
+                    existing.close();
+                  }
+
+                  return new CredentialCacheEntry(
+                      clientSupplier.get(), cacheKey.tableArn, idleTimeoutMs, now);
+                }
+
+                existing.access(now);
+                return existing;
+              });
+      return entry.resolveCredentials();
+    }
+  }
+
+  private static void evictIdleCredentialCaches(long now) {
+    CREDENTIAL_CACHES.forEach(
+        (cacheKey, entry) -> {
+          if (entry.isIdle(now) && CREDENTIAL_CACHES.remove(cacheKey, entry)) {
+            entry.close();
+          }
+        });
+  }
+
+  private static class CredentialCacheEntry {
+    private final LakeFormationClient client;
+    private final CachedSupplier<AwsCredentials> credentialCache;
+    private final long idleTimeoutMs;
+    private long lastAccessTimeMs;
+
+    private CredentialCacheEntry(
+        LakeFormationClient client, String tableArn, long idleTimeoutMs, long now) {
+      this.client = client;
+      this.credentialCache =
+          CachedSupplier.builder(
+                  new LakeFormationCredentialsProvider(client, tableArn)::refreshCredentials)
+              .cachedValueName(LakeFormationCredentialsProvider.class.getName())
+              .build();
+      this.idleTimeoutMs = idleTimeoutMs;
+      this.lastAccessTimeMs = now;
+    }
+
+    private synchronized AwsCredentials resolveCredentials() {
+      this.lastAccessTimeMs = System.currentTimeMillis();
+      return credentialCache.get();
+    }
+
+    private synchronized void access(long now) {
+      this.lastAccessTimeMs = now;
+    }
+
+    private synchronized boolean isIdle(long now) {
+      return isIdle(now, idleTimeoutMs);
+    }
+
+    private synchronized boolean isIdle(long now, long timeoutMs) {
+      return now - lastAccessTimeMs >= timeoutMs;
+    }
+
+    private synchronized void close() {
+      credentialCache.close();
+      client.close();
+    }
+  }
+
+  private static class CredentialCacheKey {
+    private final String tableArn;
+    private final Map<String, String> properties;
+
+    private CredentialCacheKey(String tableArn, Map<String, String> properties) {
+      this.tableArn = tableArn;
+      this.properties = properties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      } else if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+
+      CredentialCacheKey that = (CredentialCacheKey) other;
+      return tableArn.equals(that.tableArn) && properties.equals(that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * tableArn.hashCode() + properties.hashCode();
     }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationCredentialsProvider.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationCredentialsProvider.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lakeformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.apache.iceberg.aws.AwsProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.lakeformation.LakeFormationClient;
+import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsRequest;
+import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TestLakeFormationCredentialsProvider {
+
+  private static final String TABLE_ARN = "arn:aws:glue:eu-central-1:123456789012:table/db/table";
+
+  @Mock private LakeFormationClient lakeFormationClient;
+
+  private GetTemporaryGlueTableCredentialsResponse responseWithExpiry(
+      String accessKeyId, Instant expiration) {
+    return GetTemporaryGlueTableCredentialsResponse.builder()
+        .accessKeyId(accessKeyId)
+        .secretAccessKey("secret")
+        .sessionToken("token")
+        .expiration(expiration)
+        .build();
+  }
+
+  // ---- caching enabled (default) ----
+
+  @Test
+  void cachingEnabledReturnsCredentials() {
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
+
+    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
+        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
+            lakeFormationClient,
+            TABLE_ARN,
+            /* cacheEnabled= */ true,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+
+    AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
+    assertThat(creds.accessKeyId()).isEqualTo("AKID1");
+  }
+
+  @Test
+  void cachingEnabledCallsLakeFormationOnlyOnce() {
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
+
+    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
+        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
+            lakeFormationClient,
+            TABLE_ARN,
+            /* cacheEnabled= */ true,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+
+    provider.resolveCredentials();
+    provider.resolveCredentials();
+    provider.resolveCredentials();
+
+    verify(lakeFormationClient, times(1))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+  }
+
+  @Test
+  void cachingEnabledRefreshesAfterStaleTime() throws InterruptedException {
+    // Credential expires in 2s with a 1.5s lead time -> staleTime = now + 500ms.
+    // After sleeping 700ms past construction the cache must be stale and refetch.
+    Instant firstExpiry = Instant.now().plusMillis(2000);
+    Instant secondExpiry = Instant.now().plus(Duration.ofHours(1));
+
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", firstExpiry))
+        .thenReturn(responseWithExpiry("AKID2", secondExpiry));
+
+    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
+        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
+            lakeFormationClient,
+            TABLE_ARN,
+            /* cacheEnabled= */ true,
+            /* refreshLeadTimeMs= */ 1500L);
+
+    AwsSessionCredentials first = (AwsSessionCredentials) provider.resolveCredentials();
+    assertThat(first.accessKeyId()).isEqualTo("AKID1");
+
+    // Sleep past staleTime (firstExpiry - 1500ms ~= now + 500ms); 700ms gives ample margin.
+    Thread.sleep(700);
+
+    AwsSessionCredentials refreshed = (AwsSessionCredentials) provider.resolveCredentials();
+    assertThat(refreshed.accessKeyId()).isEqualTo("AKID2");
+
+    verify(lakeFormationClient, times(2))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+  }
+
+  // ---- caching disabled ----
+
+  @Test
+  void cachingDisabledCallsLakeFormationEveryTime() {
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
+
+    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
+        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
+            lakeFormationClient,
+            TABLE_ARN,
+            /* cacheEnabled= */ false,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+
+    provider.resolveCredentials();
+    provider.resolveCredentials();
+    provider.resolveCredentials();
+
+    verify(lakeFormationClient, times(3))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+  }
+
+  @Test
+  void cachingDisabledReturnsCredentials() {
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
+
+    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
+        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
+            lakeFormationClient,
+            TABLE_ARN,
+            /* cacheEnabled= */ false,
+            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+
+    AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
+    assertThat(creds.accessKeyId()).isEqualTo("AKID1");
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationCredentialsProvider.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationCredentialsProvider.java
@@ -20,17 +20,25 @@ package org.apache.iceberg.aws.lakeformation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.aws.AwsProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.lakeformation.LakeFormationClient;
 import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsRequest;
@@ -40,8 +48,16 @@ import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTable
 class TestLakeFormationCredentialsProvider {
 
   private static final String TABLE_ARN = "arn:aws:glue:eu-central-1:123456789012:table/db/table";
+  private static final long CACHE_EXPIRATION_MS =
+      TimeUnit.SECONDS.toMillis(
+          AwsProperties.LAKE_FORMATION_CREDENTIAL_CACHE_EXPIRATION_SECONDS_DEFAULT);
 
   @Mock private LakeFormationClient lakeFormationClient;
+
+  @AfterEach
+  void clearCredentialCaches() {
+    LakeFormationAwsClientFactory.clearCredentialCaches();
+  }
 
   private GetTemporaryGlueTableCredentialsResponse responseWithExpiry(
       String accessKeyId, Instant expiration) {
@@ -53,115 +69,127 @@ class TestLakeFormationCredentialsProvider {
         .build();
   }
 
-  // ---- caching enabled (default) ----
-
   @Test
-  void cachingEnabledReturnsCredentials() {
+  void returnsLakeFormationCredentials() {
     when(lakeFormationClient.getTemporaryGlueTableCredentials(
             any(GetTemporaryGlueTableCredentialsRequest.class)))
         .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
 
     LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
         new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
-            lakeFormationClient,
-            TABLE_ARN,
-            /* cacheEnabled= */ true,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+            lakeFormationClient, TABLE_ARN);
 
     AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
     assertThat(creds.accessKeyId()).isEqualTo("AKID1");
   }
 
   @Test
-  void cachingEnabledCallsLakeFormationOnlyOnce() {
+  void sharesCredentialsAcrossProvidersWithSameContext() {
     when(lakeFormationClient.getTemporaryGlueTableCredentials(
             any(GetTemporaryGlueTableCredentialsRequest.class)))
         .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
 
-    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
-        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
-            lakeFormationClient,
-            TABLE_ARN,
-            /* cacheEnabled= */ true,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
+    AwsCredentialsProvider first =
+        LakeFormationAwsClientFactory.cachedCredentialsProvider(
+            TABLE_ARN, Map.of("role", "reader"), CACHE_EXPIRATION_MS, () -> lakeFormationClient);
+    AwsCredentialsProvider second =
+        LakeFormationAwsClientFactory.cachedCredentialsProvider(
+            TABLE_ARN, Map.of("role", "reader"), CACHE_EXPIRATION_MS, () -> lakeFormationClient);
 
-    provider.resolveCredentials();
-    provider.resolveCredentials();
-    provider.resolveCredentials();
+    first.resolveCredentials();
+    second.resolveCredentials();
 
     verify(lakeFormationClient, times(1))
         .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
   }
 
   @Test
-  void cachingEnabledRefreshesAfterStaleTime() throws InterruptedException {
-    // Credential expires in 2s with a 1.5s lead time -> staleTime = now + 500ms.
-    // After sleeping 700ms past construction the cache must be stale and refetch.
-    Instant firstExpiry = Instant.now().plusMillis(2000);
-    Instant secondExpiry = Instant.now().plus(Duration.ofHours(1));
-
+  void doesNotShareCredentialsAcrossContexts() {
+    LakeFormationClient otherLakeFormationClient = mock(LakeFormationClient.class);
     when(lakeFormationClient.getTemporaryGlueTableCredentials(
             any(GetTemporaryGlueTableCredentialsRequest.class)))
-        .thenReturn(responseWithExpiry("AKID1", firstExpiry))
-        .thenReturn(responseWithExpiry("AKID2", secondExpiry));
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
+    when(otherLakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID2", Instant.now().plus(Duration.ofHours(1))));
+
+    AwsCredentialsProvider first =
+        LakeFormationAwsClientFactory.cachedCredentialsProvider(
+            TABLE_ARN, Map.of("role", "reader"), CACHE_EXPIRATION_MS, () -> lakeFormationClient);
+    AwsCredentialsProvider second =
+        LakeFormationAwsClientFactory.cachedCredentialsProvider(
+            TABLE_ARN,
+            Map.of("role", "writer"),
+            CACHE_EXPIRATION_MS,
+            () -> otherLakeFormationClient);
+
+    AwsSessionCredentials firstCredentials = (AwsSessionCredentials) first.resolveCredentials();
+    AwsSessionCredentials secondCredentials = (AwsSessionCredentials) second.resolveCredentials();
+
+    assertThat(firstCredentials.accessKeyId()).isEqualTo("AKID1");
+    assertThat(secondCredentials.accessKeyId()).isEqualTo("AKID2");
+    verify(lakeFormationClient, times(1))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+    verify(otherLakeFormationClient, times(1))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+  }
+
+  @Test
+  void sharesCredentialsAcrossConcurrentProviders() throws Exception {
+    CountDownLatch requestStarted = new CountDownLatch(1);
+    CountDownLatch releaseRequest = new CountDownLatch(1);
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenAnswer(
+            ignored -> {
+              requestStarted.countDown();
+              assertThat(releaseRequest.await(10, TimeUnit.SECONDS)).isTrue();
+              return responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1)));
+            });
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      executor.submit(
+          () ->
+              LakeFormationAwsClientFactory.cachedCredentialsProvider(
+                      TABLE_ARN,
+                      Map.of("role", "reader"),
+                      CACHE_EXPIRATION_MS,
+                      () -> lakeFormationClient)
+                  .resolveCredentials());
+      assertThat(requestStarted.await(10, TimeUnit.SECONDS)).isTrue();
+      executor.submit(
+          () ->
+              LakeFormationAwsClientFactory.cachedCredentialsProvider(
+                      TABLE_ARN,
+                      Map.of("role", "reader"),
+                      CACHE_EXPIRATION_MS,
+                      () -> lakeFormationClient)
+                  .resolveCredentials());
+      releaseRequest.countDown();
+    } finally {
+      executor.shutdown();
+    }
+    assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+    verify(lakeFormationClient, times(1))
+        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
+  }
+
+  @Test
+  void directProviderDoesNotCacheCredentials() {
+    when(lakeFormationClient.getTemporaryGlueTableCredentials(
+            any(GetTemporaryGlueTableCredentialsRequest.class)))
+        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
 
     LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
         new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
-            lakeFormationClient,
-            TABLE_ARN,
-            /* cacheEnabled= */ true,
-            /* refreshLeadTimeMs= */ 1500L);
+            lakeFormationClient, TABLE_ARN);
 
-    AwsSessionCredentials first = (AwsSessionCredentials) provider.resolveCredentials();
-    assertThat(first.accessKeyId()).isEqualTo("AKID1");
-
-    // Sleep past staleTime (firstExpiry - 1500ms ~= now + 500ms); 700ms gives ample margin.
-    Thread.sleep(700);
-
-    AwsSessionCredentials refreshed = (AwsSessionCredentials) provider.resolveCredentials();
-    assertThat(refreshed.accessKeyId()).isEqualTo("AKID2");
+    provider.resolveCredentials();
+    provider.resolveCredentials();
 
     verify(lakeFormationClient, times(2))
         .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
-  }
-
-  // ---- caching disabled ----
-
-  @Test
-  void cachingDisabledCallsLakeFormationEveryTime() {
-    when(lakeFormationClient.getTemporaryGlueTableCredentials(
-            any(GetTemporaryGlueTableCredentialsRequest.class)))
-        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
-
-    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
-        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
-            lakeFormationClient,
-            TABLE_ARN,
-            /* cacheEnabled= */ false,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
-
-    provider.resolveCredentials();
-    provider.resolveCredentials();
-    provider.resolveCredentials();
-
-    verify(lakeFormationClient, times(3))
-        .getTemporaryGlueTableCredentials(any(GetTemporaryGlueTableCredentialsRequest.class));
-  }
-
-  @Test
-  void cachingDisabledReturnsCredentials() {
-    when(lakeFormationClient.getTemporaryGlueTableCredentials(
-            any(GetTemporaryGlueTableCredentialsRequest.class)))
-        .thenReturn(responseWithExpiry("AKID1", Instant.now().plus(Duration.ofHours(1))));
-
-    LakeFormationAwsClientFactory.LakeFormationCredentialsProvider provider =
-        new LakeFormationAwsClientFactory.LakeFormationCredentialsProvider(
-            lakeFormationClient,
-            TABLE_ARN,
-            /* cacheEnabled= */ false,
-            AwsProperties.LAKE_FORMATION_CACHE_REFRESH_LEAD_TIME_MS_DEFAULT);
-
-    AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
-    assertThat(creds.accessKeyId()).isEqualTo("AKID1");
   }
 }


### PR DESCRIPTION
## Problem

When Iceberg reads LakeFormation-governed tables at high executor counts (e.g. 50× G.2X Spark workers), `LakeFormationCredentialsProvider` calls `GetTemporaryGlueTableCredentials` once per `resolveCredentials()` invocation. Because this is called on every S3 file open, hundreds of concurrent tasks simultaneously hit the LakeFormation API, causing:

    LakeFormationException: Rate exceeded

This was observed in production: a job that succeeded at 25× G.1X (12,281 API calls) started failing after scaling to 50× G.2X. Reducing executors back below the rate limit was the only workaround.

## Solution

Maintain a JVM-wide registry of Lake Formation credential providers. Providers sharing the same table
ARN and catalog properties reuse one AWS SDK `CachedSupplier`, so concurrent Spark partitions in one
JVM make a single credential request and then reuse the vended credentials until they need refreshing.

- Provider entries are retained for `lakeformation.credential-cache.expiration-seconds` after their
  last use; the default is 60 seconds.
- Lake Formation's returned credential expiration controls validity. The SDK cache prefetches a
  replacement 60 seconds before expiry.
- The cache key includes the table ARN and catalog properties, preventing reuse across different table
  or authentication contexts.
- A custom `LakeFormationAwsClientFactory` can override `lakeFormationCredentialsProvider()` and use
  `directLakeFormationCredentialsProvider()` to bypass the shared cache.

## Validation

Validated on a 50× G.2X Spark job against a LakeFormation-governed cross-account Iceberg table:

| | API calls | Result |
|---|---|---|
| Before fix | 12,281 | `LakeFormationException: Rate exceeded` |
| After fix | 598 | Job succeeded in 3,393 s |

- `./gradlew :iceberg-aws:checkstyleMain`
- `./gradlew :iceberg-aws:spotlessCheck`
- `./gradlew :iceberg-aws:test`
- All GitHub Actions checks passed.

## Changes

- `AwsProperties`: add `lakeformation.credential-cache.expiration-seconds`, defaulting to 60 seconds.
- `LakeFormationAwsClientFactory`: share cached providers across factory instances in a JVM and provide
  a custom-factory opt-out hook.
- `TestLakeFormationCredentialsProvider`: validate shared-cache, context isolation, concurrency, and
  direct-provider behavior.

---

**AI Disclosure**
- Model: claude-sonnet-4.6
- Platform/Tool: OpenCode
- Human Oversight: fully reviewed
- Prompt Summary: Implement credential caching in LakeFormationAwsClientFactory to prevent LakeFormation rate exceeded errors at high Spark executor counts

- Model: gpt-5.6-terra
- Platform/Tool: OpenCode
- Human Oversight: partially reviewed
- Prompt Summary: Redesign Lake Formation credential caching to prevent Spark partition bursts from
  exceeding Lake Formation API limits.