### PR TITLE
Core: Stop remote planning workers when ScanTaskIterable closes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -107,7 +106,17 @@ class ScanTaskIterable implements CloseableIterable<FileScanTask> {
   }
 
   @Override
-  public void close() throws IOException {}
+  public void close() {
+    shutdown.set(true);
+    LOG.info(
+        "ScanTaskIterable is closing. Clearing {} queued tasks, {} initial tasks, and {} plan tasks.",
+        taskQueue.size(),
+        initialFileScanTasks.size(),
+        planTasks.size());
+    taskQueue.clear();
+    initialFileScanTasks.clear();
+    planTasks.clear();
+  }
 
   private class PlanTaskWorker implements Runnable {
 
@@ -276,13 +285,7 @@ class ScanTaskIterable implements CloseableIterable<FileScanTask> {
 
     @Override
     public void close() {
-      shutdown.set(true);
-      LOG.info(
-          "ScanTasksIterator is closing. Clearing {} queued tasks and {} plan tasks.",
-          taskQueue.size(),
-          planTasks.size());
-      taskQueue.clear();
-      planTasks.clear();
+      ScanTaskIterable.this.close();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestScanTaskIterable.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestScanTaskIterable.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestScanTaskIterable {
 
@@ -601,5 +602,48 @@ public class TestScanTaskIterable {
     assertThat(terminated)
         .as("Executor should terminate - workers should have exited gracefully")
         .isTrue();
+  }
+
+  @Test
+  @Timeout(10)
+  void closeIterableStopsWorkers() throws InterruptedException {
+    CountDownLatch initialRequestStarted = new CountDownLatch(1);
+    CountDownLatch allowInitialRequestToComplete = new CountDownLatch(1);
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    mockClientPostAnswer(
+        invocation -> {
+          int count = callCount.incrementAndGet();
+
+          if (count == 1) {
+            initialRequestStarted.countDown();
+            allowInitialRequestToComplete.await();
+            return FetchScanTasksResponse.builder().withPlanTasks(planTasks(1)).build();
+          }
+
+          return FetchScanTasksResponse.builder().build();
+        });
+
+    ScanTaskIterable iterable = createIterable(planTasks(1), Collections.emptyList());
+
+    try {
+      assertThat(initialRequestStarted.await(5, TimeUnit.SECONDS))
+          .as("Initial request should start")
+          .isTrue();
+
+      iterable.close();
+      allowInitialRequestToComplete.countDown();
+
+      executorService.shutdown();
+      assertThat(executorService.awaitTermination(2, TimeUnit.SECONDS))
+          .as("Workers should exit after the iterable is closed")
+          .isTrue();
+
+      assertThat(callCount.get())
+          .as("Workers should not fetch additional plan tasks after close")
+          .isEqualTo(1);
+    } finally {
+      allowInitialRequestToComplete.countDown();
+    }
   }
 }


### PR DESCRIPTION
## Summary

Stop local remote-planning workers when `ScanTaskIterable` is closed by setting the shutdown flag and clearing pending tasks. `ScanTasksIterator` delegates to the same close path.

## Tests

Added a regression test that closes the iterable during an in-flight fetch and verifies workers exit without fetching additional plan tasks.