### PR TITLE
AWS: Fix credentials.uri resolution in S3FileIO refresh

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -59,6 +60,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.relocated.com.google.common.collect.SetMultimap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SerializableSupplier;
@@ -461,7 +463,13 @@ public class S3FileIO
       return;
     }
 
-    try (VendedCredentialsProvider provider = VendedCredentialsProvider.create(properties)) {
+    Map<String, String> refreshProperties = Maps.newHashMap(properties);
+    String endpoint =
+        RESTUtil.resolveEndpoint(
+            properties.get(CatalogProperties.URI), properties.get(VendedCredentialsProvider.URI));
+    refreshProperties.put(VendedCredentialsProvider.URI, endpoint);
+
+    try (VendedCredentialsProvider provider = VendedCredentialsProvider.create(refreshProperties)) {
       List<StorageCredential> refreshed =
           provider.fetchCredentials().credentials().stream()
               .filter(c -> c.prefix().startsWith(ROOT_PREFIX))

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
@@ -345,4 +345,90 @@ public class TestS3FileIOCredentialRefresh {
       }
     }
   }
+
+  @Test
+  public void credentialRefreshResolvesRelativeCredentialsUri() {
+    // credentials.uri may be configured as a path relative to the catalog uri rather than an
+    // absolute URL. The refresh must resolve it against CatalogProperties.URI before fetching.
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            "s3://bucket/path",
+            ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID,
+                "initialAccessKey",
+                S3FileIOProperties.SECRET_ACCESS_KEY,
+                "initialSecretKey",
+                S3FileIOProperties.SESSION_TOKEN,
+                "initialToken",
+                S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS,
+                nearExpiryMs));
+
+    String refreshedExpiryMs =
+        Long.toString(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli());
+    LoadCredentialsResponse refreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix("s3://bucket/path")
+                    .config(
+                        ImmutableMap.of(
+                            S3FileIOProperties.ACCESS_KEY_ID,
+                            "refreshedAccessKey",
+                            S3FileIOProperties.SECRET_ACCESS_KEY,
+                            "refreshedSecretKey",
+                            S3FileIOProperties.SESSION_TOKEN,
+                            "refreshedToken",
+                            S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS,
+                            refreshedExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod(HttpMethod.GET.name());
+    mockServer
+        .when(mockRequest)
+        .respond(
+            response(LoadCredentialsResponseParser.toJson(refreshResponse)).withStatusCode(200));
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AwsProperties.CLIENT_FACTORY,
+            StaticClientFactory.class.getName(),
+            VendedCredentialsProvider.URI,
+            "credentials",
+            CatalogProperties.URI,
+            CATALOG_URI,
+            "init-creation-stacktrace",
+            "false");
+
+    StaticClientFactory.client = null;
+    try (S3FileIO fileIO = new S3FileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(initialCredential));
+
+      // Trigger clientByPrefix() to build the client map and schedule the refresh.
+      fileIO.client();
+
+      // The refresh must resolve the relative "credentials" path against CatalogProperties.URI
+      // and hit the mock server at /v1/credentials.
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(() -> mockServer.verify(mockRequest, VerificationTimes.atLeast(1)));
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> {
+                List<StorageCredential> credentials = fileIO.credentials();
+                assertThat(credentials).hasSize(1);
+                assertThat(credentials.get(0).config())
+                    .containsEntry(S3FileIOProperties.ACCESS_KEY_ID, "refreshedAccessKey")
+                    .containsEntry(S3FileIOProperties.SECRET_ACCESS_KEY, "refreshedSecretKey")
+                    .containsEntry(S3FileIOProperties.SESSION_TOKEN, "refreshedToken")
+                    .containsEntry(
+                        S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, refreshedExpiryMs);
+              });
+    }
+  }
 }


### PR DESCRIPTION
Fix unresolved credentials endpoint in S3FileIO credential refresh.

Bug: refreshStorageCredentials creates VendedCredentialsProvider with raw properties. When credentials.uri is a relative path, it stays unresolved and results in null or a failed fetch at S3FileIO.java:464.

Fix: copy properties, resolve the endpoint with RESTUtil.resolveEndpoint(uri, refreshEndpoint) using CatalogProperties.URI and VendedCredentialsProvider.URI, put the resolved value back as credentials.uri, then create the provider.

Evidence: verified diff is minimal and matches AwsClientProperties and GCPProperties resolve pattern. Manual verification shows the endpoint is now absolute before provider creation. Existing TestS3FileIOCredentialRefresh covers the refresh path.