### PR TITLE
Spark 4.1: Fix rewrite failure on tables created with a sort order

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -169,8 +169,11 @@ public class SparkWriteConf {
         confParser.intConf().option(SparkWriteOptions.OUTPUT_SORT_ORDER_ID).parseOptional();
 
     if (explicitId != null) {
+      // order id 0 is reserved for unsorted order, which is a valid output for any table
+      // whether or not the table contains a sort order with that id
       Preconditions.checkArgument(
-          table.sortOrders().containsKey(explicitId),
+          explicitId == SortOrder.unsorted().orderId()
+              || table.sortOrders().containsKey(explicitId),
           "Cannot use output sort order id %s because the table does not contain a sort order with that id",
           explicitId);
       return explicitId;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -55,6 +55,8 @@ import java.util.Map;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
@@ -663,6 +665,30 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
         .isEqualTo(table.sortOrder().orderId());
 
     assertThat(writeConfNoOption.outputSortOrderId(SparkWriteRequirements.EMPTY)).isEqualTo(0);
+  }
+
+  @TestTemplate
+  void sortOrderWriteConfWithUnsortedId() {
+    Schema schema = validationCatalog.loadTable(tableIdent).schema();
+    validationCatalog.dropTable(tableIdent);
+    Table table =
+        validationCatalog
+            .buildTable(tableIdent, schema)
+            .withSortOrder(SortOrder.builderFor(schema).asc("id").build())
+            .create();
+    assertThat(table.sortOrders()).doesNotContainKey(SortOrder.unsorted().orderId());
+
+    SparkWriteConf writeConf =
+        new SparkWriteConf(
+            spark,
+            table,
+            new CaseInsensitiveStringMap(
+                ImmutableMap.of(
+                    SparkWriteOptions.OUTPUT_SORT_ORDER_ID,
+                    String.valueOf(SortOrder.unsorted().orderId()))));
+
+    assertThat(writeConf.outputSortOrderId(SparkWriteRequirements.EMPTY))
+        .isEqualTo(SortOrder.unsorted().orderId());
   }
 
   private void testWriteProperties(List<Map<String, String>> propertiesSuite) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1704,6 +1704,37 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  void zOrderWhenTableDeclaredSortOrderAtCreation() throws IOException {
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.builderFor(SCHEMA).asc("c2").build(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+    assertThat(table.sortOrders()).doesNotContainKey(SortOrder.unsorted().orderId());
+
+    writeRecords(4, 100);
+    table.refresh();
+
+    List<Object[]> originalData = currentData();
+
+    RewriteDataFiles.Result result =
+        basicRewrite(table)
+            .zOrder("c2", "c3")
+            .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
+            .execute();
+
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroup").hasSize(1);
+
+    table.refresh();
+
+    assertEquals("We shouldn't have changed the data", originalData, currentData());
+    dataFilesShouldHaveSortOrderIdMatching(table, SortOrder.unsorted());
+    shouldHaveACleanCache(table);
+  }
+
+  @TestTemplate
   public void testAutoSortShuffleOutput() throws IOException {
     Table table = createTable(20, LARGE_SCALE);
     shouldHaveLastCommitUnsorted(table, "c2");


### PR DESCRIPTION
## Problem
`rewriteDataFiles` fails on a table that declared a sort order at creation when the output is unsorted relative to that order — always for z-order, and for sort whenever the requested order matches none the table declares
```
java.lang.IllegalArgumentException: Cannot use output sort order id 0 because the table does not contain a sort order with that id
```
Introduced by #15150 (Spark 4.1) and #15832 (Spark 4.0, 3.5), both released in 1.11.0. All three Spark versions are affected. This PR fixes 4.1; a backport for 4.0 and 3.5 will follow.
## Root cause

`SparkShufflingFileRewriteRunner` sets `output-sort-order-id` from `SortOrderUtil.findTableSortOrder`, which returns `SortOrder.unsorted()` (id 0) when no table sort order matches. `SparkWriteConf.outputSortOrderId` then
rejected that id unless the table contained it:
```java
Preconditions.checkArgument(table.sortOrders().containsKey(explicitId), ...);
```
Id 0 is reserved for unsorted order and is valid for any table, but `sortOrders()` contains it only when the table was created unsorted. A table that declares a sort order at creation (only possible through the Iceberg API, REST, or another engine — `SparkCatalog` never sets one) gets `INITIAL_SORT_ORDER_ID = 1` and never lists 0, so the check rejected an id the rewrite legitimately produced. The implicit branch of the same method already returns that id without consulting the table.
## Fix
Accept the reserved unsorted order id without requiring the table to list it. Unknown ids are still rejected. Downstream, `table.sortOrders().get(0)` yields `null`, `DataFiles.Builder.withSortOrder` ignores it, and the file is written with `sort_order_id = 0`, which is the correct value.