### PR TITLE
Core: Preserve trailing slash on table location in V4 manifest reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/V4ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/V4ManifestReader.java
@@ -190,7 +190,7 @@ class V4ManifestReader extends CloseableGroup implements CloseableIterable<Track
       Preconditions.checkArgument(tableLocation != null, "Invalid table location: null");
       this.file = file;
       this.specsById = specsById;
-      this.tableLocation = LocationUtil.stripTrailingSlash(tableLocation);
+      this.tableLocation = tableLocation;
       this.unionPartitionType = Partitioning.unionPartitionTypes(specsById.values());
       Schema base = TrackedFile.schema(unionPartitionType, Types.StructType.of());
       // the read schema carries row_position (via BASE_TYPE) so the reader can fill manifestPos

--- a/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
@@ -748,6 +748,20 @@ class TestV4ManifestReader {
 
   @ParameterizedTest
   @FieldSource("MANIFEST_FORMATS")
+  public void usesTableLocationVerbatim(FileFormat format) throws IOException {
+    TrackedFile file = dataFile("data/00000-0.parquet", EMPTY_PARTITION_DATA);
+
+    InputFile manifest = writeManifest(format, EMPTY_PARTITION, ImmutableList.of(file));
+
+    try (V4ManifestReader reader =
+        V4ManifestReader.builder(manifest, UNPARTITIONED_SPECS, "s3://bucket/db/table/").build()) {
+      TrackedFile actual = Iterables.getOnlyElement(reader);
+      assertThat(actual.location()).isEqualTo("s3://bucket/db/table//data/00000-0.parquet");
+    }
+  }
+
+  @ParameterizedTest
+  @FieldSource("MANIFEST_FORMATS")
   public void resolvesRelativeDeletionVectorLocation(FileFormat format) throws IOException {
     TrackedFile file =
         dataFile(format.addExtension("data/00000-0"), EMPTY_PARTITION_DATA, dv("data/dv.puffin"));


### PR DESCRIPTION
The V4 manifest reader stripped a trailing slash from the table location before resolving relative file locations against it. Remove the strip as it should be done by the catalog during table creation and not the reader's responsibility. 