### PR TITLE
Parquet: Fix misleading AlwaysFalse placeholder exception message

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -248,7 +248,7 @@ class ParquetFilters {
 
     @Override
     public <R> R accept(Visitor<R> visitor) {
-      throw new UnsupportedOperationException("AlwaysTrue is a placeholder only");
+      throw new UnsupportedOperationException("AlwaysFalse is a placeholder only");
     }
   }
 }


### PR DESCRIPTION
Fix the exception message in `ParquetFilters.AlwaysFalse` to correctly identify the `AlwaysFalse` placeholder.