### PR TITLE
Core: Refresh metadata table schemas and specs after table evolution

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -91,9 +91,7 @@ public class PartitionsTable extends BaseMetadataTable {
           Types.LongType.get(),
           "Id of snapshot that last updated this partition");
 
-  private final Schema schema;
-
-  private final boolean unpartitionedTable;
+  private volatile Schema schema;
 
   PartitionsTable(Table table) {
     this(table, table.name() + ".partitions");
@@ -101,11 +99,35 @@ public class PartitionsTable extends BaseMetadataTable {
 
   PartitionsTable(Table table, String name) {
     super(table, name);
+    this.schema = calculateSchema();
+  }
 
-    this.schema =
+  @Override
+  public TableScan newScan() {
+    return new PartitionsScan(table());
+  }
+
+  @Override
+  public void refresh() {
+    super.refresh();
+    this.schema = calculateSchema();
+  }
+
+  @Override
+  public Schema schema() {
+    return schema;
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.PARTITIONS;
+  }
+
+  private Schema calculateSchema() {
+    Types.StructType partitionType = Partitioning.partitionType(table());
+    Schema calculatedSchema =
         new Schema(
-            Types.NestedField.required(
-                PARTITION_FIELD_ID, "partition", Partitioning.partitionType(table)),
+            Types.NestedField.required(PARTITION_FIELD_ID, "partition", partitionType),
             SPEC_ID,
             RECORD_COUNT,
             FILE_COUNT,
@@ -116,19 +138,10 @@ public class PartitionsTable extends BaseMetadataTable {
             EQUALITY_DELETE_FILE_COUNT,
             LAST_UPDATED_AT,
             LAST_UPDATED_SNAPSHOT_ID);
-    this.unpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
-  }
 
-  @Override
-  public TableScan newScan() {
-    return new PartitionsScan(table());
-  }
-
-  @Override
-  public Schema schema() {
-    if (unpartitionedTable) {
+    if (partitionType.fields().isEmpty()) {
       return TypeUtil.select(
-          schema,
+          calculatedSchema,
           ImmutableSet.of(
               RECORD_COUNT.fieldId(),
               FILE_COUNT.fieldId(),
@@ -140,21 +153,19 @@ public class PartitionsTable extends BaseMetadataTable {
               LAST_UPDATED_AT.fieldId(),
               LAST_UPDATED_SNAPSHOT_ID.fieldId()));
     }
-    return schema;
-  }
 
-  @Override
-  MetadataTableType metadataTableType() {
-    return MetadataTableType.PARTITIONS;
+    return calculatedSchema;
   }
 
   private DataTask task(StaticTableScan scan) {
+    Schema tableSchema = scan.tableSchema();
     Iterable<Partition> partitions = partitions(table(), scan);
-    if (unpartitionedTable) {
+
+    if (tableSchema.findField(PARTITION_FIELD_ID) == null) {
       // the table is unpartitioned, partitions contains only the root partition
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),
-          schema(),
+          tableSchema,
           scan.schema(),
           partitions,
           root ->
@@ -171,7 +182,7 @@ public class PartitionsTable extends BaseMetadataTable {
     } else {
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),
-          schema(),
+          tableSchema,
           scan.schema(),
           partitions,
           PartitionsTable::convertPartition);

--- a/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
+++ b/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
@@ -55,9 +55,7 @@ public class PositionDeletesTable extends BaseMetadataTable {
   public static final String CONTENT_OFFSET = "content_offset";
   public static final String CONTENT_SIZE_IN_BYTES = "content_size_in_bytes";
 
-  private final Schema schema;
-  private final int defaultSpecId;
-  private final Map<Integer, PartitionSpec> specs;
+  private volatile MetadataTableState state;
 
   PositionDeletesTable(Table table) {
     this(table, table.name() + ".position_deletes");
@@ -65,9 +63,7 @@ public class PositionDeletesTable extends BaseMetadataTable {
 
   PositionDeletesTable(Table table, String name) {
     super(table, name);
-    this.schema = calculateSchema();
-    this.defaultSpecId = table.spec().specId();
-    this.specs = transformSpecs(schema(), table.specs());
+    this.state = newState();
   }
 
   @Override
@@ -88,17 +84,24 @@ public class PositionDeletesTable extends BaseMetadataTable {
 
   @Override
   public Schema schema() {
-    return schema;
+    return state.schema;
   }
 
   @Override
   public PartitionSpec spec() {
-    return specs.get(defaultSpecId);
+    MetadataTableState currentState = state;
+    return currentState.specs.get(currentState.defaultSpecId);
   }
 
   @Override
   public Map<Integer, PartitionSpec> specs() {
-    return specs;
+    return state.specs;
+  }
+
+  @Override
+  public void refresh() {
+    super.refresh();
+    this.state = newState();
   }
 
   @Override
@@ -109,6 +112,12 @@ public class PositionDeletesTable extends BaseMetadataTable {
         table().properties().entrySet().stream()
             .filter(entry -> entry.getKey().startsWith("write."))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+  }
+
+  private MetadataTableState newState() {
+    Schema currentSchema = calculateSchema();
+    return new MetadataTableState(
+        currentSchema, table().spec().specId(), transformSpecs(currentSchema, table().specs()));
   }
 
   private Schema calculateSchema() {
@@ -381,4 +390,7 @@ public class PositionDeletesTable extends BaseMetadataTable {
               });
     }
   }
+
+  private record MetadataTableState(
+      Schema schema, int defaultSpecId, Map<Integer, PartitionSpec> specs) {}
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -2035,6 +2035,95 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(actualContents).containsExactlyInAnyOrder(0, 0, 0, 0, 2, 2);
   }
 
+  @TestTemplate
+  public void partitionsTableRefreshesSchemaAfterPartitionSpecEvolution() {
+    String tableName = "partitions-refresh";
+    File unpartitionedTableDir = new File(tableDir, tableName);
+    Table baseTable =
+        TestTables.create(
+            unpartitionedTableDir, tableName, SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
+
+    Table partitionsTable = new PartitionsTable(baseTable);
+
+    assertThat(partitionsTable.schema().findField("partition")).isNull();
+    assertThat(partitionsTable.schema().findField("spec_id")).isNull();
+
+    Table writer = TestTables.load(unpartitionedTableDir, tableName);
+    writer.updateSpec().addField("id").commit();
+
+    // Refresh the wrapped base table without refreshing the metadata table state.
+    baseTable.refresh();
+    assertThat(partitionsTable.schema().findField("partition.id")).isNull();
+
+    partitionsTable.refresh();
+
+    assertThat(partitionsTable.schema().findField("partition.id")).isNotNull();
+    assertThat(partitionsTable.schema().findField("spec_id")).isNotNull();
+    assertThat(partitionsTable.newScan().schema().findField("partition.id")).isNotNull();
+  }
+
+  @TestTemplate
+  public void positionDeletesTableRefreshesSchemaAfterPartitionSpecEvolution() {
+    assumeThat(formatVersion).as("Position deletes are not supported by V1 Tables").isNotEqualTo(1);
+
+    PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
+
+    assertThat(positionDeletesTable.schema().findField("partition.id")).isNull();
+
+    Table writer = load();
+    writer.updateSpec().addField("id").commit();
+
+    table.refresh();
+    assertThat(positionDeletesTable.schema().findField("partition.id")).isNull();
+
+    positionDeletesTable.refresh();
+
+    assertThat(positionDeletesTable.schema().findField("partition.id")).isNotNull();
+    assertThat(positionDeletesTable.newBatchScan().schema().findField("partition.id")).isNotNull();
+  }
+
+  @TestTemplate
+  public void positionDeletesTableRefreshesSpecsAfterPartitionSpecEvolution() {
+    assumeThat(formatVersion).as("Position deletes are not supported by V1 Tables").isNotEqualTo(1);
+
+    PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
+    int previousSpecId = table.spec().specId();
+
+    Table writer = load();
+    writer.updateSpec().addField("id").commit();
+    int currentSpecId = writer.spec().specId();
+
+    table.refresh();
+    assertThat(positionDeletesTable.spec().specId()).isEqualTo(previousSpecId);
+
+    positionDeletesTable.refresh();
+
+    assertThat(positionDeletesTable.spec().specId()).isEqualTo(currentSpecId);
+    assertThat(positionDeletesTable.specs().keySet())
+        .containsExactlyInAnyOrder(previousSpecId, currentSpecId);
+  }
+
+  @TestTemplate
+  public void positionDeletesTableRefreshesSchemaAfterBaseTableSchemaEvolution() {
+    assumeThat(formatVersion).as("Position deletes are not supported by V1 Tables").isNotEqualTo(1);
+
+    PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
+
+    assertThat(positionDeletesTable.schema().findField("row.new_column")).isNull();
+
+    Table writer = load();
+    writer.updateSchema().addColumn("new_column", Types.StringType.get()).commit();
+
+    table.refresh();
+    assertThat(positionDeletesTable.schema().findField("row.new_column")).isNull();
+
+    positionDeletesTable.refresh();
+
+    assertThat(positionDeletesTable.schema().findField("row.new_column")).isNotNull();
+    assertThat(positionDeletesTable.newBatchScan().schema().findField("row.new_column"))
+        .isNotNull();
+  }
+
   private int rowCount(TableScan scan) throws IOException {
     int count = 0;
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {


### PR DESCRIPTION
## Summary

`PartitionsTable` and `PositionDeletesTable` cache schemas and partition specs at construction time. After the base table evolves and the metadata table is refreshed, long-lived instances may continue exposing stale partition fields, row schemas, and specs.

This change derives those values from the current table metadata and ensures partition rows use the schema captured by the scan.

## Tests
Tests cover partition spec evolution, base table schema evolution, and partition row materialization after refresh.
