### PR TITLE
OpenAPI: Add snapshot encryption key ID

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -352,6 +352,11 @@ class Snapshot(BaseModel):
     )
     summary: Summary
     schema_id: int | None = Field(None, alias='schema-id')
+    key_id: str | None = Field(
+        None,
+        alias='key-id',
+        description="ID of the encryption key used to encrypt this snapshot's manifest list.",
+    )
 
 
 class SnapshotReference(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2990,6 +2990,9 @@ components:
             type: string
         schema-id:
           type: integer
+        key-id:
+          type: string
+          description: ID of the encryption key used to encrypt this snapshot's manifest list.
 
     SnapshotReference:
       type: object


### PR DESCRIPTION
## Description

Adds the optional `key-id` field to the OpenAPI `Snapshot` schema and regenerates the Python models.

This preserves manifest list encryption key IDs in generated clients while remaining compatible with snapshots that do not use encryption.
