### PR TITLE
Core: Simplify first-iteration check in Partitioning.commonActiveFieldIds

### DIFF
--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -379,15 +379,14 @@ public class Partitioning {
   private static Set<Integer> commonActiveFieldIds(Schema schema, Collection<PartitionSpec> specs) {
     Set<Integer> commonActiveFieldIds = Sets.newHashSet();
 
-    int specIndex = 0;
+    boolean first = true;
     for (PartitionSpec spec : specs) {
-      if (specIndex == 0) {
+      if (first) {
         commonActiveFieldIds.addAll(activeFieldIds(schema, spec));
+        first = false;
       } else {
         commonActiveFieldIds.retainAll(activeFieldIds(schema, spec));
       }
-
-      specIndex++;
     }
 
     return commonActiveFieldIds;


### PR DESCRIPTION
In `Partitioning.commonActiveFieldIds`, the loop uses an `int specIndex` counter solely to detect the first spec (the first spec seeds the set with `addAll`, the rest intersect with `retainAll`). Replaces it with a `boolean first` flag, which expresses the intent directly and drops the unused running count. Behavior-preserving; no functional change.