### PR TITLE
Core: Fail on repeated page tokens in RESTSessionCatalog listing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -56,6 +57,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
@@ -321,6 +323,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     Map<String, String> queryParams = Maps.newHashMap();
     ImmutableList.Builder<TableIdentifier> tables = ImmutableList.builder();
     String pageToken = "";
+    Set<String> seenPageTokens = new HashSet<>();
     if (pageSize != null) {
       queryParams.put("pageSize", String.valueOf(pageSize));
     }
@@ -339,6 +342,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ErrorHandlers.namespaceErrorHandler());
       pageToken = response.nextPageToken();
       tables.addAll(response.identifiers());
+      checkPageTokenNotRepeated(pageToken, seenPageTokens, "listTables");
     } while (pageToken != null);
 
     return tables.build();
@@ -784,6 +788,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();
     String pageToken = "";
+    Set<String> seenPageTokens = new HashSet<>();
     if (pageSize != null) {
       queryParams.put("pageSize", String.valueOf(pageSize));
     }
@@ -802,6 +807,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ErrorHandlers.namespaceErrorHandler());
       pageToken = response.nextPageToken();
       namespaces.addAll(response.namespaces());
+      checkPageTokenNotRepeated(pageToken, seenPageTokens, "listNamespaces");
     } while (pageToken != null);
 
     return namespaces.build();
@@ -1419,6 +1425,22 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
   }
 
+  /**
+   * Guards a paginated listing loop against a REST server that returns a page token it has already
+   * returned earlier in the same call. The REST spec requires the final page to have a null
+   * next-page-token; a server that repeats a token would otherwise cause the client to request
+   * pages indefinitely and accumulate duplicated results.
+   */
+  private static void checkPageTokenNotRepeated(
+      String nextPageToken, Set<String> seenPageTokens, String operation) {
+    if (nextPageToken != null && !seenPageTokens.add(nextPageToken)) {
+      throw new RESTException(
+          "Detected repeated page token '%s' returned by REST server during %s; "
+              + "refusing to loop indefinitely",
+          nextPageToken, operation);
+    }
+  }
+
   public void commitTransaction(SessionContext context, List<TableCommit> commits) {
     Endpoint.check(endpoints, Endpoint.V1_COMMIT_TRANSACTION);
     List<UpdateTableRequest> tableChanges = Lists.newArrayListWithCapacity(commits.size());
@@ -1449,6 +1471,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     Map<String, String> queryParams = Maps.newHashMap();
     ImmutableList.Builder<TableIdentifier> views = ImmutableList.builder();
     String pageToken = "";
+    Set<String> seenPageTokens = new HashSet<>();
     if (pageSize != null) {
       queryParams.put("pageSize", String.valueOf(pageSize));
     }
@@ -1467,6 +1490,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ErrorHandlers.namespaceErrorHandler());
       pageToken = response.nextPageToken();
       views.addAll(response.identifiers());
+      checkPageTokenNotRepeated(pageToken, seenPageTokens, "listViews");
     } while (pageToken != null);
 
     return views.build();

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2586,6 +2586,105 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
+  public void listNamespacesFailsWhenServerRepeatsPageToken() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "10"));
+
+    Mockito.doAnswer(
+            invocation ->
+                ListNamespacesResponse.builder()
+                    .add(Namespace.of("ns0"))
+                    .nextPageToken("stuck")
+                    .build())
+        .when(adapter)
+        .execute(
+            matches(HTTPMethod.GET, RESOURCE_PATHS.namespaces()),
+            eq(ListNamespacesResponse.class),
+            any(),
+            any());
+
+    assertThatThrownBy(() -> catalog.listNamespaces())
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Detected repeated page token 'stuck'")
+        .hasMessageContaining("listNamespaces");
+  }
+
+  @Test
+  public void listNamespacesFailsWhenServerAlternatesPageTokens() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "10"));
+
+    // alternate between two tokens forever; a same-token-only guard would not catch this
+    AtomicBoolean flip = new AtomicBoolean(false);
+    Mockito.doAnswer(
+            invocation -> {
+              String next = flip.getAndSet(!flip.get()) ? "a" : "b";
+              return ListNamespacesResponse.builder()
+                  .add(Namespace.of("ns"))
+                  .nextPageToken(next)
+                  .build();
+            })
+        .when(adapter)
+        .execute(
+            matches(HTTPMethod.GET, RESOURCE_PATHS.namespaces()),
+            eq(ListNamespacesResponse.class),
+            any(),
+            any());
+
+    assertThatThrownBy(() -> catalog.listNamespaces())
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Detected repeated page token")
+        .hasMessageContaining("listNamespaces");
+  }
+
+  @Test
+  public void listTablesFailsWhenServerRepeatsPageToken() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "10"));
+
+    String namespaceName = "newdb";
+    Namespace namespace = Namespace.of(namespaceName);
+    catalog.createNamespace(namespace);
+
+    Mockito.doAnswer(
+            invocation ->
+                ListTablesResponse.builder()
+                    .add(TableIdentifier.of(namespace, "t0"))
+                    .nextPageToken("stuck")
+                    .build())
+        .when(adapter)
+        .execute(
+            matches(HTTPMethod.GET, RESOURCE_PATHS.tables(namespace)),
+            eq(ListTablesResponse.class),
+            any(),
+            any());
+
+    assertThatThrownBy(() -> catalog.listTables(namespace))
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Detected repeated page token 'stuck'")
+        .hasMessageContaining("listTables");
+  }
+
+  @Test
+  public void paginationTerminatesNormallyWhenServerReturnsNullToken() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "10"));
+
+    catalog.createNamespace(Namespace.of("only"));
+
+    // regression check: happy path with a single page (null next-page-token) still returns cleanly
+    assertThat(catalog.listNamespaces()).containsExactly(Namespace.of("only"));
+  }
+
+  @Test
   public void testCleanupUncommitedFilesForCleanableFailures() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest;
 
 import static org.apache.iceberg.rest.RequestMatcher.matches;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -45,6 +46,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -237,6 +239,36 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
             any(),
             eq(ListTablesResponse.class),
             any());
+  }
+
+  @Test
+  public void listViewsFailsWhenServerRepeatsPageToken() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "10"));
+
+    String namespaceName = "newdb";
+    Namespace namespace = Namespace.of(namespaceName);
+    catalog().createNamespace(namespace);
+
+    Mockito.doAnswer(
+            invocation ->
+                ListTablesResponse.builder()
+                    .add(TableIdentifier.of(namespace, "v0"))
+                    .nextPageToken("stuck")
+                    .build())
+        .when(adapter)
+        .execute(
+            matches(HTTPMethod.GET, String.format("v1/namespaces/%s/views", namespaceName)),
+            eq(ListTablesResponse.class),
+            any(),
+            any());
+
+    assertThatThrownBy(() -> catalog.listViews(namespace))
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Detected repeated page token 'stuck'")
+        .hasMessageContaining("listViews");
   }
 
   @Test


### PR DESCRIPTION
## Which Iceberg project does this PR belong to?

Core

## What changes are proposed in this pull request?

Fixes #17755.

`RESTSessionCatalog.listTables`, `listNamespaces`, and `listViews` currently loop until the server returns a `null` `next-page-token`. If a REST server returns a token it has already returned earlier in the same call — whether the same token every time or an alternating cycle of two or more tokens — the client requests pages indefinitely and accumulates duplicated results. Every individual HTTP call succeeds, so socket timeouts do not bound the operation. The reporter observed 51,043 requests in 5 seconds against a stub that returned a fixed non-null token.

This change adds a small `checkPageTokenNotRepeated` helper to `RESTSessionCatalog`. Each of the three listing loops tracks the set of `next-page-token` values it has received; on the second occurrence of the same token the client throws a `RESTException` with the offending token and the listing operation. A set (not just previous-token comparison) is required to also detect alternating-token cycles, per the possible-fix note in #17755.

Returning a partial result would be unsafe because callers could treat missing namespaces, tables, or views as complete. Failing loudly matches the "favor the client" REST-spec guidance in `AGENTS.md` and the reporter's stated preferred behavior in the issue.

## Tests

New unit tests added in `TestRESTCatalog` and `TestRESTViewCatalog`:

- `listNamespacesFailsWhenServerRepeatsPageToken` — server returns the same non-null token every time.
- `listNamespacesFailsWhenServerAlternatesPageTokens` — server alternates between two tokens; proves the guard uses a set, not just previous-token comparison.
- `listTablesFailsWhenServerRepeatsPageToken`.
- `listViewsFailsWhenServerRepeatsPageToke- `paginationTerminatesNormallyWhenServerReturnsNullToken` — regression: the guard does not affect the happy path when the server terminates pagination correctly.

Existing `testPaginationForListNamespaces`, `testPaginationForListTables`, and `testPaginationForListViews` continue to pass unchanged.

---
**AI Disclosure**
- Platform/Tool: Cursor