### PR TITLE
Spark 4.1: Add per-task write duration metrics

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesMetrics.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesMetrics.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.iceberg.spark.source.metrics.WriteCloseDuration;
+import org.apache.iceberg.spark.source.metrics.WriteDuration;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.execution.ui.SQLAppStatusStore;
+import org.apache.spark.sql.execution.ui.SQLExecutionUIData;
+import org.apache.spark.sql.execution.ui.SQLPlanMetric;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Covers the write timing metrics on the position deletes rewrite path, which is driven by a
+ * procedure rather than a plain SQL write.
+ */
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewritePositionDeleteFilesMetrics extends ExtensionsTestBase {
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void writeDurationForDVRewrite() throws Exception {
+    // v3 tables rewrite deletes through DVWriter rather than DeleteWriter
+    createTableWithDeletes(3);
+
+    sql(
+        "CALL %s.system.rewrite_position_delete_files("
+            + "table => '%s', options => map('rewrite-all','true'))",
+        catalogName, tableIdent);
+
+    assertThat(maxMetricValue(new WriteDuration().description()))
+        .as("write duration should be reported by the DV rewrite")
+        .isGreaterThan(0);
+    assertThat(maxMetricValue(new WriteCloseDuration().description()))
+        .as("write close duration should be reported by the DV rewrite")
+        .isGreaterThan(0);
+  }
+
+  private void createTableWithDeletes(int formatVersion) throws Exception {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
+            + "('format-version'='%d', 'write.delete.mode'='merge-on-read',"
+            + " 'write.delete.granularity'='partition')",
+        tableName, formatVersion);
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "c"),
+            new SimpleRecord(4, "d"));
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    sql("DELETE FROM %s WHERE id = 1", tableName);
+    sql("DELETE FROM %s WHERE id = 2", tableName);
+  }
+
+  @TestTemplate
+  public void writeDurationForPositionDeletesRewrite() throws Exception {
+    createTableWithDeletes(2);
+
+    sql(
+        "CALL %s.system.rewrite_position_delete_files("
+            + "table => '%s', options => map('rewrite-all','true'))",
+        catalogName, tableIdent);
+
+    // the rewrite runs as its own SQL execution, so look for the write node across executions
+    assertThat(maxMetricValue(new WriteDuration().description()))
+        .as("write duration should be reported by the position deletes rewrite")
+        .isGreaterThan(0);
+    assertThat(maxMetricValue(new WriteCloseDuration().description()))
+        .as("write close duration should be reported by the position deletes rewrite")
+        .isGreaterThan(0);
+  }
+
+  /** Looks up a metric by the description Spark stores in the UI, across all executions. */
+  private long maxMetricValue(String metricDescription) {
+    SQLAppStatusStore statusStore = spark.sharedState().statusStore();
+    long max = 0L;
+
+    for (SQLExecutionUIData execution : CollectionConverters.asJava(statusStore.executionsList())) {
+      Map<Object, String> metricValues =
+          CollectionConverters.asJava(
+              statusStore.execution(execution.executionId()).get().metricValues());
+
+      for (SQLPlanMetric metric : CollectionConverters.asJava(execution.metrics())) {
+        if (metric.name().equals(metricDescription)) {
+          String value = metricValues.get(metric.accumulatorId());
+          if (value != null) {
+            max = Math.max(max, parseNanos(value));
+          }
+        }
+      }
+    }
+
+    return max;
+  }
+
+  /** Durations are stored formatted (e.g. "1.5 s"), so recover a comparable magnitude. */
+  private long parseNanos(String formatted) {
+    String[] parts = formatted.trim().split(" ");
+    double value = Double.parseDouble(parts[0].replace(",", ""));
+    switch (parts[1]) {
+      case "ns":
+        return (long) value;
+      case "us":
+        return (long) (value * 1_000);
+      case "ms":
+        return (long) (value * 1_000_000);
+      case "s":
+        return (long) (value * 1_000_000_000L);
+      default:
+        throw new IllegalArgumentException("Unknown duration unit: " + formatted);
+    }
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesMetrics.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesMetrics.java
@@ -130,9 +130,14 @@ public class TestRewritePositionDeleteFilesMetrics extends ExtensionsTestBase {
     return max;
   }
 
-  /** Durations are stored formatted (e.g. "1.5 s"), so recover a comparable magnitude. */
+  /**
+   * Durations are stored as "total (min, med, max)\n1.5 s (0.4 s, 0.5 s, 0.6 s)", so recover the
+   * total as a comparable magnitude.
+   */
   private long parseNanos(String formatted) {
-    String[] parts = formatted.trim().split(" ");
+    String total = formatted.substring(formatted.indexOf('\n') + 1);
+    total = total.substring(0, total.indexOf(" (")).trim();
+    String[] parts = total.split(" ");
     double value = Double.parseDouble(parts[0].replace(",", ""));
     switch (parts[1]) {
       case "ns":

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteUtil.java
@@ -55,6 +55,8 @@ import org.apache.iceberg.spark.source.metrics.TotalEqualityDeletes;
 import org.apache.iceberg.spark.source.metrics.TotalFileSizeInBytes;
 import org.apache.iceberg.spark.source.metrics.TotalPositionalDeletes;
 import org.apache.iceberg.spark.source.metrics.TotalRecords;
+import org.apache.iceberg.spark.source.metrics.WriteCloseDuration;
+import org.apache.iceberg.spark.source.metrics.WriteDuration;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.apache.spark.sql.connector.distributions.Distribution;
@@ -310,12 +312,25 @@ public class SparkWriteUtil {
       new TotalEqualityDeletes(),
       new TotalFileSizeInBytes(),
       new TotalPositionalDeletes(),
-      new TotalRecords()
+      new TotalRecords(),
+      new WriteDuration(),
+      new WriteCloseDuration()
     };
   }
 
   public static CustomTaskMetric[] customTaskMetrics(InMemoryMetricsReporter metricsReporter) {
+    return customTaskMetrics(metricsReporter, WriteDurations.EMPTY);
+  }
+
+  /**
+   * Builds the driver-side metrics for a write, combining the commit report with the write times
+   * tasks reported back in their commit messages.
+   */
+  public static CustomTaskMetric[] customTaskMetrics(
+      InMemoryMetricsReporter metricsReporter, WriteDurations writeDurations) {
     List<CustomTaskMetric> metrics = Lists.newArrayList();
+    addValue(new WriteDuration(), writeDurations.writeNanos(), metrics);
+    addValue(new WriteCloseDuration(), writeDurations.closeNanos(), metrics);
     if (metricsReporter != null) {
       CommitReport commitReport = metricsReporter.commitReport();
       if (commitReport != null) {
@@ -346,6 +361,22 @@ public class SparkWriteUtil {
       }
     }
     return metrics.toArray(new CustomTaskMetric[0]);
+  }
+
+  private static void addValue(
+      CustomMetric metric, long value, List<CustomTaskMetric> taskMetrics) {
+    taskMetrics.add(
+        new CustomTaskMetric() {
+          @Override
+          public String name() {
+            return metric.name();
+          }
+
+          @Override
+          public long value() {
+            return value;
+          }
+        });
   }
 
   private static void addValue(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/WriteDurations.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/WriteDurations.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.io.Serializable;
+
+/**
+ * Write times summed across the tasks of a write.
+ *
+ * <p>Tasks report their own times in their commit messages. Spark collects task metrics before it
+ * calls {@code DataWriter.commit()}, so the close time, where buffered rows are flushed, is not yet
+ * known at that point and cannot be reported as a task metric. Both times therefore travel back to
+ * the driver with the commit messages and are aggregated here.
+ */
+public class WriteDurations implements Serializable {
+
+  public static final WriteDurations EMPTY = new WriteDurations(0L, 0L);
+
+  private final long writeNanos;
+  private final long closeNanos;
+
+  private WriteDurations(long writeNanos, long closeNanos) {
+    this.writeNanos = writeNanos;
+    this.closeNanos = closeNanos;
+  }
+
+  public static WriteDurations of(long writeNanos, long closeNanos) {
+    return new WriteDurations(writeNanos, closeNanos);
+  }
+
+  public WriteDurations combine(WriteDurations other) {
+    return new WriteDurations(writeNanos + other.writeNanos, closeNanos + other.closeNanos);
+  }
+
+  public long writeNanos() {
+    return writeNanos;
+  }
+
+  public long closeNanos() {
+    return closeNanos;
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewrite.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.spark.PositionDeletesRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteUtil;
+import org.apache.iceberg.spark.WriteDurations;
 import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -86,6 +87,7 @@ public class SparkPositionDeletesRewrite implements Write {
   private final StructLike partition;
   private final Map<String, String> writeProperties;
   private InMemoryMetricsReporter metricsReporter;
+  private WriteDurations writeDurations = WriteDurations.EMPTY;
 
   /**
    * Constructs a {@link SparkPositionDeletesRewrite}.
@@ -136,7 +138,7 @@ public class SparkPositionDeletesRewrite implements Write {
 
   @Override
   public CustomTaskMetric[] reportDriverMetrics() {
-    return SparkWriteUtil.customTaskMetrics(metricsReporter);
+    return SparkWriteUtil.customTaskMetrics(metricsReporter, writeDurations);
   }
 
   @Override
@@ -183,14 +185,18 @@ public class SparkPositionDeletesRewrite implements Write {
 
     private List<DeleteFile> files(WriterCommitMessage[] messages) {
       List<DeleteFile> files = Lists.newArrayList();
+      // both commit and abort funnel through here, so this is where task write times are collected
+      WriteDurations durations = WriteDurations.EMPTY;
 
       for (WriterCommitMessage message : messages) {
         if (message != null) {
           DeleteTaskCommit taskCommit = (DeleteTaskCommit) message;
           files.addAll(Arrays.asList(taskCommit.files()));
+          durations = durations.combine(taskCommit.writeDurations());
         }
       }
 
+      SparkPositionDeletesRewrite.this.writeDurations = durations;
       return files;
     }
   }
@@ -323,6 +329,7 @@ public class SparkPositionDeletesRewrite implements Write {
    * assumption that all incoming deletes belong to the same partition.
    */
   private static class DeleteWriter implements DataWriter<InternalRow> {
+    private final WriteTimer timer = new WriteTimer();
     private final SparkFileWriterFactory writerFactoryWithRow;
     private final SparkFileWriterFactory writerFactoryWithoutRow;
     private final OutputFileFactory deleteFileFactory;
@@ -387,22 +394,25 @@ public class SparkPositionDeletesRewrite implements Write {
 
     @Override
     public void write(InternalRow record) {
-      String file = record.getString(fileOrdinal);
-      long position = record.getLong(positionOrdinal);
-      InternalRow row = record.getStruct(rowOrdinal, rowSize);
-      if (row != null) {
-        positionDelete.set(file, position, row);
-        lazyWriterWithRow().write(positionDelete, spec, partition);
-      } else {
-        positionDelete.set(file, position, null);
-        lazyWriterWithoutRow().write(positionDelete, spec, partition);
-      }
+      timer.timeWrite(
+          () -> {
+            String file = record.getString(fileOrdinal);
+            long position = record.getLong(positionOrdinal);
+            InternalRow row = record.getStruct(rowOrdinal, rowSize);
+            if (row != null) {
+              positionDelete.set(file, position, row);
+              lazyWriterWithRow().write(positionDelete, spec, partition);
+            } else {
+              positionDelete.set(file, position, null);
+              lazyWriterWithoutRow().write(positionDelete, spec, partition);
+            }
+          });
     }
 
     @Override
     public WriterCommitMessage commit() throws IOException {
       close();
-      return new DeleteTaskCommit(allDeleteFiles());
+      return new DeleteTaskCommit(allDeleteFiles(), timer.writeDurations());
     }
 
     @Override
@@ -414,12 +424,15 @@ public class SparkPositionDeletesRewrite implements Write {
     @Override
     public void close() throws IOException {
       if (!closed) {
-        if (writerWithRow != null) {
-          writerWithRow.close();
-        }
-        if (writerWithoutRow != null) {
-          writerWithoutRow.close();
-        }
+        timer.timeClose(
+            () -> {
+              if (writerWithRow != null) {
+                writerWithRow.close();
+              }
+              if (writerWithoutRow != null) {
+                writerWithoutRow.close();
+              }
+            });
         this.closed = true;
       }
     }
@@ -461,6 +474,7 @@ public class SparkPositionDeletesRewrite implements Write {
    * supports DVs.
    */
   private static class DVWriter implements DataWriter<InternalRow> {
+    private final WriteTimer timer = new WriteTimer();
     private final PositionDelete<InternalRow> positionDelete;
     private final FileIO io;
     private final PartitionSpec spec;
@@ -498,16 +512,19 @@ public class SparkPositionDeletesRewrite implements Write {
 
     @Override
     public void write(InternalRow record) {
-      String file = record.getString(fileOrdinal);
-      long position = record.getLong(positionOrdinal);
-      positionDelete.set(file, position, null);
-      dvWriter.write(positionDelete, spec, partition);
+      timer.timeWrite(
+          () -> {
+            String file = record.getString(fileOrdinal);
+            long position = record.getLong(positionOrdinal);
+            positionDelete.set(file, position, null);
+            dvWriter.write(positionDelete, spec, partition);
+          });
     }
 
     @Override
     public WriterCommitMessage commit() throws IOException {
       close();
-      return new DeleteTaskCommit(allDeleteFiles());
+      return new DeleteTaskCommit(allDeleteFiles(), timer.writeDurations());
     }
 
     @Override
@@ -519,9 +536,12 @@ public class SparkPositionDeletesRewrite implements Write {
     @Override
     public void close() throws IOException {
       if (!closed) {
-        if (null != dvWriter) {
-          dvWriter.close();
-        }
+        timer.timeClose(
+            () -> {
+              if (null != dvWriter) {
+                dvWriter.close();
+              }
+            });
         this.closed = true;
       }
     }
@@ -533,9 +553,15 @@ public class SparkPositionDeletesRewrite implements Write {
 
   public static class DeleteTaskCommit implements WriterCommitMessage {
     private final DeleteFile[] taskFiles;
+    private final WriteDurations writeDurations;
 
-    DeleteTaskCommit(List<DeleteFile> deleteFiles) {
+    DeleteTaskCommit(List<DeleteFile> deleteFiles, WriteDurations writeDurations) {
       this.taskFiles = deleteFiles.toArray(new DeleteFile[0]);
+      this.writeDurations = writeDurations;
+    }
+
+    WriteDurations writeDurations() {
+      return writeDurations;
     }
 
     DeleteFile[] files() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -74,6 +74,7 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.spark.SparkWriteUtil;
+import org.apache.iceberg.spark.WriteDurations;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.DeleteFileSet;
@@ -124,6 +125,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
   private final Map<String, String> writeProperties;
 
   private boolean cleanupOnAbort = false;
+  private WriteDurations writeDurations = WriteDurations.EMPTY;
   private InMemoryMetricsReporter metricsReporter;
 
   SparkPositionDeltaWrite(
@@ -195,7 +197,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
 
   @Override
   public CustomTaskMetric[] reportDriverMetrics() {
-    return SparkWriteUtil.customTaskMetrics(metricsReporter);
+    return SparkWriteUtil.customTaskMetrics(metricsReporter, writeDurations);
   }
 
   private class PositionDeltaBatchWrite implements DeltaBatchWrite {
@@ -246,9 +248,11 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
       int addedDataFilesCount = 0;
       int addedDeleteFilesCount = 0;
       int removedDeleteFilesCount = 0;
+      WriteDurations durations = WriteDurations.EMPTY;
 
       for (WriterCommitMessage message : messages) {
         DeltaTaskCommit taskCommit = (DeltaTaskCommit) message;
+        durations = durations.combine(taskCommit.writeDurations());
 
         for (DataFile dataFile : taskCommit.dataFiles()) {
           rowDelta.addRows(dataFile);
@@ -267,6 +271,8 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
 
         referencedDataFiles.addAll(Arrays.asList(taskCommit.referencedDataFiles()));
       }
+
+      SparkPositionDeltaWrite.this.writeDurations = durations;
 
       // the scan may be null if the optimizer replaces it with an empty relation
       // no validation is needed in this case as the command is independent of the table state
@@ -381,19 +387,26 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
     private final DeleteFile[] deleteFiles;
     private final DeleteFile[] rewrittenDeleteFiles;
     private final CharSequence[] referencedDataFiles;
+    private final WriteDurations writeDurations;
 
-    DeltaTaskCommit(WriteResult result) {
+    DeltaTaskCommit(WriteResult result, WriteDurations writeDurations) {
       this.dataFiles = result.dataFiles();
       this.deleteFiles = result.deleteFiles();
       this.referencedDataFiles = result.referencedDataFiles();
       this.rewrittenDeleteFiles = result.rewrittenDeleteFiles();
+      this.writeDurations = writeDurations;
     }
 
-    DeltaTaskCommit(DeleteWriteResult result) {
+    DeltaTaskCommit(DeleteWriteResult result, WriteDurations writeDurations) {
       this.dataFiles = new DataFile[0];
       this.deleteFiles = result.deleteFiles().toArray(new DeleteFile[0]);
       this.referencedDataFiles = result.referencedDataFiles().toArray(new CharSequence[0]);
       this.rewrittenDeleteFiles = result.rewrittenDeleteFiles().toArray(new DeleteFile[0]);
+      this.writeDurations = writeDurations;
+    }
+
+    WriteDurations writeDurations() {
+      return writeDurations;
     }
 
     DataFile[] dataFiles() {
@@ -495,6 +508,11 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
   }
 
   private abstract static class BaseDeltaWriter implements DeltaWriter<InternalRow> {
+    private final WriteTimer timer = new WriteTimer();
+
+    protected WriteTimer timer() {
+      return timer;
+    }
 
     protected InternalRowWrapper initPartitionRowWrapper(Types.StructType partitionType) {
       StructType sparkPartitionType = (StructType) SparkSchemaUtil.convert(partitionType);
@@ -640,7 +658,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
       String file = id.getString(fileOrdinal);
       long position = id.getLong(positionOrdinal);
       positionDelete.set(file, position);
-      delegate.write(positionDelete, spec, partitionProjection);
+      timer().timeWrite(() -> delegate.write(positionDelete, spec, partitionProjection));
     }
 
     @Override
@@ -660,7 +678,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
       close();
 
       DeleteWriteResult result = delegate.result();
-      return new DeltaTaskCommit(result);
+      return new DeltaTaskCommit(result, timer().writeDurations());
     }
 
     @Override
@@ -674,7 +692,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
     @Override
     public void close() throws IOException {
       if (!closed) {
-        delegate.close();
+        timer().timeClose(delegate::close);
         this.closed = true;
       }
     }
@@ -734,7 +752,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
 
       String file = id.getString(fileOrdinal);
       long position = id.getLong(positionOrdinal);
-      delegate.delete(file, position, spec, partitionProjection);
+      timer().timeWrite(() -> delegate.delete(file, position, spec, partitionProjection));
     }
 
     @Override
@@ -742,7 +760,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
       close();
 
       WriteResult result = delegate.result();
-      return new DeltaTaskCommit(result);
+      return new DeltaTaskCommit(result, timer().writeDurations());
     }
 
     @Override
@@ -763,7 +781,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
     @Override
     public void close() throws IOException {
       if (!closed) {
-        delegate.close();
+        timer().timeClose(delegate::close);
         this.closed = true;
       }
     }
@@ -808,7 +826,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
 
     @Override
     public void reinsert(InternalRow meta, InternalRow row) throws IOException {
-      delegate.insert(decorateWithRowLineage(meta, row), dataSpec, null);
+      timer().timeWrite(() -> delegate.insert(decorateWithRowLineage(meta, row), dataSpec, null));
     }
   }
 
@@ -852,8 +870,12 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
 
     @Override
     public void reinsert(InternalRow meta, InternalRow row) throws IOException {
-      dataPartitionKey.partition(internalRowDataWrapper.wrap(row));
-      delegate.insert(decorateWithRowLineage(meta, row), dataSpec, dataPartitionKey);
+      timer()
+          .timeWrite(
+              () -> {
+                dataPartitionKey.partition(internalRowDataWrapper.wrap(row));
+                delegate.insert(decorateWithRowLineage(meta, row), dataSpec, dataPartitionKey);
+              });
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -61,6 +61,7 @@ import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.spark.SparkWriteUtil;
+import org.apache.iceberg.spark.WriteDurations;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.DataFileSet;
 import org.apache.iceberg.util.DeleteFileSet;
@@ -116,6 +117,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
   private boolean cleanupOnAbort = false;
   private InMemoryMetricsReporter metricsReporter;
+  private WriteDurations writeDurations = WriteDurations.EMPTY;
 
   SparkWrite(
       SparkSession spark,
@@ -285,20 +287,24 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
   private DataFileSet files(WriterCommitMessage[] messages) {
     DataFileSet files = DataFileSet.create();
+    // every commit path funnels through here, so this is where task write times are collected
+    WriteDurations durations = WriteDurations.EMPTY;
 
     for (WriterCommitMessage message : messages) {
       if (message != null) {
         TaskCommit taskCommit = (TaskCommit) message;
         files.addAll(Arrays.asList(taskCommit.files()));
+        durations = durations.combine(taskCommit.writeDurations());
       }
     }
 
+    this.writeDurations = durations;
     return files;
   }
 
   @Override
   public CustomTaskMetric[] reportDriverMetrics() {
-    return SparkWriteUtil.customTaskMetrics(metricsReporter);
+    return SparkWriteUtil.customTaskMetrics(metricsReporter, writeDurations);
   }
 
   @Override
@@ -674,9 +680,19 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
   public static class TaskCommit implements WriterCommitMessage {
     private final DataFile[] taskFiles;
+    private final WriteDurations writeDurations;
 
     TaskCommit(DataFile[] taskFiles) {
+      this(taskFiles, WriteDurations.EMPTY);
+    }
+
+    TaskCommit(DataFile[] taskFiles, WriteDurations writeDurations) {
       this.taskFiles = taskFiles;
+      this.writeDurations = writeDurations;
+    }
+
+    WriteDurations writeDurations() {
+      return writeDurations;
     }
 
     // Reports bytesWritten and recordsWritten to the Spark output metrics.
@@ -807,7 +823,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     public void write(InternalRow meta, InternalRow record) throws IOException {
-      delegate.write(decorateWithRowLineage(meta, record));
+      timer().timeWrite(() -> delegate.write(decorateWithRowLineage(meta, record)));
     }
 
     @Override
@@ -815,7 +831,8 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
       close();
 
       DataWriteResult result = delegate.result();
-      TaskCommit taskCommit = new TaskCommit(result.dataFiles().toArray(new DataFile[0]));
+      TaskCommit taskCommit =
+          new TaskCommit(result.dataFiles().toArray(new DataFile[0]), timer().writeDurations());
       taskCommit.reportOutputMetrics();
       return taskCommit;
     }
@@ -830,7 +847,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     public void close() throws IOException {
-      delegate.close();
+      timer().timeClose(delegate::close);
     }
   }
 
@@ -870,8 +887,12 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     public void write(InternalRow meta, InternalRow record) throws IOException {
-      partitionKey.partition(internalRowWrapper.wrap(record));
-      delegate.write(decorateWithRowLineage(meta, record), spec, partitionKey);
+      timer()
+          .timeWrite(
+              () -> {
+                partitionKey.partition(internalRowWrapper.wrap(record));
+                delegate.write(decorateWithRowLineage(meta, record), spec, partitionKey);
+              });
     }
 
     @Override
@@ -879,7 +900,8 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
       close();
 
       DataWriteResult result = delegate.result();
-      TaskCommit taskCommit = new TaskCommit(result.dataFiles().toArray(new DataFile[0]));
+      TaskCommit taskCommit =
+          new TaskCommit(result.dataFiles().toArray(new DataFile[0]), timer().writeDurations());
       taskCommit.reportOutputMetrics();
       return taskCommit;
     }
@@ -894,17 +916,22 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     public void close() throws IOException {
-      delegate.close();
+      timer().timeClose(delegate::close);
     }
   }
 
   private abstract static class DataWriterWithLineage<T> implements DataWriter<T> {
+    private final WriteTimer timer = new WriteTimer();
     private final Function<InternalRow, InternalRow> rowLineageExtractor;
 
     DataWriterWithLineage(Function<InternalRow, InternalRow> rowLineageExtractor) {
       Preconditions.checkArgument(
           rowLineageExtractor != null, "Row lineage extractor cannot be null");
       this.rowLineageExtractor = rowLineageExtractor;
+    }
+
+    protected WriteTimer timer() {
+      return timer;
     }
 
     protected InternalRow decorateWithRowLineage(InternalRow meta, InternalRow record) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/WriteTimer.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/WriteTimer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.spark.WriteDurations;
+
+/**
+ * Accumulates the wall time a write task spends producing files.
+ *
+ * <p>Times are split into the row-level write calls and the final close, which flushes buffered
+ * rows and finishes the files. Both are timed per call rather than per row: a nanoTime pair per row
+ * would cost more than the work it measures.
+ */
+class WriteTimer {
+  private long writeNanos = 0L;
+  private long closeNanos = 0L;
+
+  /** Runs the row-level write, adding its duration to the write time. */
+  <E extends Exception> void timeWrite(ThrowingRunnable<E> writeOp) throws E {
+    long start = System.nanoTime();
+    try {
+      writeOp.run();
+    } finally {
+      this.writeNanos += System.nanoTime() - start;
+    }
+  }
+
+  /** Runs the close, adding its duration to the close time. */
+  <E extends Exception> void timeClose(ThrowingRunnable<E> closeOp) throws E {
+    long start = System.nanoTime();
+    try {
+      closeOp.run();
+    } finally {
+      this.closeNanos += System.nanoTime() - start;
+    }
+  }
+
+  WriteDurations writeDurations() {
+    return WriteDurations.of(writeNanos, closeNanos);
+  }
+
+  long writeNanos() {
+    return writeNanos;
+  }
+
+  long closeNanos() {
+    return closeNanos;
+  }
+
+  @FunctionalInterface
+  interface ThrowingRunnable<E extends Exception> {
+    void run() throws E;
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.spark.sql.connector.metric.CustomSumMetric;
+
+/** Base class for metrics that sum nanosecond durations reported by tasks. */
+abstract class NanoDurationMetric extends CustomSumMetric {
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long totalNanos = 0L;
+    for (long taskMetric : taskMetrics) {
+      totalNanos += taskMetric;
+    }
+
+    // raw nanos are unreadable on the UI, scale to the largest meaningful unit
+    if (totalNanos < TimeUnit.MICROSECONDS.toNanos(1)) {
+      return totalNanos + " ns";
+    } else if (totalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMicros(totalNanos) + " us";
+    } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
+    } else {
+      return String.format("%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.source.metrics;
 
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import org.apache.spark.sql.connector.metric.CustomSumMetric;
 
@@ -39,7 +40,8 @@ abstract class NanoDurationMetric extends CustomSumMetric {
     } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
       return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
     } else {
-      return String.format("%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+      return String.format(
+          Locale.ROOT, "%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NanoDurationMetric.java
@@ -18,30 +18,50 @@
  */
 package org.apache.iceberg.spark.source.metrics;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import org.apache.spark.sql.connector.metric.CustomSumMetric;
 
-/** Base class for metrics that sum nanosecond durations reported by tasks. */
+/** Base class for metrics that report nanosecond durations accumulated by tasks. */
 abstract class NanoDurationMetric extends CustomSumMetric {
 
   @Override
   public String aggregateTaskMetrics(long[] taskMetrics) {
+    if (taskMetrics.length == 0) {
+      return format(0L);
+    }
+
     long totalNanos = 0L;
     for (long taskMetric : taskMetrics) {
       totalNanos += taskMetric;
     }
 
+    // sort a copy: Spark reuses the array it hands us
+    long[] sorted = Arrays.copyOf(taskMetrics, taskMetrics.length);
+    Arrays.sort(sorted);
+
+    // mirrors MetricUtils.stringValue for Spark's own timing metrics, so a straggler task is
+    // visible instead of being hidden by the total
+    return String.format(
+        Locale.ROOT,
+        "total (min, med, max)\n%s (%s, %s, %s)",
+        format(totalNanos),
+        format(sorted[0]),
+        format(sorted[sorted.length / 2]),
+        format(sorted[sorted.length - 1]));
+  }
+
+  private String format(long nanos) {
     // raw nanos are unreadable on the UI, scale to the largest meaningful unit
-    if (totalNanos < TimeUnit.MICROSECONDS.toNanos(1)) {
-      return totalNanos + " ns";
-    } else if (totalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {
-      return TimeUnit.NANOSECONDS.toMicros(totalNanos) + " us";
-    } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
-      return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
+    if (nanos < TimeUnit.MICROSECONDS.toNanos(1)) {
+      return nanos + " ns";
+    } else if (nanos < TimeUnit.MILLISECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMicros(nanos) + " us";
+    } else if (nanos < TimeUnit.SECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMillis(nanos) + " ms";
     } else {
-      return String.format(
-          Locale.ROOT, "%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+      return String.format(Locale.ROOT, "%.1f s", nanos / (double) TimeUnit.SECONDS.toNanos(1));
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/WriteCloseDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/WriteCloseDuration.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+public class WriteCloseDuration extends NanoDurationMetric {
+
+  public static final String NAME = "writeCloseDuration";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public String description() {
+    return "total write close duration";
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/WriteDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/WriteDuration.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+public class WriteDuration extends NanoDurationMetric {
+
+  public static final String NAME = "writeDuration";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public String description() {
+    return "total write duration";
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriteMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriteMetrics.java
@@ -45,6 +45,8 @@ import org.apache.iceberg.spark.source.metrics.TotalEqualityDeletes;
 import org.apache.iceberg.spark.source.metrics.TotalFileSizeInBytes;
 import org.apache.iceberg.spark.source.metrics.TotalPositionalDeletes;
 import org.apache.iceberg.spark.source.metrics.TotalRecords;
+import org.apache.iceberg.spark.source.metrics.WriteCloseDuration;
+import org.apache.iceberg.spark.source.metrics.WriteDuration;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -194,6 +196,133 @@ public class TestSparkWriteMetrics extends TestBaseWithCatalog {
       assertThat(metricsMap)
           .hasEntrySatisfying(metric, m -> assertThat(m.value()).as(metric).isEqualTo(0));
     }
+  }
+
+  @TestTemplate
+  public void writeDurationForUnpartitionedTable() {
+    sql("CREATE TABLE %s (id BIGINT) USING iceberg", tableName);
+
+    Dataset<Row> result =
+        spark.sql(String.format("INSERT INTO %s SELECT id FROM range(1000)", tableName));
+    result.collect();
+
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationForPartitionedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING) USING iceberg PARTITIONED BY (data)", tableName);
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "INSERT INTO %s SELECT id, CAST(id %% 4 AS STRING) FROM range(1000)", tableName));
+    result.collect();
+
+    // exercises PartitionedDataWriter rather than UnpartitionedDataWriter
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationForCopyOnWriteDelete() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('write.delete.mode'='copy-on-write')",
+        tableName);
+    spark.range(100).coalesce(1).writeTo(tableName).append();
+
+    Dataset<Row> result = spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+    result.collect();
+
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationForMergeOnReadDelete() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('write.delete.mode'='merge-on-read')",
+        tableName);
+    spark.range(100).coalesce(1).writeTo(tableName).append();
+
+    // DeleteOnlyDeltaWriter in SparkPositionDeltaWrite
+    Dataset<Row> result = spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+    result.collect();
+
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationForMergeOnReadUpdate() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('write.update.mode'='merge-on-read')",
+        tableName);
+    spark.range(100).coalesce(1).writeTo(tableName).append();
+
+    // UnpartitionedDeltaWriter: an update writes both deletes and data
+    Dataset<Row> result =
+        spark.sql(String.format("UPDATE %s SET id = id + 1000 WHERE id < 10", tableName));
+    result.collect();
+
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationForPartitionedMergeOnReadUpdate() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING) USING iceberg PARTITIONED BY (data) "
+            + "TBLPROPERTIES ('write.update.mode'='merge-on-read')",
+        tableName);
+    sql("INSERT INTO %s SELECT id, CAST(id %% 4 AS STRING) FROM range(100)", tableName);
+
+    // PartitionedDeltaWriter
+    Dataset<Row> result =
+        spark.sql(String.format("UPDATE %s SET id = id + 1000 WHERE id < 10", tableName));
+    result.collect();
+
+    assertWriteDurationsReported(result.queryExecution().executedPlan());
+  }
+
+  @TestTemplate
+  public void writeDurationAggregatesAcrossTasks() {
+    sql("CREATE TABLE %s (id BIGINT) USING iceberg", tableName);
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "INSERT INTO %s SELECT /*+ REPARTITION(4) */ id FROM range(2000)", tableName));
+    result.collect();
+
+    Map<String, SQLMetric> metricsMap = writeMetrics(result.queryExecution().executedPlan());
+
+    // four tasks each wrote a file, so the reported durations are sums over all four
+    assertThat(metricsMap)
+        .hasEntrySatisfying(AddedDataFiles.NAME, metric -> assertThat(metric.value()).isEqualTo(4));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            WriteDuration.NAME, metric -> assertThat(metric.value()).isGreaterThan(0));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            WriteCloseDuration.NAME, metric -> assertThat(metric.value()).isGreaterThan(0));
+  }
+
+  private void assertWriteDurationsReported(SparkPlan plan) {
+    Map<String, SQLMetric> metricsMap = writeMetrics(plan);
+
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            WriteDuration.NAME, metric -> assertThat(metric.value()).isGreaterThan(0));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            WriteCloseDuration.NAME, metric -> assertThat(metric.value()).isGreaterThan(0));
+  }
+
+  private Map<String, SQLMetric> writeMetrics(SparkPlan plan) {
+    Map<String, SQLMetric> metricsMap = CollectionConverters.asJava(plan.metrics());
+    if (!metricsMap.containsKey(WriteDuration.NAME)) {
+      metricsMap = findMetrics(plan, WriteDuration.NAME);
+    }
+
+    assertThat(metricsMap).as("write metrics not found in plan").isNotNull();
+    return metricsMap;
   }
 
   private Map<String, SQLMetric> findMetrics(SparkPlan plan, String metricName) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteTimer.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteTimer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import org.apache.iceberg.spark.WriteDurations;
+import org.junit.jupiter.api.Test;
+
+public class TestWriteTimer {
+
+  @Test
+  public void testAccumulatesWriteAndCloseSeparately() {
+    WriteTimer timer = new WriteTimer();
+
+    timer.timeWrite(() -> busyWait());
+    long afterFirstWrite = timer.writeNanos();
+    assertThat(afterFirstWrite).isGreaterThan(0);
+    assertThat(timer.closeNanos()).isEqualTo(0);
+
+    timer.timeWrite(() -> busyWait());
+    assertThat(timer.writeNanos()).isGreaterThan(afterFirstWrite);
+    assertThat(timer.closeNanos()).isEqualTo(0);
+
+    timer.timeClose(() -> busyWait());
+    assertThat(timer.closeNanos()).isGreaterThan(0);
+  }
+
+  @Test
+  public void testRecordsTimeWhenOperationThrows() {
+    WriteTimer timer = new WriteTimer();
+
+    assertThatThrownBy(
+            () ->
+                timer.timeWrite(
+                    () -> {
+                      busyWait();
+                      throw new IOException("write failed");
+                    }))
+        .isInstanceOf(IOException.class)
+        .hasMessage("write failed");
+
+    // a task that fails mid-write still reports what it wrote
+    assertThat(timer.writeNanos()).isGreaterThan(0);
+  }
+
+  @Test
+  public void testWriteDurations() {
+    WriteTimer timer = new WriteTimer();
+    timer.timeWrite(() -> busyWait());
+    timer.timeClose(() -> busyWait());
+
+    WriteDurations durations = timer.writeDurations();
+    assertThat(durations.writeNanos()).isEqualTo(timer.writeNanos());
+    assertThat(durations.closeNanos()).isEqualTo(timer.closeNanos());
+  }
+
+  @Test
+  public void testCombine() {
+    WriteDurations combined =
+        WriteDurations.of(10L, 20L)
+            .combine(WriteDurations.of(3L, 4L))
+            .combine(WriteDurations.EMPTY);
+
+    assertThat(combined.writeNanos()).isEqualTo(13L);
+    assertThat(combined.closeNanos()).isEqualTo(24L);
+  }
+
+  private static void busyWait() {
+    long start = System.nanoTime();
+    while (System.nanoTime() - start < 1_000L) {
+      // spin so the timer observes a non-zero duration
+    }
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.junit.jupiter.api.Test;
+
+public class TestNanoDurationMetric {
+
+  private final CustomSumMetric metric = new WriteDuration();
+
+  @Test
+  public void testFormatsLargestMeaningfulUnit() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
+    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L})).isEqualTo("700 ns");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L})).isEqualTo("4 us");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L})).isEqualTo("1 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500_000_000L, 1_000_000_000L}))
+        .isEqualTo("2.5 s");
+  }
+
+  @Test
+  public void testUnitBoundaries() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {999L})).isEqualTo("999 ns");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000L})).isEqualTo("1 us");
+    assertThat(metric.aggregateTaskMetrics(new long[] {999_999L})).isEqualTo("999 us");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L})).isEqualTo("1 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {999_999_999L})).isEqualTo("999 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000_000L})).isEqualTo("1.0 s");
+  }
+
+  @Test
+  public void testMetricNames() {
+    assertThat(new WriteDuration().name()).isEqualTo("writeDuration");
+    assertThat(new WriteCloseDuration().name()).isEqualTo("writeCloseDuration");
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Locale;
 import org.apache.spark.sql.connector.metric.CustomSumMetric;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,18 @@ public class TestNanoDurationMetric {
     assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L})).isEqualTo("1 ms");
     assertThat(metric.aggregateTaskMetrics(new long[] {999_999_999L})).isEqualTo("999 ms");
     assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000_000L})).isEqualTo("1.0 s");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsIsLocaleIndependent() {
+    Locale previous = Locale.getDefault();
+    try {
+      // a comma-decimal locale would render "2,5 s" without an explicit Locale.ROOT
+      Locale.setDefault(Locale.GERMANY);
+      assertThat(metric.aggregateTaskMetrics(new long[] {2_500_000_000L})).isEqualTo("2.5 s");
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestNanoDurationMetric.java
@@ -30,22 +30,43 @@ public class TestNanoDurationMetric {
 
   @Test
   public void testFormatsLargestMeaningfulUnit() {
-    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
-    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L})).isEqualTo("700 ns");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L})).isEqualTo("4 us");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L})).isEqualTo("1 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L}))
+        .isEqualTo("total (min, med, max)\n700 ns (300 ns, 400 ns, 400 ns)");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L}))
+        .isEqualTo("total (min, med, max)\n4 us (1 us, 2 us, 2 us)");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L}))
+        .isEqualTo("total (min, med, max)\n1 ms (500 us, 1 ms, 1 ms)");
     assertThat(metric.aggregateTaskMetrics(new long[] {1_500_000_000L, 1_000_000_000L}))
-        .isEqualTo("2.5 s");
+        .isEqualTo("total (min, med, max)\n2.5 s (1.0 s, 1.5 s, 1.5 s)");
   }
 
   @Test
   public void testUnitBoundaries() {
-    assertThat(metric.aggregateTaskMetrics(new long[] {999L})).isEqualTo("999 ns");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_000L})).isEqualTo("1 us");
-    assertThat(metric.aggregateTaskMetrics(new long[] {999_999L})).isEqualTo("999 us");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L})).isEqualTo("1 ms");
-    assertThat(metric.aggregateTaskMetrics(new long[] {999_999_999L})).isEqualTo("999 ms");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000_000L})).isEqualTo("1.0 s");
+    assertThat(total(999L)).isEqualTo("999 ns");
+    assertThat(total(1_000L)).isEqualTo("1 us");
+    assertThat(total(999_999L)).isEqualTo("999 us");
+    assertThat(total(1_000_000L)).isEqualTo("1 ms");
+    assertThat(total(999_999_999L)).isEqualTo("999 ms");
+    assertThat(total(1_000_000_000L)).isEqualTo("1.0 s");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsWithNoTasks() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsSurfacesStragglers() {
+    // the total alone would hide that one task took the bulk of the time
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 1_000_000L, 8_000_000L}))
+        .isEqualTo("total (min, med, max)\n10 ms (1 ms, 1 ms, 8 ms)");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsDoesNotMutateInput() {
+    long[] taskMetrics = new long[] {3_000_000L, 1_000_000L, 2_000_000L};
+    metric.aggregateTaskMetrics(taskMetrics);
+    assertThat(taskMetrics).containsExactly(3_000_000L, 1_000_000L, 2_000_000L);
   }
 
   @Test
@@ -54,7 +75,8 @@ public class TestNanoDurationMetric {
     try {
       // a comma-decimal locale would render "2,5 s" without an explicit Locale.ROOT
       Locale.setDefault(Locale.GERMANY);
-      assertThat(metric.aggregateTaskMetrics(new long[] {2_500_000_000L})).isEqualTo("2.5 s");
+      assertThat(metric.aggregateTaskMetrics(new long[] {2_500_000_000L}))
+          .isEqualTo("total (min, med, max)\n2.5 s (2.5 s, 2.5 s, 2.5 s)");
     } finally {
       Locale.setDefault(previous);
     }
@@ -64,5 +86,11 @@ public class TestNanoDurationMetric {
   public void testMetricNames() {
     assertThat(new WriteDuration().name()).isEqualTo("writeDuration");
     assertThat(new WriteCloseDuration().name()).isEqualTo("writeCloseDuration");
+  }
+
+  private String total(long nanos) {
+    String line = metric.aggregateTaskMetrics(new long[] {nanos});
+    line = line.substring(line.indexOf('\n') + 1);
+    return line.substring(0, line.indexOf(" ("));
   }
 }


### PR DESCRIPTION
## Summary

- Iceberg reports write counts and sizes per commit, but has no timer for how long tasks spent writing, so write throughput can't be derived from Iceberg metrics alone.

## Changes

- Add `writeDuration` (time in row-level write calls) and `writeCloseDuration` (time closing writers, where buffered rows flush and files are finished). Nanoseconds.
- Both travel to the driver in the commit messages. Spark calls `currentMetricsValues()` before `commit()`, so the close, which happens inside `commit()`, can't be a `CustomTaskMetric`.
- Aggregate renders as `total (min, med, max)`, matching `MetricUtils.stringValue` and `scanDuration` in #17562.
- Covers all three write families: `SparkWrite` (append, overwrite, copy-on-write, streaming), `SparkPositionDeltaWrite` (merge-on-read), and `SparkPositionDeletesRewrite` (`DeleteWriter` and `DVWriter`).

## Testing done

- `TestSparkWriteMetrics` (7): unpartitioned and partitioned inserts, copy-on-write delete, merge-on-read delete and update, multi-task aggregation.
- `TestRewritePositionDeleteFilesMetrics`: rewrite path for v2 (`DeleteWriter`) and v3 (`DVWriter`).
- `TestWriteTimer` and `TestNanoDurationMetric`: phase accumulation, timing on throw, rendering, locale independence.
- Assertions discriminate: disabling either timer fails 7 of 9 tests in `TestSparkWriteMetrics`.
- Regression sweep over copy-on-write and merge-on-read deletes/updates, position deletes, streaming reads, and DataFrame writes: 0 failures. `spotlessCheck` and `checkstyle` pass.

## Notes

- Scoped to `spark/v4.1`. v4.0 is near-identical and can follow.
- v3.5 has no write custom metrics wired at all, so it would need the driver-metrics plumbing backported first.
