### PR TITLE
Build: Add descriptions to OpenAPI spec validation tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -593,6 +593,8 @@ project(':iceberg-aws') {
   // TODO delete once s3-signer-open-api.yaml is removed
   def s3SignerSpec = layout.projectDirectory.file("src/main/resources/s3-signer-open-api.yaml")
   tasks.register('validateS3SignerSpec', org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
+    description = 'Validates the S3 signer OpenAPI spec'
+    group = 'verification'
     inputSpec.set(s3SignerSpec)
     recommend.set(true)
   }
@@ -1160,6 +1162,8 @@ project(':iceberg-open-api') {
 
   def restCatalogSpec = layout.projectDirectory.file("rest-catalog-open-api.yaml")
   tasks.register('validateRESTCatalogSpec', org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
+    description = 'Validates the REST catalog OpenAPI spec'
+    group = 'verification'
     inputSpec.set(restCatalogSpec)
     recommend.set(true)
   }


### PR DESCRIPTION
The `validateS3SignerSpec` (iceberg-aws) and `validateRESTCatalogSpec` (iceberg-open-api) tasks register an OpenAPI `ValidateTask` but set no `description` or `group`, so they show up under "Other tasks" with no explanation in `./gradlew tasks`. Gives each a short `description` and the `verification` group, matching how the other validation tasks are surfaced. Build-only; no behavior change to the tasks.