### PR TITLE
Spec: v4 constraints

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -691,6 +691,8 @@ The fields that define what a constraint requires are embedded directly in the c
 
 The `field-ids` of a `unique` or `primary-key` constraint must reference primitive fields that are either top-level fields or nested in required structs, and must not reference fields within a `list` or a `map`. These are the same restrictions that apply to [identifier fields](#identifier-field-ids).
 
+A field referenced by a constraint must not be dropped. A writer must reject a schema change that removes a field referenced by a `check` constraint's `expression` or by a `unique` or `primary-key` constraint's `field-ids` unless the constraint is removed in the same change.
+
 When a constraint is `enforced`, writers must verify that the rows they add satisfy the constraint and must fail the write if they do not. A writer that cannot verify an enforced constraint must reject writes to the table rather than add rows that have not been verified. When a constraint is not enforced, writers are not required to verify the rows they add.
 
 Whether to trust a constraint that is not enforced is left to engines and is not tracked in table metadata.
@@ -707,7 +709,7 @@ Constraint IDs are assigned from the table's `last-constraint-id`, which is trea
 
 The `expression` of a `check` constraint is serialized as described in the [Iceberg expressions spec](expressions-spec.md) and must use ID references so that it remains bound to the same fields when columns are renamed or reordered.
 
-A check expression must be a deterministic predicate over a single row. Expressions that depend on more than one row, such as aggregates and window functions, and expressions that depend on another table, such as subqueries, must not be used.
+A check expression is evaluated for each row over the values of that row. Expressions that depend on more than one row, such as aggregates and window functions, and expressions that depend on another table, such as subqueries, must not be used.
 
 Iceberg predicates use two-valued logic: a predicate always produces true or false and never produces null, so a comparison with a null operand produces false. This differs from SQL `CHECK`, where a row satisfies a constraint unless the predicate produces false and a null value therefore satisfies the constraint.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -62,6 +62,7 @@ The full set of changes are listed in [Appendix E](#version-3).
 Version 4 of the Iceberg spec restructures metadata for improved performance and new capabilities:
 
 * Support for [relative locations](#file-locations-in-metadata) in metadata fields
+* Support for table [constraints](#constraints)
 
 The full set of changes are listed in [Appendix E](#version-4).
 
@@ -654,6 +655,106 @@ Sorting floating-point numbers should produce the following behavior: `-NaN` < `
 
 A data or delete file is associated with a sort order by the sort order's id within [a manifest](#manifests). Therefore, the table must declare all the sort orders for lookup. A table could also be configured with a default sort order id, indicating how the new data should be sorted by default. Writers should use this default sort order to sort the data on write, but are not required to if the default order is prohibitively expensive, as it would be for streaming writes.
 
+### Constraints
+
+A **constraint** declares a property that a table's rows are expected to satisfy. A constraint's definition is stored in table metadata. Whether a constraint holds is recorded for each snapshot, see [Constraint Validation](#constraint-validation).
+
+Iceberg does not evaluate constraints. Enforcement and validation are performed by engines that write to a table. Iceberg stores constraint definitions and records the status that a writer reports for a commit without verifying it.
+
+Constraints are added in v4 and are not supported in v3 or earlier.
+
+Three constraint types are defined:
+
+* `check` -- every row must satisfy a predicate
+* `unique` -- the values of a set of fields must be distinct across all rows
+* `primary-key` -- the values of a set of fields must be distinct across all rows and must not be null
+
+Constraints are stored separately from schemas because a constraint may reference more than one field and because constraints and schemas evolve independently. Every constraint references the fields that it applies to by field ID, so a constraint continues to apply to the same columns after a column is renamed or reordered.
+
+A required field in a schema expresses `NOT NULL`. It is not represented as a constraint.
+
+#### Constraint Fields
+
+A constraint consists of the following fields:
+
+| Requirement | Field name                | Type      | Description |
+|-------------|---------------------------|-----------|-------------|
+| _required_ | **`constraint-id`**       | `int`     | ID of the constraint; unique within the table |
+| _required_ | **`type`**                | `string`  | The constraint type: `check`, `unique`, or `primary-key` |
+| _required_ | **`name`**                | `string`  | A name for the constraint that is unique within the table. Names are for human consumption and must not be used to identify a constraint in metadata |
+| _required_ | **`enforced`**            | `boolean` | Whether writers must verify that the rows they add satisfy the constraint |
+| _required_ | **`timestamp-ms`**        | `long`    | Timestamp in milliseconds from the unix epoch when the constraint was created or last modified |
+| _required_ | **`constraint-metadata`** | `struct`  | Defines what the constraint requires; its fields depend on the constraint `type` (see below) |
+
+`constraint-metadata` for a `check` constraint consists of:
+
+| Requirement | Field name       | Type         | Description |
+|-------------|------------------|--------------|-------------|
+| _required_ | **`expression`** | `expression` | A predicate that every row must satisfy, see [Check Constraint Expressions](#check-constraint-expressions) |
+
+`constraint-metadata` for a `unique` or `primary-key` constraint consists of:
+
+| Requirement | Field name      | Type        | Description |
+|-------------|-----------------|-------------|-------------|
+| _required_ | **`field-ids`** | `list<int>` | A list of field IDs that the constraint applies to |
+
+Each type carries only the metadata that it requires: a `check` constraint must not declare `field-ids` and a `unique` or `primary-key` constraint must not declare an `expression`. This keeps a single source of truth for the fields that a constraint references.
+
+The `field-ids` of a `unique` or `primary-key` constraint must reference primitive fields that are either top-level fields or nested in required structs, and must not reference fields within a `list` or a `map`. These are the same restrictions that apply to [identifier fields](#identifier-field-ids).
+
+When a constraint is `enforced`, writers must verify that the rows they add satisfy the constraint and must fail the write if they do not. A writer that cannot verify an enforced constraint must reject writes to the table rather than add rows that have not been verified. When a constraint is not enforced, writers are not required to verify the rows they add.
+
+Whether to trust a constraint that is not enforced is left to engines and is not tracked in table metadata.
+
+Constraint IDs are assigned from the table's `last-constraint-id`, which is treated as 0 when it is not present. Writers must assign a new constraint an ID that is higher than the table's current `last-constraint-id` and must update `last-constraint-id` to the highest assigned ID. Constraint IDs must not be reused after the constraint that used an ID is removed, because retained snapshots may still reference the removed ID. Readers must not assume that every `constraint-id` referenced by a snapshot is present in `constraints`.
+
+#### Check Constraint Expressions
+
+The `expression` of a `check` constraint is serialized as described in the [Iceberg expressions spec](expressions-spec.md) and must use ID references so that it remains bound to the same fields when columns are renamed or reordered.
+
+A check expression must be a deterministic predicate over a single row. Expressions that depend on more than one row, such as aggregates and window functions, and expressions that depend on another table, such as subqueries, must not be used.
+
+Iceberg predicates use two-valued logic: a predicate always produces true or false and never produces null, so a comparison with a null operand produces false. This differs from SQL `CHECK`, where a row satisfies a constraint unless the predicate produces false and a null value therefore satisfies the constraint.
+
+To express SQL `CHECK` semantics for an optional field, the stored expression must make the null case explicit. For example, SQL `CHECK (price >= 0)` for an optional `price` field is stored as the expression for `price >= 0 OR price IS NULL`. This is unnecessary for required fields, which can never be null.
+
+#### Constraint Validation
+
+Enforcement and validation are separate properties. Whether writers must verify the rows that they add is a property of a constraint, tracked by `enforced`. Whether a table is known to satisfy a constraint is a property of a table's data, tracked per snapshot by `constraint-statuses`.
+
+A snapshot's `constraint-statuses` records the status of each constraint that was active when the snapshot was created. Each entry consists of:
+
+| Requirement | Field name          | Type     | Description |
+|-------------|---------------------|----------|-------------|
+| _required_ | **`constraint-id`** | `int`    | ID of the constraint that the status describes |
+| _required_ | **`status`**        | `string` | The status of the constraint for this snapshot |
+
+A status is one of:
+
+| Status        | Description |
+|---------------|-------------|
+| `validated`   | The constraint was checked and holds for all rows in the snapshot |
+| `valid`       | The constraint holds for all rows in the snapshot because it was enforced for the commit that produced the snapshot and the parent snapshot's status is `validated` or `valid` |
+| `invalid`     | The constraint was checked and at least one row in the snapshot violates it |
+| `unvalidated` | Whether the constraint holds for all rows in the snapshot is not known |
+
+A constraint that is not present in a snapshot's `constraint-statuses` was not active when the snapshot was created, and the snapshot makes no claim about it. This is the case for snapshots created before the constraint was added and for snapshots created after it was dropped.
+
+Writers must record a status for every constraint that is active when a snapshot is created:
+
+* `validated` must not be recorded unless the constraint was checked for every row in the snapshot
+* `valid` must not be recorded unless the constraint was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`
+* `invalid` must not be recorded unless a row in the snapshot is known to violate the constraint
+* `unvalidated` must be recorded when no other status can be recorded
+
+Enforcing a constraint for a commit is not sufficient to record `valid`. When the parent snapshot's status is not `validated` or `valid`, rows added by earlier commits were never checked, so the status is `unvalidated` even though the writer verified the rows that it added.
+
+When a constraint becomes enforced, either by being added with `enforced` set to true or by `enforced` changing from false to true, writers should validate the table and record `validated`. A writer that does not validate records `unvalidated`, and the constraint remains `unvalidated` until a later validation records `validated`.
+
+Only `validated` and `valid` state that a constraint holds. They are distinguished so that readers can tell whether that conclusion was reached by checking data or by relying on writers to enforce the constraint, and so that the most recent `validated` snapshot can be found if a constraint is later found to be `invalid`.
+
+Writers may commit to a table where a constraint is `invalid`. An enforced constraint requires that a writer not add rows that violate the constraint; it does not require a writer to repair existing violations. Returning a constraint to `validated` is a separate operation.
+
 ### Manifests
 
 A manifest is an immutable Avro file that lists data files or delete files, along with each file’s partition data tuple, metrics, and tracking information. One or more manifest files are used to store a [snapshot](#snapshots), which tracks all of the files in a table at some point in time. Manifests are tracked by a [manifest list](#manifest-lists) for each table snapshot.
@@ -962,6 +1063,20 @@ A snapshot consists of the following fields:
     |            |            | _required_ | **`first-row-id`**           | The first `_row_id` assigned to the first row in the first data file in the first manifest, see [Row Lineage](#row-lineage) |
     |            |            | _required_ | **`added-rows`**             | The upper bound of the number of rows with assigned row IDs, see [Row Lineage](#row-lineage) |
     |            |            | _optional_ | **`key-id`**                 | ID of the encryption key that encrypts the manifest list key metadata |
+=== "v4"
+    | v4         | Field                        | Description |
+    |------------|------------------------------|-------------|
+    | _required_ | **`snapshot-id`**            | A unique long ID |
+    | _optional_ | **`parent-snapshot-id`**     | The snapshot ID of the snapshot's parent. Omitted for any snapshot with no parent |
+    | _required_ | **`sequence-number`**        | A monotonically increasing long that tracks the order of changes to a table |
+    | _required_ | **`timestamp-ms`**           | A timestamp when the snapshot was created, used for garbage collection and table inspection |
+    | _required_ | **`manifest-list`**          | The location of a manifest list for this snapshot that tracks manifest files with additional metadata |
+    | _required_ | **`summary`**                | A string map that summarizes the snapshot changes, including `operation` as a _required_ field (see below) |
+    | _optional_ | **`schema-id`**              | ID of the table's current schema when the snapshot was created |
+    | _required_ | **`first-row-id`**           | The first `_row_id` assigned to the first row in the first data file in the first manifest, see [Row Lineage](#row-lineage) |
+    | _required_ | **`added-rows`**             | The upper bound of the number of rows with assigned row IDs, see [Row Lineage](#row-lineage) |
+    | _optional_ | **`key-id`**                 | ID of the encryption key that encrypts the manifest list key metadata |
+    | _optional_ | **`constraint-statuses`**    | A list (optional) of constraint statuses for the snapshot, see [Constraint Validation](#constraint-validation) |
 
 The snapshot summary's `operation` field is used by some operations, like snapshot expiration, to skip processing certain snapshots. Possible `operation` values are:
 
@@ -1194,6 +1309,8 @@ Table metadata consists of the following fields:
     | _optional_ | **`partition-statistics`**  | A list (optional) of [partition statistics](#partition-statistics). |
     | _required_ | **`next-row-id`**           | A `long` higher than all assigned row IDs; the next snapshot's `first-row-id`. See [Row Lineage](#row-lineage). |
     | _optional_ | **`encryption-keys`**       | A list (optional) of [encryption keys](#encryption-keys) used for table encryption. |
+    | _optional_ | **`last-constraint-id`**    | An integer; the highest assigned constraint ID for the table. This is used to ensure constraints are always assigned an unused ID. See [Constraints](#constraints). |
+    | _optional_ | **`constraints`**           | A list (optional) of [constraints](#constraints) for the table. |
 
 For serialization details, see Appendix C.
 
@@ -1796,6 +1913,8 @@ A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/
 |**`default-sort-order-id`**|`JSON int`|`0`|
 |**`refs`**|`JSON map with string key and object value:`<br />`{`<br />&nbsp;&nbsp;`"<name>": {`<br />&nbsp;&nbsp;`"snapshot-id": <id>,`<br />&nbsp;&nbsp;`"type": <type>,`<br />&nbsp;&nbsp;`"max-ref-age-ms": <long>,`<br />&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`...`<br />`}`|`{`<br />&nbsp;&nbsp;`"test": {`<br />&nbsp;&nbsp;`"snapshot-id": 123456789000,`<br />&nbsp;&nbsp;`"type": "tag",`<br />&nbsp;&nbsp;`"max-ref-age-ms": 10000000`<br />&nbsp;&nbsp;`}`<br />`}`|
 |**`encryption-keys`**|`JSON list of encryption key objects`|`[ {"key-id": "5f819b", "key-metadata": "aWNlYmVyZwo="} ]`|
+|**`last-constraint-id`**|`JSON int`|`2`|
+|**`constraints`**|`JSON list of objects: [ {`<br />&nbsp;&nbsp;`"constraint-id": <id>,`<br />&nbsp;&nbsp;`"type": <type>,`<br />&nbsp;&nbsp;`"name": "<name>",`<br />&nbsp;&nbsp;`"enforced": <boolean>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"constraint-metadata": { ... }`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"constraint-id": 1,`<br />&nbsp;&nbsp;`"type": "primary-key",`<br />&nbsp;&nbsp;`"name": "pk_sales",`<br />&nbsp;&nbsp;`"enforced": false,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"constraint-metadata": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"field-ids": [1]`<br />&nbsp;&nbsp;`}`<br />`} ]`|
 
 ### Name Mapping Serialization
 
@@ -1912,6 +2031,13 @@ Reading v4 metadata:
 * Readers must check whether location fields contain a URI scheme to determine if a path is absolute or relative
 * Relative paths must be resolved against the table location before use (see [Path Resolution](#path-resolution))
 * When `location` is omitted, the table location must be provided (see [Table Location Specification](#table-location-specification))
+
+Constraints are added in v4:
+
+* [Constraints](#constraints) must not be added to v3 or earlier tables
+* Table metadata may contain `constraints` and `last-constraint-id`
+* Snapshots may contain `constraint-statuses`
+* Upgrading a v2 or v3 table to v4 does not add constraints; a table upgraded to v4 has no constraints until they are added
 
 ### Version 3
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -666,7 +666,7 @@ Constraints are added in v4 and are not supported in v3 or earlier.
 Three constraint types are defined:
 
 * `check` -- every row must satisfy a predicate
-* `unique` -- the values of a set of fields must be distinct across all rows; a null value is not equal to any other null value, so more than one row may be null
+* `unique` -- the non-null values of a set of fields must be distinct across all rows; more than one row may have a null value
 * `primary-key` -- the values of a set of fields must be distinct across all rows and must not be null
 
 Constraints are stored separately from schemas because the two evolve independently. Every constraint references the fields that it applies to by field ID, so a constraint continues to apply to the same columns after a column is renamed or reordered.
@@ -684,27 +684,22 @@ A constraint consists of the following fields:
 | _required_ | **`name`**                | `string`  | A name for the constraint that is unique within the table. Names are for human consumption and must not be used to identify a constraint in metadata |
 | _required_ | **`enforced`**            | `boolean` | Whether writers must verify that the rows they add satisfy the constraint |
 | _required_ | **`timestamp-ms`**        | `long`    | Timestamp in milliseconds from the unix epoch when the constraint was created or last modified. The timestamp is informational and must not be used to determine whether a constraint applies to a snapshot or whether it holds |
-| _required_ | **`constraint-metadata`** | `struct`  | Defines what the constraint requires; its fields depend on the constraint `type` (see below) |
+| _optional_ | **`expression`**          | `expression` | The predicate that every row must satisfy, see [Check Constraint Expressions](#check-constraint-expressions). Required for a `check` constraint and must not be set for other types |
+| _optional_ | **`field-ids`**           | `list<int>`  | The list of field IDs that the constraint applies to. Required for a `unique` or `primary-key` constraint and must not be set for a `check` constraint |
 
-`constraint-metadata` for a `check` constraint consists of:
-
-| Requirement | Field name       | Type         | Description |
-|-------------|------------------|--------------|-------------|
-| _required_ | **`expression`** | `expression` | A predicate that every row must satisfy, see [Check Constraint Expressions](#check-constraint-expressions) |
-
-`constraint-metadata` for a `unique` or `primary-key` constraint consists of:
-
-| Requirement | Field name      | Type        | Description |
-|-------------|-----------------|-------------|-------------|
-| _required_ | **`field-ids`** | `list<int>` | A list of field IDs that the constraint applies to |
-
-Each type carries only the metadata that it requires: a `check` constraint must not declare `field-ids` and a `unique` or `primary-key` constraint must not declare an `expression`. This keeps a single source of truth for the fields that a constraint references.
+The fields that define what a constraint requires are embedded directly in the constraint based on its `type`. Each type carries only the metadata that it requires: a `check` constraint has an `expression` and must not declare `field-ids`, and a `unique` or `primary-key` constraint has `field-ids` and must not declare an `expression`. This keeps a single source of truth for the fields that a constraint references.
 
 The `field-ids` of a `unique` or `primary-key` constraint must reference primitive fields that are either top-level fields or nested in required structs, and must not reference fields within a `list` or a `map`. These are the same restrictions that apply to [identifier fields](#identifier-field-ids).
 
 When a constraint is `enforced`, writers must verify that the rows they add satisfy the constraint and must fail the write if they do not. A writer that cannot verify an enforced constraint must reject writes to the table rather than add rows that have not been verified. When a constraint is not enforced, writers are not required to verify the rows they add.
 
 Whether to trust a constraint that is not enforced is left to engines and is not tracked in table metadata.
+
+A table may have at most one `primary-key` constraint. A key that spans several fields is expressed as a single `primary-key` constraint over multiple `field-ids`.
+
+A `primary-key` constraint replaces [identifier field IDs](#identifier-field-ids), which express the same concept: a set of fields that identifies a row, without a uniqueness guarantee. When a table is upgraded to v4, its `identifier-field-ids` are rewritten as a `primary-key` constraint that is not enforced. Identifier field IDs are not used in v4.
+
+Only a constraint's `name` and `enforced` fields may be changed in place. Changing the `expression` of a `check` constraint or the `field-ids` of a `unique` or `primary-key` constraint changes what the constraint requires, so it must be done by removing the constraint and adding a new one with a new `constraint-id`, so that statuses recorded for the old definition are not read as applying to the new one.
 
 Constraint IDs are assigned from the table's `last-constraint-id`, which is treated as 0 when it is not present. Writers must assign a new constraint an ID that is higher than the table's current `last-constraint-id` and must update `last-constraint-id` to the highest assigned ID. Constraint IDs must not be reused after the constraint that used an ID is removed, because retained snapshots may still reference the removed ID. Readers must not assume that every `constraint-id` referenced by a snapshot is present in `constraints`.
 
@@ -731,42 +726,33 @@ The status of a constraint for a snapshot is one of:
 | `invalid`     | The constraint was checked and at least one row in the snapshot violates it |
 | `unvalidated` | Whether the constraint holds for all rows in the snapshot is not known |
 
-A snapshot's `constraint-statuses` consists of:
+A snapshot's `constraint-statuses` records, for each status, the IDs of the constraints that have that status for the snapshot:
 
-| Requirement | Field name               | Type           | Description |
-|-------------|--------------------------|----------------|-------------|
-| _required_ | **`last-constraint-id`** | `int`          | The table's `last-constraint-id` when the snapshot was created |
-| _required_ | **`default-status`**     | `string`       | The status of every constraint that is not listed in `statuses` |
-| _optional_ | **`statuses`**           | `list<struct>` | Statuses for constraints whose status is not `default-status` |
+| Requirement | Field name        | Type        | Description |
+|-------------|-------------------|-------------|-------------|
+| _optional_ | **`validated`**   | `list<int>` | IDs of constraints that are `validated` for the snapshot |
+| _optional_ | **`valid`**       | `list<int>` | IDs of constraints that are `valid` for the snapshot |
+| _optional_ | **`invalid`**     | `list<int>` | IDs of constraints that are `invalid` for the snapshot |
+| _optional_ | **`unvalidated`** | `list<int>` | IDs of constraints that are `unvalidated` for the snapshot |
 
-Each entry of `statuses` consists of:
+Each list contains the `constraint-id` of every constraint that has that status for the snapshot. A `constraint-id` must appear in at most one list. A list with no constraints may be omitted. A constraint whose ID is not present in any list makes no claim for the snapshot and is treated as `unvalidated`.
 
-| Requirement | Field name          | Type     | Description |
-|-------------|---------------------|----------|-------------|
-| _required_ | **`constraint-id`** | `int`    | ID of the constraint that the status describes |
-| _required_ | **`status`**        | `string` | The status of the constraint for this snapshot |
-
-`default-status` covers the constraints that share a status and `statuses` records only the constraints that differ from it, so the size of `constraint-statuses` does not grow with the number of constraints in a table. When every constraint has the same status, that status is recorded once, no matter how many constraints the table has.
+This is an explicit representation: each constraint's status is recorded independently, so the size of `constraint-statuses` grows with the number of constraints in a table. This keeps the encoding simple; more compact representations may be added in a later version if it becomes a problem.
 
 Readers must determine the status of a constraint for a snapshot as follows:
 
 1. If the snapshot has no `constraint-statuses`, the snapshot makes no claim about any constraint
-2. If the constraint's `constraint-id` is greater than the snapshot's `last-constraint-id`, the constraint did not exist when the snapshot was created and the snapshot makes no claim about it
-3. If the constraint is listed in `statuses`, its status is the listed status
-4. Otherwise, its status is `default-status`
+2. If the constraint's `constraint-id` is listed in `validated`, `valid`, `invalid`, or `unvalidated`, that is its status
+3. Otherwise, the snapshot makes no claim about the constraint and its status is treated as `unvalidated`
 
-`last-constraint-id` is what makes a defaulted status safe. Without it, a `default-status` recorded before a constraint was added would apply to that constraint, and a reader could conclude that a constraint held for a snapshot created before the constraint existed.
+Writers must record `constraint-statuses` in every snapshot of a table that has constraints, and must place each constraint's ID in the list for a status that follows these rules:
 
-Writers must record `constraint-statuses` in every snapshot of a table that has constraints, must set `last-constraint-id` to the table's `last-constraint-id` when the snapshot is created, and must choose `default-status` and `statuses` so that every constraint resolves to a status that follows these rules:
+* A constraint must not be listed as `validated` unless it was checked for every row in the snapshot
+* A constraint must not be listed as `valid` unless it was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`
+* A constraint must not be listed as `invalid` unless a row in the snapshot is known to violate it
+* `unvalidated` is the status of a constraint that cannot be listed in any other status
 
-* A constraint must not resolve to `validated` unless it was checked for every row in the snapshot
-* A constraint must not resolve to `valid` unless it was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`
-* A constraint must not resolve to `invalid` unless a row in the snapshot is known to violate it
-* `unvalidated` is the status of a constraint that cannot resolve to any other status
-
-Writers should choose the `default-status` that produces the shortest `statuses` list.
-
-Enforcing a constraint for a commit is not sufficient to resolve to `valid`. When the parent snapshot's status is not `validated` or `valid`, rows added by earlier commits were never checked, so the status is `unvalidated` even though the writer verified the rows that it added.
+Enforcing a constraint for a commit is not sufficient to list it as `valid`. When the parent snapshot's status is not `validated` or `valid`, rows added by earlier commits were never checked, so the status is `unvalidated` even though the writer verified the rows that it added.
 
 When a constraint becomes enforced, either by being added with `enforced` set to true or by `enforced` changing from false to true, writers should validate the table and record `validated`. A writer that does not validate records `unvalidated`, and the constraint remains `unvalidated` until a later validation records `validated`.
 
@@ -1929,7 +1915,7 @@ A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/
 |**`last-partition-id`**|`JSON int`|`1000`|
 |**`properties`**|`JSON object: {`<br />&nbsp;&nbsp;`"<key>": "<val>",`<br />&nbsp;&nbsp;`...`<br />`}`|`{`<br />&nbsp;&nbsp;`"write.format.default": "avro",`<br />&nbsp;&nbsp;`"commit.retry.num-retries": "4"`<br />`}`|
 |**`current-snapshot-id`**|`JSON long`|`3051729675574597004`|
-|**`snapshots`**|`JSON list of objects: [ {`<br />&nbsp;&nbsp;`"snapshot-id": <id>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"summary": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"operation": <operation>,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`... },`<br />&nbsp;&nbsp;`"manifest-list": "<location>",`<br />&nbsp;&nbsp;`"schema-id": "<id>"`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"snapshot-id": 3051729675574597004,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"summary": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"operation": "append"`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`"manifest-list": "s3://b/wh/.../s1.avro"`<br />&nbsp;&nbsp;`"schema-id": 0`<br />`} ]`|
+|**`snapshots`**|`JSON list of objects: [ {`<br />&nbsp;&nbsp;`"snapshot-id": <id>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"summary": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"operation": <operation>,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`... },`<br />&nbsp;&nbsp;`"manifest-list": "<location>",`<br />&nbsp;&nbsp;`"schema-id": "<id>",`<br />&nbsp;&nbsp;`"constraint-statuses": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"validated": [ ... ],`<br />&nbsp;&nbsp;&nbsp;&nbsp;`... }`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"snapshot-id": 3051729675574597004,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"summary": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"operation": "append"`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`"manifest-list": "s3://b/wh/.../s1.avro"`<br />&nbsp;&nbsp;`"schema-id": 0,`<br />&nbsp;&nbsp;`"constraint-statuses": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"validated": [1],`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"unvalidated": [2]`<br />&nbsp;&nbsp;`}`<br />`} ]`|
 |**`snapshot-log`**|`JSON list of objects: [`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;`"snapshot-id": ,`<br />&nbsp;&nbsp;`"timestamp-ms":`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"snapshot-id": 30517296...,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100...`<br />`} ]`|
 |**`metadata-log`**|`JSON list of objects: [`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;`"metadata-file": ,`<br />&nbsp;&nbsp;`"timestamp-ms":`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"metadata-file": "s3://bucket/.../v1.json",`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100...`<br />`} ]` |
 |**`sort-orders`**|`JSON sort orders (list of sort field object)`|`See above`|
@@ -1937,7 +1923,7 @@ A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/
 |**`refs`**|`JSON map with string key and object value:`<br />`{`<br />&nbsp;&nbsp;`"<name>": {`<br />&nbsp;&nbsp;`"snapshot-id": <id>,`<br />&nbsp;&nbsp;`"type": <type>,`<br />&nbsp;&nbsp;`"max-ref-age-ms": <long>,`<br />&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`...`<br />`}`|`{`<br />&nbsp;&nbsp;`"test": {`<br />&nbsp;&nbsp;`"snapshot-id": 123456789000,`<br />&nbsp;&nbsp;`"type": "tag",`<br />&nbsp;&nbsp;`"max-ref-age-ms": 10000000`<br />&nbsp;&nbsp;`}`<br />`}`|
 |**`encryption-keys`**|`JSON list of encryption key objects`|`[ {"key-id": "5f819b", "key-metadata": "aWNlYmVyZwo="} ]`|
 |**`last-constraint-id`**|`JSON int`|`2`|
-|**`constraints`**|`JSON list of objects: [ {`<br />&nbsp;&nbsp;`"constraint-id": <id>,`<br />&nbsp;&nbsp;`"type": <type>,`<br />&nbsp;&nbsp;`"name": "<name>",`<br />&nbsp;&nbsp;`"enforced": <boolean>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"constraint-metadata": { ... }`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"constraint-id": 1,`<br />&nbsp;&nbsp;`"type": "primary-key",`<br />&nbsp;&nbsp;`"name": "pk_sales",`<br />&nbsp;&nbsp;`"enforced": false,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"constraint-metadata": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"field-ids": [1]`<br />&nbsp;&nbsp;`}`<br />`} ]`|
+|**`constraints`**|`JSON list of objects: [ {`<br />&nbsp;&nbsp;`"constraint-id": <id>,`<br />&nbsp;&nbsp;`"type": "check",`<br />&nbsp;&nbsp;`"name": "<name>",`<br />&nbsp;&nbsp;`"enforced": <boolean>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"expression": { ... }`<br />`}, {`<br />&nbsp;&nbsp;`"constraint-id": <id>,`<br />&nbsp;&nbsp;`"type": "primary-key",`<br />&nbsp;&nbsp;`"name": "<name>",`<br />&nbsp;&nbsp;`"enforced": <boolean>,`<br />&nbsp;&nbsp;`"timestamp-ms": <timestamp-in-ms>,`<br />&nbsp;&nbsp;`"field-ids": [ ... ]`<br />`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"constraint-id": 1,`<br />&nbsp;&nbsp;`"type": "check",`<br />&nbsp;&nbsp;`"name": "chk_amount",`<br />&nbsp;&nbsp;`"enforced": true,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"expression": { ... }`<br />`}, {`<br />&nbsp;&nbsp;`"constraint-id": 2,`<br />&nbsp;&nbsp;`"type": "primary-key",`<br />&nbsp;&nbsp;`"name": "pk_sales",`<br />&nbsp;&nbsp;`"enforced": false,`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100955770,`<br />&nbsp;&nbsp;`"field-ids": [1]`<br />`} ]`|
 
 ### Name Mapping Serialization
 
@@ -2060,7 +2046,7 @@ Constraints are added in v4:
 * [Constraints](#constraints) must not be added to v3 or earlier tables
 * Table metadata may contain `constraints` and `last-constraint-id`
 * Snapshots may contain `constraint-statuses`
-* Upgrading a v2 or v3 table to v4 does not add constraints; a table upgraded to v4 has no constraints until they are added
+* Upgrading a v2 or v3 table to v4 rewrites the table's `identifier-field-ids` as a `primary-key` constraint that is not enforced; a table with no identifier fields has no constraints until they are added
 
 ### Version 3
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -669,7 +669,7 @@ Three constraint types are defined:
 * `unique` -- the values of a set of fields must be distinct across all rows
 * `primary-key` -- the values of a set of fields must be distinct across all rows and must not be null
 
-Constraints are stored separately from schemas because a constraint may reference more than one field and because constraints and schemas evolve independently. Every constraint references the fields that it applies to by field ID, so a constraint continues to apply to the same columns after a column is renamed or reordered.
+Constraints are stored separately from schemas because the two evolve independently. Every constraint references the fields that it applies to by field ID, so a constraint continues to apply to the same columns after a column is renamed or reordered.
 
 A required field in a schema expresses `NOT NULL`. It is not represented as a constraint.
 
@@ -753,7 +753,7 @@ When a constraint becomes enforced, either by being added with `enforced` set to
 
 Only `validated` and `valid` state that a constraint holds. They are distinguished so that readers can tell whether that conclusion was reached by checking data or by relying on writers to enforce the constraint, and so that the most recent `validated` snapshot can be found if a constraint is later found to be `invalid`.
 
-Writers may commit to a table where a constraint is `invalid`. An enforced constraint requires that a writer not add rows that violate the constraint; it does not require a writer to repair existing violations. Returning a constraint to `validated` is a separate operation.
+Writers may commit to a table where a constraint is `invalid`. An enforced constraint requires that a writer not add rows that violate the constraint; it does not require a writer to repair existing violations.
 
 ### Manifests
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -666,7 +666,7 @@ Constraints are added in v4 and are not supported in v3 or earlier.
 Three constraint types are defined:
 
 * `check` -- every row must satisfy a predicate
-* `unique` -- the values of a set of fields must be distinct across all rows
+* `unique` -- the values of a set of fields must be distinct across all rows; a null value is not equal to any other null value, so more than one row may be null
 * `primary-key` -- the values of a set of fields must be distinct across all rows and must not be null
 
 Constraints are stored separately from schemas because the two evolve independently. Every constraint references the fields that it applies to by field ID, so a constraint continues to apply to the same columns after a column is renamed or reordered.
@@ -683,7 +683,7 @@ A constraint consists of the following fields:
 | _required_ | **`type`**                | `string`  | The constraint type: `check`, `unique`, or `primary-key` |
 | _required_ | **`name`**                | `string`  | A name for the constraint that is unique within the table. Names are for human consumption and must not be used to identify a constraint in metadata |
 | _required_ | **`enforced`**            | `boolean` | Whether writers must verify that the rows they add satisfy the constraint |
-| _required_ | **`timestamp-ms`**        | `long`    | Timestamp in milliseconds from the unix epoch when the constraint was created or last modified |
+| _required_ | **`timestamp-ms`**        | `long`    | Timestamp in milliseconds from the unix epoch when the constraint was created or last modified. The timestamp is informational and must not be used to determine whether a constraint applies to a snapshot or whether it holds |
 | _required_ | **`constraint-metadata`** | `struct`  | Defines what the constraint requires; its fields depend on the constraint `type` (see below) |
 
 `constraint-metadata` for a `check` constraint consists of:
@@ -722,14 +722,7 @@ To express SQL `CHECK` semantics for an optional field, the stored expression mu
 
 Enforcement and validation are separate properties. Whether writers must verify the rows that they add is a property of a constraint, tracked by `enforced`. Whether a table is known to satisfy a constraint is a property of a table's data, tracked per snapshot by `constraint-statuses`.
 
-A snapshot's `constraint-statuses` records the status of each constraint that was active when the snapshot was created. Each entry consists of:
-
-| Requirement | Field name          | Type     | Description |
-|-------------|---------------------|----------|-------------|
-| _required_ | **`constraint-id`** | `int`    | ID of the constraint that the status describes |
-| _required_ | **`status`**        | `string` | The status of the constraint for this snapshot |
-
-A status is one of:
+The status of a constraint for a snapshot is one of:
 
 | Status        | Description |
 |---------------|-------------|
@@ -738,18 +731,48 @@ A status is one of:
 | `invalid`     | The constraint was checked and at least one row in the snapshot violates it |
 | `unvalidated` | Whether the constraint holds for all rows in the snapshot is not known |
 
-A constraint that is not present in a snapshot's `constraint-statuses` was not active when the snapshot was created, and the snapshot makes no claim about it. This is the case for snapshots created before the constraint was added and for snapshots created after it was dropped.
+A snapshot's `constraint-statuses` consists of:
 
-Writers must record a status for every constraint that is active when a snapshot is created:
+| Requirement | Field name               | Type           | Description |
+|-------------|--------------------------|----------------|-------------|
+| _required_ | **`last-constraint-id`** | `int`          | The table's `last-constraint-id` when the snapshot was created |
+| _required_ | **`default-status`**     | `string`       | The status of every constraint that is not listed in `statuses` |
+| _optional_ | **`statuses`**           | `list<struct>` | Statuses for constraints whose status is not `default-status` |
 
-* `validated` must not be recorded unless the constraint was checked for every row in the snapshot
-* `valid` must not be recorded unless the constraint was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`
-* `invalid` must not be recorded unless a row in the snapshot is known to violate the constraint
-* `unvalidated` must be recorded when no other status can be recorded
+Each entry of `statuses` consists of:
 
-Enforcing a constraint for a commit is not sufficient to record `valid`. When the parent snapshot's status is not `validated` or `valid`, rows added by earlier commits were never checked, so the status is `unvalidated` even though the writer verified the rows that it added.
+| Requirement | Field name          | Type     | Description |
+|-------------|---------------------|----------|-------------|
+| _required_ | **`constraint-id`** | `int`    | ID of the constraint that the status describes |
+| _required_ | **`status`**        | `string` | The status of the constraint for this snapshot |
+
+`default-status` covers the constraints that share a status and `statuses` records only the constraints that differ from it, so the size of `constraint-statuses` does not grow with the number of constraints in a table. When every constraint has the same status, that status is recorded once, no matter how many constraints the table has.
+
+Readers must determine the status of a constraint for a snapshot as follows:
+
+1. If the snapshot has no `constraint-statuses`, the snapshot makes no claim about any constraint
+2. If the constraint's `constraint-id` is greater than the snapshot's `last-constraint-id`, the constraint did not exist when the snapshot was created and the snapshot makes no claim about it
+3. If the constraint is listed in `statuses`, its status is the listed status
+4. Otherwise, its status is `default-status`
+
+`last-constraint-id` is what makes a defaulted status safe. Without it, a `default-status` recorded before a constraint was added would apply to that constraint, and a reader could conclude that a constraint held for a snapshot created before the constraint existed.
+
+Writers must record `constraint-statuses` in every snapshot of a table that has constraints, must set `last-constraint-id` to the table's `last-constraint-id` when the snapshot is created, and must choose `default-status` and `statuses` so that every constraint resolves to a status that follows these rules:
+
+* A constraint must not resolve to `validated` unless it was checked for every row in the snapshot
+* A constraint must not resolve to `valid` unless it was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`
+* A constraint must not resolve to `invalid` unless a row in the snapshot is known to violate it
+* `unvalidated` is the status of a constraint that cannot resolve to any other status
+
+Writers should choose the `default-status` that produces the shortest `statuses` list.
+
+Enforcing a constraint for a commit is not sufficient to resolve to `valid`. When the parent snapshot's status is not `validated` or `valid`, rows added by earlier commits were never checked, so the status is `unvalidated` even though the writer verified the rows that it added.
 
 When a constraint becomes enforced, either by being added with `enforced` set to true or by `enforced` changing from false to true, writers should validate the table and record `validated`. A writer that does not validate records `unvalidated`, and the constraint remains `unvalidated` until a later validation records `validated`.
+
+A snapshot's `constraint-statuses` must not be modified after the snapshot is created. Recording a different status for a constraint requires a new snapshot. A snapshot that changes only constraint statuses may reuse its parent's manifest list.
+
+A constraint that a snapshot states holds may later be found not to hold for that snapshot, because `valid` relies on writers rather than on checking data. Writers should then commit a snapshot that records `invalid` and should expire the snapshots that state that the constraint holds, because queries against those snapshots would otherwise continue to rely on a constraint that does not hold.
 
 Only `validated` and `valid` state that a constraint holds. They are distinguished so that readers can tell whether that conclusion was reached by checking data or by relying on writers to enforce the constraint, and so that the most recent `validated` snapshot can be found if a constraint is later found to be `invalid`.
 
@@ -1076,7 +1099,7 @@ A snapshot consists of the following fields:
     | _required_ | **`first-row-id`**           | The first `_row_id` assigned to the first row in the first data file in the first manifest, see [Row Lineage](#row-lineage) |
     | _required_ | **`added-rows`**             | The upper bound of the number of rows with assigned row IDs, see [Row Lineage](#row-lineage) |
     | _optional_ | **`key-id`**                 | ID of the encryption key that encrypts the manifest list key metadata |
-    | _optional_ | **`constraint-statuses`**    | A list (optional) of constraint statuses for the snapshot, see [Constraint Validation](#constraint-validation) |
+    | _optional_ | **`constraint-statuses`**    | A struct (optional) that records the status of the table's constraints for the snapshot, see [Constraint Validation](#constraint-validation) |
 
 The snapshot summary's `operation` field is used by some operations, like snapshot expiration, to skip processing certain snapshots. Possible `operation` values are:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -745,7 +745,7 @@ A snapshot's `constraint-statuses` records, for each status, the IDs of the cons
 | _optional_ | **`invalid`**     | `list<int>` | IDs of constraints that are `invalid` for the snapshot |
 | _optional_ | **`unvalidated`** | `list<int>` | IDs of constraints that are `unvalidated` for the snapshot |
 
-Each list contains the `constraint-id` of every constraint that has that status for the snapshot. A `constraint-id` must appear in at most one list. A list with no constraints may be omitted. A constraint whose ID is not present in any list makes no claim for the snapshot and is treated as `unvalidated`.
+Each list contains the `constraint-id` of every constraint that has that status for the snapshot. Every constraint that exists when the snapshot is created must be listed in exactly one of the four lists, and a `constraint-id` must not appear in more than one list. A list with no constraints may be omitted. A constraint whose ID is not present in any list did not exist when the snapshot was created, so the snapshot makes no claim about it.
 
 This is an explicit representation: each constraint's status is recorded independently, so the size of `constraint-statuses` grows with the number of constraints in a table. This keeps the encoding simple; more compact representations may be added in a later version if it becomes a problem.
 
@@ -753,9 +753,9 @@ Readers must determine the status of a constraint for a snapshot as follows:
 
 1. If the snapshot has no `constraint-statuses`, the snapshot makes no claim about any constraint
 2. If the constraint's `constraint-id` is listed in `validated`, `valid`, `invalid`, or `unvalidated`, that is its status
-3. Otherwise, the snapshot makes no claim about the constraint and its status is treated as `unvalidated`
+3. Otherwise, the constraint did not exist when the snapshot was created and the snapshot makes no claim about it
 
-Writers must record `constraint-statuses` in every snapshot of a table that has constraints, and must place each constraint's ID in the list for a status that follows these rules:
+Writers must record `constraint-statuses` in every snapshot of a table that has constraints, and must place every constraint that exists when the snapshot is created into exactly one status list, following these rules:
 
 * A constraint must not be listed as `validated` unless it was checked for every row in the snapshot
 * A constraint must not be listed as `valid` unless it was enforced for the commit and the parent snapshot's status for the constraint is `validated` or `valid`

--- a/format/spec.md
+++ b/format/spec.md
@@ -691,8 +691,6 @@ The fields that define what a constraint requires are embedded directly in the c
 
 The `field-ids` of a `unique` or `primary-key` constraint must reference primitive fields that are either top-level fields or nested in required structs, and must not reference fields within a `list` or a `map`. These are the same restrictions that apply to [identifier fields](#identifier-field-ids).
 
-A field referenced by a constraint must not be dropped. A writer must reject a schema change that removes a field referenced by a `check` constraint's `expression` or by a `unique` or `primary-key` constraint's `field-ids` unless the constraint is removed in the same change.
-
 When a constraint is `enforced`, writers must verify that the rows they add satisfy the constraint and must fail the write if they do not. A writer that cannot verify an enforced constraint must reject writes to the table rather than add rows that have not been verified. When a constraint is not enforced, writers are not required to verify the rows they add.
 
 Whether to trust a constraint that is not enforced is left to engines and is not tracked in table metadata.
@@ -714,6 +712,16 @@ A check expression is evaluated for each row over the values of that row. Expres
 Iceberg predicates use two-valued logic: a predicate always produces true or false and never produces null, so a comparison with a null operand produces false. This differs from SQL `CHECK`, where a row satisfies a constraint unless the predicate produces false and a null value therefore satisfies the constraint.
 
 To express SQL `CHECK` semantics for an optional field, the stored expression must make the null case explicit. For example, SQL `CHECK (price >= 0)` for an optional `price` field is stored as the expression for `price >= 0 OR price IS NULL`. This is unnecessary for required fields, which can never be null.
+
+#### Constraints and Schema Evolution
+
+A constraint references fields by ID, so schema changes interact with constraints as follows. The referenced fields of a `check` constraint are the field IDs in its `expression`; the referenced fields of a `unique` or `primary-key` constraint are its `field-ids`.
+
+* Renaming or reordering a referenced field is allowed; the constraint continues to apply to the same fields.
+* If a dropped field is referenced only by single-column constraints, the drop is allowed and those constraints are removed automatically. If a dropped field is referenced by a multi-column constraint, the writer must reject the drop unless that constraint is removed in the same change.
+* The type of a referenced field must not be changed, even for type promotions that are otherwise allowed. This restriction may be relaxed in a later version.
+
+Changing a constraint's own definition is governed by the mutability rule above: only `name` and `enforced` may be changed in place; changing an `expression` or `field-ids` requires a new constraint.
 
 #### Constraint Validation
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -768,7 +768,9 @@ When a constraint becomes enforced, either by being added with `enforced` set to
 
 A snapshot's `constraint-statuses` must not be modified after the snapshot is created. Recording a different status for a constraint requires a new snapshot. A snapshot that changes only constraint statuses may reuse its parent's manifest list.
 
-A constraint that a snapshot states holds may later be found not to hold for that snapshot, because `valid` relies on writers rather than on checking data. Writers should then commit a snapshot that records `invalid` and should expire the snapshots that state that the constraint holds, because queries against those snapshots would otherwise continue to rely on a constraint that does not hold.
+A constraint that a snapshot reports as `valid` may later be found not to hold for that snapshot. A `valid` status depends on every commit in the snapshot's history having correctly enforced the constraint, and Iceberg records the status a writer reports without re-checking the data. So if any of those writers was buggy or non-compliant, the `valid` status can be wrong even though nothing detected it at commit time. A `validated` status, which reflects an actual scan of all rows, does not depend on that chain. Writers should then commit a snapshot that records `invalid` and should expire the snapshots that state that the constraint holds, because queries against those snapshots would otherwise continue to rely on a constraint that does not hold.
+
+Iceberg does not detect violations on its own. A constraint is only found to be `invalid` when an engine scans the data and checks the constraint, for example during an explicit validation or when validating a newly enforced constraint, and then records `invalid`. Until such a scan runs, a `valid` status that does not actually hold is not detected.
 
 Only `validated` and `valid` state that a constraint holds. They are distinguished so that readers can tell whether that conclusion was reached by checking data or by relying on writers to enforce the constraint, and so that the most recent `validated` snapshot can be found if a constraint is later found to be `invalid`.
 


### PR DESCRIPTION
Adds table constraints to the v4 spec
- New `Constraints` section defining `check`, `unique`, and `primary-key` constraints
- `constraints` and `last-constraint-id` added to v4 table metadata
- `constraint-statuses` added to v4 snapshots, recording whether a constraint is `validated`, `valid`, `invalid`, or `unvalidated`
- Engines enforce and validate; Iceberg stores the definitions and the reported statuses