### PR TITLE
Kafka Connect: Warn and count records dropped by NoOpWriter

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
@@ -20,7 +20,10 @@ package org.apache.iceberg.connect.data;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
@@ -48,6 +51,8 @@ class IcebergWriterFactory {
 
   private final Catalog catalog;
   private final IcebergSinkConfig config;
+  private final Set<String> warnedMissingTables = ConcurrentHashMap.newKeySet();
+  private final AtomicLong droppedRecordCount = new AtomicLong();
 
   IcebergWriterFactory(Catalog catalog, IcebergSinkConfig config) {
     this.catalog = catalog;
@@ -63,7 +68,17 @@ class IcebergWriterFactory {
       if (config.autoCreateEnabled()) {
         table = autoCreateTable(tableName, sample);
       } else if (ignoreMissingTable) {
-        return new NoOpWriter();
+        if (warnedMissingTables.add(tableName)) {
+          LOG.warn(
+              "Table {} does not exist in catalog {} and auto-create is disabled; "
+                  + "records routed to it will be silently discarded. "
+                  + "Set iceberg.tables.auto-create-enabled=true or pre-create the table "
+                  + "in the catalog.",
+              tableName,
+              catalog.name(),
+              nst);
+        }
+        return new NoOpWriter(droppedRecordCount);
       } else {
         throw nst;
       }
@@ -78,6 +93,21 @@ class IcebergWriterFactory {
     TableReference tableReference = TableReference.of(catalog.name(), identifier, tableUuid);
 
     return new IcebergWriter(table, tableReference, config);
+  }
+
+  /**
+   * Returns the number of records discarded by {@link NoOpWriter} instances created by this
+   * factory. A non-zero value indicates that dynamic routing encountered a table that does not
+   * exist in the catalog while auto-create was disabled.
+   */
+  @VisibleForTesting
+  long droppedRecordCount() {
+    return droppedRecordCount.get();
+  }
+
+  @VisibleForTesting
+  Set<String> warnedMissingTables() {
+    return warnedMissingTables;
   }
 
   @VisibleForTesting

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/NoOpWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/NoOpWriter.java
@@ -19,23 +19,33 @@
 package org.apache.iceberg.connect.data;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+/**
+ * Placeholder writer used when dynamic routing encounters a table that does not exist in the
+ * catalog and auto-create is disabled. Every record written through this writer is discarded and
+ * counted in a shared, factory-scoped counter so operators can distinguish "no records dropped"
+ * from "records silently dropped".
+ */
 class NoOpWriter implements RecordWriter {
+  private final AtomicLong droppedRecordCount;
+
+  NoOpWriter(AtomicLong droppedRecordCount) {
+    this.droppedRecordCount = droppedRecordCount;
+  }
+
   @Override
   public void write(SinkRecord record) {
-    // NO-OP
+    droppedRecordCount.incrementAndGet();
   }
 
   @Override
   public List<IcebergWriterResult> complete() {
-    // NO-OP
     return ImmutableList.of();
   }
 
   @Override
-  public void close() {
-    // NO-OP
-  }
+  public void close() {}
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -42,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -95,5 +97,117 @@ public class TestIcebergWriterFactory {
     assertThat(capturedArguments.get(0)).isEqualTo(Namespace.of("foo1"));
     assertThat(capturedArguments.get(1)).isEqualTo(Namespace.of("foo1", "foo2"));
     assertThat(capturedArguments.get(2)).isEqualTo(Namespace.of("foo1", "foo2", "foo3"));
+  }
+
+  @Test
+  public void missingTableWithIgnoreFlagReturnsNoOpWriterAndTracksTable() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    RecordWriter writer = factory.createWriter("db.missing", mock(SinkRecord.class), true);
+    assertThat(writer).isInstanceOf(NoOpWriter.class);
+    assertThat(factory.warnedMissingTables()).containsExactly("db.missing");
+  }
+
+  @Test
+  public void missingTableRecordsWarnAtMostOncePerTable() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    // two calls for the same missing table
+    factory.createWriter("db.missing", mock(SinkRecord.class), true);
+    factory.createWriter("db.missing", mock(SinkRecord.class), true);
+
+    // the same table appears only once in the warned-set (proxy for "WARN logged once")
+    assertThat(factory.warnedMissingTables()).containsExactly("db.missing");
+  }
+
+  @Test
+  public void missingTablesEachRecordSeparateWarn() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    factory.createWriter("db.missing_a", mock(SinkRecord.class), true);
+    factory.createWriter("db.missing_b", mock(SinkRecord.class), true);
+
+    assertThat(factory.warnedMissingTables())
+        .containsExactlyInAnyOrder("db.missing_a", "db.missing_b");
+  }
+
+  @Test
+  public void noOpWriterIncrementsDroppedRecordCountPerWrite() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+    RecordWriter writer = factory.createWriter("db.missing", mock(SinkRecord.class), true);
+
+    for (int i = 0; i < 5; i++) {
+      writer.write(mock(SinkRecord.class));
+    }
+
+    assertThat(factory.droppedRecordCount()).isEqualTo(5L);
+  }
+
+  @Test
+  public void droppedRecordCountAccumulatesAcrossTables() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+    RecordWriter writerA = factory.createWriter("db.missing_a", mock(SinkRecord.class), true);
+    RecordWriter writerB = factory.createWriter("db.missing_b", mock(SinkRecord.class), true);
+
+    writerA.write(mock(SinkRecord.class));
+    writerA.write(mock(SinkRecord.class));
+    writerB.write(mock(SinkRecord.class));
+
+    assertThat(factory.droppedRecordCount()).isEqualTo(3L);
+  }
+
+  @Test
+  public void missingTableWithoutIgnoreFlagRethrows() {
+    Catalog catalog = mock(Catalog.class);
+    when(catalog.name()).thenReturn("test-catalog");
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateEnabled()).thenReturn(false);
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.createWriter("db.missing", mock(SinkRecord.class), false))
+        .isInstanceOf(NoSuchTableException.class);
+
+    // no warn, no counter increment, because the record was never dropped — the caller got the
+    // error
+    assertThat(factory.warnedMissingTables()).isEmpty();
+    assertThat(factory.droppedRecordCount()).isZero();
   }
 }


### PR DESCRIPTION
## Which Iceberg project does this PR belong to?

Kafka Connect

## What changes are proposed in this pull request?

Fixes #17641.

Under dynamic routing, when the sink is configured with `iceberg.tables.auto-create-enabled=false` and a record is routed to a table that does not exist in the catalog, `IcebergWriterFactory.createWriter` returned a `NoOpWriter` that silently discarded every subsequent record for that table. There was no log line, no counter, and no metric — the connector stayed in `RUNNING` state while data was lost. The reporter documented two AWS MSK Connect production incidents in the issue and proposed the fix.

This PR:

- Adds a `Set<String> warnedMissingTables` (backed by `ConcurrentHashMap.newKeySet()`) to `IcebergWriterFactory`. The first time a given `tableName` resolves to `NoOpWriter`, the factory logs a WARN that includes the table name, the catalog name, and the actionable hint from the issue. Subsequent misses for the same table do not re-log (log-flood protection at high record throughput).
- Adds a factory-scoped `AtomicLong droppedRecordCount`. `NoOpWriter` now accepts a reference to this counter in its constructor and increments it on every `write(record)`. This gives operators the precise number of records lost, not just the number of unique unresolved tables.
- Exposes both fields via `@VisibleForTesting` accessors so unit tests can assert the behavior deterministically without needing an slf4j appender fixture.

Behavior for the happy path (table exists, or `ignoreMissingTable=false`) is unchanged.

### Design choices vs. reporter's open questions

- **Q1 — Metric name.** Not addressed in this PR. Wiring the counter into a Kafka Connect sink metric is deferred so the metric name can be discussed independently.
- **Q2 — WARN wording.** Matches the reporter's pred message in the issue.
- **Q3 — Rate-limit shape.** Log-once-per-table-name-per-factory, matching the reporter's simplest proposal.
- **Q4 — Scope of the counter.** Single factory-scoped counter (task-scoped in practice, since each `SinkWriter` has one factory per task). Per-table breakdown is deferred to keep the diff minimal.
- **Q5 — Where to increment.** Incremented on `NoOpWriter.write(record)` so the counter reflects records lost, not unique missing tables.

## Tests

New unit tests in `TestIcebergWriterFactory`:

- `missingTableWithIgnoreFlagReturnsNoOpWriterAndTracksTable` — the first miss returns a `NoOpWriter` and adds the table to `warnedMissingTables`.
- `missingTableRecordsWarnAtMostOncePerTable` — two calls for the same missing table produce exactly one entry (proxy for "WARN logged once").
- `missingTablesEachRecordSeparateWarn` — two different missing tables each get their own warned-set entry.
- `noOpWriterIncrementsDroppedRecordCountPerWrite` — `NoOpWriter.write` incrementsunter once per call.
- `droppedRecordCountAccumulatesAcrossTables` — the counter is factory-scoped and accumulates across all `NoOpWriter` instances the factory returns.
- `missingTableWithoutIgnoreFlagRethrows` — regression: when `ignoreMissingTable=false`, `NoSuchTableException` still propagates and no warn / counter increment happens.

Existing `testAutoCreateTable` continues to pass unchanged. Existing `TestSinkWriter` tests (which construct `IcebergWriterFactory` indirectly through `SinkWriter`) also continue to pass — the change is behavior-additive.

---
**AI Disclosure**
- Platform/Tool: Cursor