### PR TITLE
fix: redact catalog options from NessieCatalog log

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -203,10 +203,9 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
       //        currentNamespace
       //    );
       LOG.warn(
-          "Catalog creation for inputName={} and options {} failed, because parameter "
+          "Catalog creation for inputName={} failed, because parameter "
               + "'warehouse' is not set, Nessie can't store data.",
-          name,
-          catalogOptions);
+          name);
       throw new IllegalStateException("Parameter 'warehouse' not set, Nessie can't store data.");
     }
 


### PR DESCRIPTION
### Problem

When `warehouse` is not set, `NessieCatalog.warehouseLocation()` logs the entire `catalogOptions` map at WARN level, then throws. The map includes sensitive credentials such as Nessie auth tokens, S3 secret access keys, and session tokens.

### Fix

Remove the `catalogOptions` map from the WARN log message. Only the catalog name is logged, preserving the useful diagnostic while avoiding credential leakage.

### Affected

`org.apache.iceberg:iceberg-nessie`

Fixes #17804