### PR TITLE
Core: Support column files in V4ManifestReader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ColumnFile.java
+++ b/core/src/main/java/org/apache/iceberg/ColumnFile.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.types.Types;
+
+interface ColumnFile {
+  Types.NestedField FORMAT_VERSION =
+      Types.NestedField.required(
+          161, "format_version", Types.IntegerType.get(), "Format version of this column file");
+  Types.NestedField FIELD_IDS =
+      Types.NestedField.required(
+          162,
+          "field_ids",
+          Types.ListType.ofRequired(163, Types.IntegerType.get()),
+          "Live field IDs in this column file");
+  Types.NestedField LOCATION =
+      Types.NestedField.required(
+          164, "location", Types.StringType.get(), "Location of the column file");
+  Types.NestedField FILE_FORMAT =
+      Types.NestedField.required(
+          165,
+          "file_format",
+          Types.StringType.get(),
+          "String file format name for this column file");
+  Types.NestedField FILE_SIZE_IN_BYTES =
+      Types.NestedField.required(
+          166, "file_size_in_bytes", Types.LongType.get(), "Total column file size in bytes");
+  Types.NestedField KEY_METADATA =
+      Types.NestedField.optional(
+          167,
+          "key_metadata",
+          Types.BinaryType.get(),
+          "Implementation-specific key metadata for encryption");
+  Types.NestedField SPLIT_OFFSETS =
+      Types.NestedField.optional(
+          168,
+          "split_offsets",
+          Types.ListType.ofRequired(169, Types.LongType.get()),
+          "Split offsets for the data file");
+
+  static Types.StructType schema() {
+    return Types.StructType.of(
+        FORMAT_VERSION,
+        FIELD_IDS,
+        LOCATION,
+        FILE_FORMAT,
+        FILE_SIZE_IN_BYTES,
+        KEY_METADATA,
+        SPLIT_OFFSETS);
+  }
+
+  /** Returns the format version of this column file. */
+  int formatVersion();
+
+  /** Returns the field IDs contained in this column file. */
+  List<Integer> fieldIds();
+
+  /** Returns the location of this column file. */
+  String location();
+
+  /** Returns the format of this column file. */
+  FileFormat fileFormat();
+
+  /** Returns the total size of this column file in bytes. */
+  long fileSizeInBytes();
+
+  /** Returns encryption key metadata, or null if this column file is not encrypted. */
+  ByteBuffer keyMetadata();
+
+  /** Returns the list of recommended split locations for this column file, or null. */
+  List<Long> splitOffsets();
+
+  /** Copies this column file. */
+  ColumnFile copy();
+}

--- a/core/src/main/java/org/apache/iceberg/ColumnFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ColumnFileStruct.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.avro.SupportsIndexProjection;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ArrayUtil;
+import org.apache.iceberg.util.ByteBuffers;
+
+/** Mutable {@link StructLike} implementation of {@link ColumnFile}. */
+class ColumnFileStruct extends SupportsIndexProjection implements ColumnFile, Serializable {
+  private static final Types.StructType BASE_TYPE =
+      Types.StructType.of(
+          ColumnFile.FORMAT_VERSION,
+          ColumnFile.FIELD_IDS,
+          ColumnFile.LOCATION,
+          ColumnFile.FILE_FORMAT,
+          ColumnFile.FILE_SIZE_IN_BYTES,
+          ColumnFile.KEY_METADATA,
+          ColumnFile.SPLIT_OFFSETS);
+
+  private int formatVersion = -1;
+  private int[] fieldIds = null;
+  private String location = null;
+  private FileFormat fileFormat = null;
+  private long fileSizeInBytes = -1L;
+  private byte[] keyMetadata = null;
+  private long[] splitOffsets = null;
+
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  ColumnFileStruct(Types.StructType projection) {
+    super(BASE_TYPE, projection);
+  }
+
+  ColumnFileStruct(
+      int formatVersion,
+      List<Integer> fieldIds,
+      String location,
+      FileFormat fileFormat,
+      long fileSizeInBytes,
+      ByteBuffer keyMetadata,
+      List<Long> splitOffsets) {
+    super(BASE_TYPE.fields().size());
+    this.formatVersion = formatVersion;
+    this.fieldIds = ArrayUtil.toIntArray(fieldIds);
+    this.location = location;
+    this.fileFormat = fileFormat;
+    this.fileSizeInBytes = fileSizeInBytes;
+    this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
+    this.splitOffsets = ArrayUtil.toLongArray(splitOffsets);
+  }
+
+  /** Copy constructor. */
+  private ColumnFileStruct(ColumnFileStruct toCopy) {
+    super(toCopy);
+    this.formatVersion = toCopy.formatVersion;
+    this.fieldIds =
+        toCopy.fieldIds != null ? Arrays.copyOf(toCopy.fieldIds, toCopy.fieldIds.length) : null;
+    this.location = toCopy.location;
+    this.fileFormat = toCopy.fileFormat;
+    this.fileSizeInBytes = toCopy.fileSizeInBytes;
+    this.keyMetadata =
+        toCopy.keyMetadata != null
+            ? Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length)
+            : null;
+    this.splitOffsets =
+        toCopy.splitOffsets != null
+            ? Arrays.copyOf(toCopy.splitOffsets, toCopy.splitOffsets.length)
+            : null;
+  }
+
+  /** Constructor for Java serialization. */
+  ColumnFileStruct() {
+    super(BASE_TYPE.fields().size());
+  }
+
+  @Override
+  public int formatVersion() {
+    return formatVersion;
+  }
+
+  @Override
+  public List<Integer> fieldIds() {
+    return fieldIds != null ? ArrayUtil.toUnmodifiableIntList(fieldIds) : null;
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public FileFormat fileFormat() {
+    return fileFormat;
+  }
+
+  @Override
+  public long fileSizeInBytes() {
+    return fileSizeInBytes;
+  }
+
+  @Override
+  public ByteBuffer keyMetadata() {
+    return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
+  }
+
+  @Override
+  public List<Long> splitOffsets() {
+    return splitOffsets != null ? ArrayUtil.toUnmodifiableLongList(splitOffsets) : null;
+  }
+
+  @Override
+  public ColumnFile copy() {
+    return new ColumnFileStruct(this);
+  }
+
+  @Override
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int pos) {
+    return switch (pos) {
+      case 0 -> formatVersion;
+      case 1 -> fieldIds();
+      case 2 -> location;
+      case 3 -> fileFormat != null ? fileFormat.toString() : null;
+      case 4 -> fileSizeInBytes;
+      case 5 -> keyMetadata();
+      case 6 -> splitOffsets();
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected <T> void internalSet(int pos, T value) {
+    switch (pos) {
+      case 0 -> this.formatVersion = (int) value;
+      case 1 -> this.fieldIds = ArrayUtil.toIntArray((List<Integer>) value);
+        // always coerce to String for Serializable
+      case 2 -> this.location = value.toString();
+      case 3 -> this.fileFormat = FileFormat.fromString(value.toString());
+      case 4 -> this.fileSizeInBytes = (long) value;
+      case 5 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 6 -> this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+      default -> {
+        // ignore the object, it must be from a newer version of the format
+      }
+    }
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("format_version", formatVersion)
+        .add("field_ids", fieldIds)
+        .add("location", location)
+        .add("file_format", fileFormat)
+        .add("file_size_in_bytes", fileSizeInBytes)
+        .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
+        .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
+        .toString();
+  }
+
+  static class Builder {
+    private Integer formatVersion = null;
+    private List<Integer> fieldIds = null;
+    private String location = null;
+    private FileFormat fileFormat = null;
+    private Long fileSizeInBytes = null;
+    private ByteBuffer keyMetadata = null;
+    private List<Long> splitOffsets = null;
+
+    Builder formatVersion(int newFormatVersion) {
+      Preconditions.checkArgument(
+          newFormatVersion >= 0, "Invalid format version: %s (must be >= 0)", newFormatVersion);
+      this.formatVersion = newFormatVersion;
+      return this;
+    }
+
+    Builder fieldIds(List<Integer> newFieldIds) {
+      Preconditions.checkArgument(newFieldIds != null, "Invalid field IDs: null");
+      Preconditions.checkArgument(!newFieldIds.isEmpty(), "Invalid field IDs: empty");
+      Preconditions.checkArgument(
+          Sets.newHashSet(newFieldIds).size() == newFieldIds.size(),
+          "Invalid field IDs: duplicated IDs found in: %s",
+          newFieldIds);
+      this.fieldIds = newFieldIds;
+      return this;
+    }
+
+    Builder location(String newLocation) {
+      Preconditions.checkArgument(newLocation != null, "Invalid location: null");
+      Preconditions.checkArgument(!newLocation.isEmpty(), "Invalid location: empty");
+      this.location = newLocation;
+      return this;
+    }
+
+    Builder fileFormat(FileFormat newFileFormat) {
+      Preconditions.checkArgument(newFileFormat != null, "Invalid file format: null");
+      this.fileFormat = newFileFormat;
+      return this;
+    }
+
+    Builder fileSizeInBytes(long newFileSizeInBytes) {
+      Preconditions.checkArgument(
+          newFileSizeInBytes >= 0,
+          "Invalid file size in bytes: %s (must be >= 0)",
+          newFileSizeInBytes);
+      this.fileSizeInBytes = newFileSizeInBytes;
+      return this;
+    }
+
+    Builder keyMetadata(ByteBuffer newKeyMetadata) {
+      Preconditions.checkArgument(newKeyMetadata != null, "Invalid key metadata: null");
+      this.keyMetadata = newKeyMetadata;
+      return this;
+    }
+
+    Builder splitOffsets(List<Long> newSplitOffsets) {
+      Preconditions.checkArgument(newSplitOffsets != null, "Invalid split offsets: null");
+      this.splitOffsets = newSplitOffsets;
+      return this;
+    }
+
+    ColumnFile build() {
+      Preconditions.checkArgument(formatVersion != null, "Missing required value: formatVersion");
+      Preconditions.checkArgument(fieldIds != null, "Missing required value: fieldIds");
+      Preconditions.checkArgument(location != null, "Missing required value: location");
+      Preconditions.checkArgument(fileFormat != null, "Missing required value: fileFormat");
+      Preconditions.checkArgument(
+          fileSizeInBytes != null, "Missing required value: fileSizeInBytes");
+      return new ColumnFileStruct(
+          formatVersion,
+          fieldIds,
+          location,
+          fileFormat,
+          fileSizeInBytes,
+          keyMetadata,
+          splitOffsets);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ColumnFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ColumnFileStruct.java
@@ -112,6 +112,12 @@ class ColumnFileStruct extends SupportsIndexProjection implements ColumnFile, Se
     return location;
   }
 
+  // Package-private only so the manifest reader can store the location resolved against the
+  // table location; other callers must go through construction.
+  void setLocation(String newLocation) {
+    this.location = newLocation;
+  }
+
   @Override
   public FileFormat fileFormat() {
     return fileFormat;

--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -95,6 +95,9 @@ interface TrackedFile {
           "equality_ids",
           Types.ListType.ofRequired(136, Types.IntegerType.get()),
           "Field ids used to determine row equality in equality delete files");
+  Types.NestedField COLUMN_FILES =
+      Types.NestedField.optional(
+          158, "column_files", Types.ListType.ofRequired(159, ColumnFile.schema()), "Column files");
 
   /**
    * Returns the schema for the given partition and content stats types.
@@ -124,7 +127,8 @@ interface TrackedFile {
         MANIFEST_INFO,
         KEY_METADATA,
         SPLIT_OFFSETS,
-        EQUALITY_IDS);
+        EQUALITY_IDS,
+        COLUMN_FILES);
   }
 
   private static Type typeOrUnknown(Types.StructType structType) {
@@ -178,6 +182,9 @@ interface TrackedFile {
 
   /** Returns the set of field IDs used for equality comparison in equality delete files. */
   List<Integer> equalityIds();
+
+  /** Returns the column files for this file. */
+  List<ColumnFile> columnFiles();
 
   /** Copies this tracked file. */
   TrackedFile copy();

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -21,10 +21,12 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -59,7 +61,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
           TrackedFile.MANIFEST_INFO,
           TrackedFile.KEY_METADATA,
           TrackedFile.SPLIT_OFFSETS,
-          TrackedFile.EQUALITY_IDS);
+          TrackedFile.EQUALITY_IDS,
+          TrackedFile.COLUMN_FILES);
 
   private FileContent contentType = null;
   private int formatVersion = -1;
@@ -79,6 +82,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   private byte[] keyMetadata = null;
   private long[] splitOffsets = null;
   private int[] equalityIds = null;
+  private List<ColumnFile> columnFiles = null;
 
   /** Used by internal readers to instantiate this class with a projection schema. */
   TrackedFileStruct(Types.StructType projection) {
@@ -112,7 +116,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       ManifestInfo manifestInfo,
       ByteBuffer keyMetadata,
       List<Long> splitOffsets,
-      List<Integer> equalityIds) {
+      List<Integer> equalityIds,
+      List<ColumnFile> columnFiles) {
     super(BASE_TYPE.fields().size());
     this.tracking = tracking;
     this.contentType = contentType;
@@ -130,9 +135,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
     this.splitOffsets = ArrayUtil.toLongArray(splitOffsets);
     this.equalityIds = ArrayUtil.toIntArray(equalityIds);
+    this.columnFiles = columnFiles != null ? Lists.newArrayList(columnFiles) : null;
   }
 
   /** Copy constructor. */
+  @SuppressWarnings("CyclomaticComplexity")
   private TrackedFileStruct(TrackedFileStruct toCopy, Set<Integer> statsIds) {
     super(toCopy);
     this.contentType = toCopy.contentType;
@@ -167,6 +174,17 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
+
+    if (toCopy.columnFiles != null) {
+      this.columnFiles = Lists.newArrayListWithCapacity(toCopy.columnFiles.size());
+      for (ColumnFile columnFile : toCopy.columnFiles) {
+        if (columnFile != null) {
+          this.columnFiles.add(columnFile.copy());
+        }
+      }
+    } else {
+      this.columnFiles = null;
+    }
   }
 
   @Override
@@ -256,6 +274,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   }
 
   @Override
+  public List<ColumnFile> columnFiles() {
+    return columnFiles != null ? Collections.unmodifiableList(columnFiles) : null;
+  }
+
+  @Override
   public TrackedFile copy() {
     return new TrackedFileStruct(this, null);
   }
@@ -288,6 +311,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       case 13 -> keyMetadata();
       case 14 -> splitOffsets();
       case 15 -> equalityIds();
+      case 16 -> columnFiles();
       default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     };
   }
@@ -313,6 +337,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       case 13 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
       case 14 -> this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
       case 15 -> this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
+      case 16 -> this.columnFiles = (List<ColumnFile>) value;
       default -> {
         // ignore the object, it must be from a newer version of the format
       }
@@ -338,6 +363,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
         .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
         .add("equality_ids", equalityIds == null ? "null" : equalityIds())
+        .add("column_files", columnFiles)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -65,6 +65,12 @@ interface Tracking {
           "replaced_positions",
           Types.BinaryType.get(),
           "Bitmap of positions replaced in this snapshot");
+  Types.NestedField LATEST_COLUMN_FILE_SNAPSHOT_ID =
+      Types.NestedField.optional(
+          160,
+          "latest_column_file_snapshot_id",
+          Types.LongType.get(),
+          "Snapshot ID where the latest column file was added; null if there are no column files");
 
   static Types.StructType schema() {
     return Types.StructType.of(
@@ -75,7 +81,8 @@ interface Tracking {
         DV_SNAPSHOT_ID,
         FIRST_ROW_ID,
         DELETED_POSITIONS,
-        REPLACED_POSITIONS);
+        REPLACED_POSITIONS,
+        LATEST_COLUMN_FILE_SNAPSHOT_ID);
   }
 
   /** Returns the status of the entry. */
@@ -106,6 +113,12 @@ interface Tracking {
 
   /** Returns the bitmap of positions replaced in this snapshot. */
   ByteBuffer replacedPositions();
+
+  /**
+   * Returns the snapshot ID where the latest column file was added; null if there are no column
+   * files.
+   */
+  Long latestColumnFileSnapshotId();
 
   /** Returns the manifest location this entry was read from, or null. */
   String manifestLocation();

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -25,13 +25,14 @@ import org.apache.iceberg.util.ByteBuffers;
 class TrackingBuilder {
   private final long newSnapshotId;
   private final Long snapshotId;
-  private final Long dataSequenceNumber;
   private final Long fileSequenceNumber;
   private final Long firstRowId;
   private EntryStatus status;
+  private Long dataSequenceNumber;
   private Long dvSnapshotId;
   private byte[] deletedPositions;
   private byte[] replacedPositions;
+  private Long latestColumnFileSnapshotId;
 
   /**
    * Creates a builder for a newly added file.
@@ -86,6 +87,7 @@ class TrackingBuilder {
     this.dvSnapshotId = null;
     this.deletedPositions = null;
     this.replacedPositions = null;
+    this.latestColumnFileSnapshotId = null;
   }
 
   private TrackingBuilder(Tracking source, long newSnapshotId) {
@@ -100,6 +102,7 @@ class TrackingBuilder {
     this.dvSnapshotId = source.dvSnapshotId();
     this.deletedPositions = null;
     this.replacedPositions = null;
+    this.latestColumnFileSnapshotId = source.latestColumnFileSnapshotId();
   }
 
   /** Indicates that the DV has been updated for the new Tracking. */
@@ -112,6 +115,19 @@ class TrackingBuilder {
       this.status = EntryStatus.MODIFIED;
     }
 
+    return this;
+  }
+
+  /** Indicates that the column files list has been updated for the new Tracking. */
+  TrackingBuilder columnFilesUpdated() {
+    this.latestColumnFileSnapshotId = newSnapshotId;
+    if (status == EntryStatus.EXISTING) {
+      this.status = EntryStatus.MODIFIED;
+    }
+    // Reset to null to inherit from the new snapshot sequence number. It is safe to bump up the
+    // dataSequenceNumber as writers are required to rewrite v2 equality and position deletes to DVs
+    // when applying column update.
+    this.dataSequenceNumber = null;
     return this;
   }
 
@@ -144,7 +160,8 @@ class TrackingBuilder {
         dvSnapshotId,
         firstRowId,
         deletedPositions,
-        replacedPositions);
+        replacedPositions,
+        latestColumnFileSnapshotId);
   }
 
   private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {
@@ -158,7 +175,8 @@ class TrackingBuilder {
         source.dvSnapshotId(),
         source.firstRowId(),
         null,
-        null);
+        null,
+        source.latestColumnFileSnapshotId());
   }
 
   private static void validateSource(Tracking source) {

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -41,6 +41,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
           Tracking.FIRST_ROW_ID,
           Tracking.DELETED_POSITIONS,
           Tracking.REPLACED_POSITIONS,
+          Tracking.LATEST_COLUMN_FILE_SNAPSHOT_ID,
           MetadataColumns.ROW_POSITION);
 
   // tracking fields read on the scan path; row_position backs manifestPos.
@@ -62,6 +63,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   private Long firstRowId = null;
   private byte[] deletedPositions = null;
   private byte[] replacedPositions = null;
+  private Long latestColumnFileSnapshotId = null;
 
   // set by manifest readers, not written to manifests
   private String manifestLocation = null;
@@ -92,6 +94,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         toCopy.replacedPositions != null
             ? Arrays.copyOf(toCopy.replacedPositions, toCopy.replacedPositions.length)
             : null;
+    this.latestColumnFileSnapshotId = toCopy.latestColumnFileSnapshotId;
     this.manifestLocation = toCopy.manifestLocation;
     this.manifestPos = toCopy.manifestPos;
   }
@@ -104,7 +107,8 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
       Long dvSnapshotId,
       Long firstRowId,
       byte[] deletedPositions,
-      byte[] replacedPositions) {
+      byte[] replacedPositions,
+      Long latestColumnFileSnapshotId) {
     super(BASE_TYPE.fields().size());
     this.status = status;
     this.snapshotId = snapshotId;
@@ -114,6 +118,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     this.firstRowId = firstRowId;
     this.deletedPositions = deletedPositions;
     this.replacedPositions = replacedPositions;
+    this.latestColumnFileSnapshotId = latestColumnFileSnapshotId;
   }
 
   void inheritFrom(Tracking manifestTracking) {
@@ -130,11 +135,13 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
           manifestTracking.dataSequenceNumber(),
           manifestTracking.fileSequenceNumber());
 
-      if (status == EntryStatus.ADDED) {
+      if (status == EntryStatus.ADDED || status == EntryStatus.MODIFIED) {
         if (dataSequenceNumber == null) {
           this.dataSequenceNumber = manifestTracking.fileSequenceNumber();
         }
+      }
 
+      if (status == EntryStatus.ADDED) {
         if (fileSequenceNumber == null) {
           this.fileSequenceNumber = manifestTracking.fileSequenceNumber();
         }
@@ -187,6 +194,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   }
 
   @Override
+  public Long latestColumnFileSnapshotId() {
+    return latestColumnFileSnapshotId;
+  }
+
+  @Override
   public String manifestLocation() {
     return manifestLocation;
   }
@@ -207,62 +219,37 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case 0:
-        return status != null ? status.id() : null;
-      case 1:
-        return snapshotId();
-      case 2:
-        return dataSequenceNumber();
-      case 3:
-        return fileSequenceNumber();
-      case 4:
-        return dvSnapshotId;
-      case 5:
-        return firstRowId;
-      case 6:
-        return deletedPositions();
-      case 7:
-        return replacedPositions();
-      case 8:
-        return manifestPos;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> status != null ? status.id() : null;
+      case 1 -> snapshotId();
+      case 2 -> dataSequenceNumber();
+      case 3 -> fileSequenceNumber();
+      case 4 -> dvSnapshotId;
+      case 5 -> firstRowId;
+      case 6 -> deletedPositions();
+      case 7 -> replacedPositions();
+      case 8 -> latestColumnFileSnapshotId;
+      case 9 -> manifestPos;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.status = EntryStatus.fromId((Integer) value);
-        break;
-      case 1:
-        this.snapshotId = (Long) value;
-        break;
-      case 2:
-        this.dataSequenceNumber = (Long) value;
-        break;
-      case 3:
-        this.fileSequenceNumber = (Long) value;
-        break;
-      case 4:
-        this.dvSnapshotId = (Long) value;
-        break;
-      case 5:
-        this.firstRowId = (Long) value;
-        break;
-      case 6:
-        this.deletedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 7:
-        this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 8:
-        this.manifestPos = (long) value;
-        break;
-      default:
+      case 0 -> this.status = EntryStatus.fromId((Integer) value);
+      case 1 -> this.snapshotId = (Long) value;
+      case 2 -> this.dataSequenceNumber = (Long) value;
+      case 3 -> this.fileSequenceNumber = (Long) value;
+      case 4 -> this.dvSnapshotId = (Long) value;
+      case 5 -> this.firstRowId = (Long) value;
+      case 6 -> this.deletedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 7 -> this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 8 -> this.latestColumnFileSnapshotId = (Long) value;
+      case 9 -> this.manifestPos = (long) value;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
@@ -277,6 +264,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         .add("first_row_id", firstRowId)
         .add("deleted_positions", deletedPositions == null ? "null" : "(binary)")
         .add("replaced_positions", replacedPositions == null ? "null" : "(binary)")
+        .add("latest_column_file_snapshot_id", latestColumnFileSnapshotId)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/V4ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/V4ManifestReader.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.expressions.Evaluator;
@@ -134,6 +135,8 @@ class V4ManifestReader extends CloseableGroup implements CloseableIterable<Track
             .setCustomType(TrackedFile.TRACKING.fieldId(), TrackingStruct.class)
             .setCustomType(TrackedFile.DELETION_VECTOR.fieldId(), DeletionVectorStruct.class)
             .setCustomType(TrackedFile.MANIFEST_INFO.fieldId(), ManifestInfoStruct.class)
+            .setCustomType(
+                TrackedFile.COLUMN_FILES.type().asListType().elementId(), ColumnFileStruct.class)
             .setCustomType(TrackedFile.PARTITION_ID, PartitionData.class)
             .reuseContainers()
             .build();
@@ -162,6 +165,17 @@ class V4ManifestReader extends CloseableGroup implements CloseableIterable<Track
     if (dv != null && dv.location() != null) {
       ((DeletionVectorStruct) dv)
           .setLocation(LocationUtil.resolveLocation(tableLocation, dv.location()));
+    }
+
+    List<ColumnFile> columnFiles = copy.columnFiles();
+    if (columnFiles != null) {
+      for (ColumnFile columnFile : columnFiles) {
+        if (columnFile instanceof ColumnFileStruct columnFileStruct
+            && columnFile.location() != null) {
+          columnFileStruct.setLocation(
+              LocationUtil.resolveLocation(tableLocation, columnFile.location()));
+        }
+      }
     }
 
     return copy;

--- a/core/src/test/java/org/apache/iceberg/StatsTestUtil.java
+++ b/core/src/test/java/org/apache/iceberg/StatsTestUtil.java
@@ -42,6 +42,7 @@ class StatsTestUtil {
         null,
         null,
         null,
+        null,
         null);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestColumnFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestColumnFileStruct.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestColumnFileStruct {
+
+  private static final int FORMAT_VERSION = 4;
+  private static final List<Integer> FIELD_IDS = Lists.newArrayList(1, 2, 3);
+  private static final String LOCATION = "s3://bucket/data/column.parquet";
+  private static final FileFormat FILE_FORMAT = FileFormat.PARQUET;
+  private static final long FILE_SIZE_IN_BYTES = 1024L;
+  private static final ByteBuffer KEY_METADATA = ByteBuffer.wrap(new byte[] {1, 2, 3});
+  private static final List<Long> SPLIT_OFFSETS = Lists.newArrayList(0L, 512L);
+
+  @Test
+  void fieldAccess() {
+    ColumnFile columnFile =
+        new ColumnFileStruct(
+            FORMAT_VERSION,
+            FIELD_IDS,
+            LOCATION,
+            FILE_FORMAT,
+            FILE_SIZE_IN_BYTES,
+            KEY_METADATA,
+            SPLIT_OFFSETS);
+
+    assertThat(columnFile.formatVersion()).isEqualTo(FORMAT_VERSION);
+    assertThat(columnFile.fieldIds()).containsExactlyElementsOf(FIELD_IDS);
+    assertThat(columnFile.location()).isEqualTo(LOCATION);
+    assertThat(columnFile.fileFormat()).isEqualTo(FILE_FORMAT);
+    assertThat(columnFile.fileSizeInBytes()).isEqualTo(FILE_SIZE_IN_BYTES);
+    assertThat(columnFile.keyMetadata()).isEqualTo(KEY_METADATA);
+    assertThat(columnFile.splitOffsets()).containsExactlyElementsOf(SPLIT_OFFSETS);
+  }
+
+  @Test
+  void copy() {
+    ColumnFile columnFile =
+        new ColumnFileStruct(
+            FORMAT_VERSION,
+            FIELD_IDS,
+            LOCATION,
+            FILE_FORMAT,
+            FILE_SIZE_IN_BYTES,
+            KEY_METADATA,
+            SPLIT_OFFSETS);
+
+    ColumnFile copy = columnFile.copy();
+
+    assertThat(copy.formatVersion()).isEqualTo(FORMAT_VERSION);
+    assertThat(copy.fieldIds()).containsExactlyElementsOf(FIELD_IDS);
+    assertThat(copy.location()).isEqualTo(LOCATION);
+    assertThat(copy.fileFormat()).isEqualTo(FILE_FORMAT);
+    assertThat(copy.fileSizeInBytes()).isEqualTo(FILE_SIZE_IN_BYTES);
+    assertThat(copy.keyMetadata()).isEqualTo(KEY_METADATA);
+    assertThat(copy.splitOffsets()).containsExactlyElementsOf(SPLIT_OFFSETS);
+  }
+
+  @Test
+  void structLikeSize() {
+    ColumnFileStruct columnFile = new ColumnFileStruct();
+    assertThat(columnFile.size()).isEqualTo(7);
+  }
+
+  @Test
+  void setFieldsByOrdinals() {
+    ColumnFileStruct columnFile = new ColumnFileStruct();
+
+    columnFile.set(0, FORMAT_VERSION);
+    columnFile.set(1, FIELD_IDS);
+    columnFile.set(2, LOCATION);
+    columnFile.set(3, FILE_FORMAT.toString());
+    columnFile.set(4, FILE_SIZE_IN_BYTES);
+    columnFile.set(5, KEY_METADATA);
+    columnFile.set(6, SPLIT_OFFSETS);
+
+    assertThat(columnFile.formatVersion()).isEqualTo(FORMAT_VERSION);
+    assertThat(columnFile.fieldIds()).containsExactlyElementsOf(FIELD_IDS);
+    assertThat(columnFile.location()).isEqualTo(LOCATION);
+    assertThat(columnFile.fileFormat()).isEqualTo(FILE_FORMAT);
+    assertThat(columnFile.fileSizeInBytes()).isEqualTo(FILE_SIZE_IN_BYTES);
+    assertThat(columnFile.keyMetadata()).isEqualTo(KEY_METADATA);
+    assertThat(columnFile.splitOffsets()).containsExactlyElementsOf(SPLIT_OFFSETS);
+  }
+
+  @Test
+  void getFieldsByOrdinals() {
+    ColumnFileStruct columnFile =
+        new ColumnFileStruct(
+            FORMAT_VERSION,
+            FIELD_IDS,
+            LOCATION,
+            FILE_FORMAT,
+            FILE_SIZE_IN_BYTES,
+            KEY_METADATA,
+            SPLIT_OFFSETS);
+
+    assertThat(columnFile.get(0, Integer.class)).isEqualTo(FORMAT_VERSION);
+    assertThat(columnFile.get(1, List.class)).containsExactlyElementsOf(FIELD_IDS);
+    assertThat(columnFile.get(2, String.class)).isEqualTo(LOCATION);
+    assertThat(columnFile.get(3, String.class)).isEqualTo(FILE_FORMAT.toString());
+    assertThat(columnFile.get(4, Long.class)).isEqualTo(FILE_SIZE_IN_BYTES);
+    assertThat(columnFile.get(5, ByteBuffer.class)).isEqualTo(KEY_METADATA);
+    assertThat(columnFile.get(6, List.class)).containsExactlyElementsOf(SPLIT_OFFSETS);
+  }
+
+  @Test
+  void projectedStructLike() {
+    Types.StructType projection =
+        Types.StructType.of(ColumnFile.LOCATION, ColumnFile.FILE_SIZE_IN_BYTES);
+
+    ColumnFileStruct columnFile = new ColumnFileStruct(projection);
+    assertThat(columnFile.size()).isEqualTo(2);
+
+    // projected position 0 maps to internal position of location
+    // projected position 1 maps to internal position of file_size_in_bytes
+    columnFile.set(0, LOCATION);
+    columnFile.set(1, FILE_SIZE_IN_BYTES);
+
+    assertThat(columnFile.location()).isEqualTo(LOCATION);
+    assertThat(columnFile.fileSizeInBytes()).isEqualTo(FILE_SIZE_IN_BYTES);
+    assertThat(columnFile.get(0, String.class)).isEqualTo(LOCATION);
+    assertThat(columnFile.get(1, Long.class)).isEqualTo(FILE_SIZE_IN_BYTES);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  void serializationRoundTrip(TestHelpers.RoundTripSerializer<ColumnFile> roundTripSerializer)
+      throws IOException, ClassNotFoundException {
+    ColumnFile columnFile =
+        new ColumnFileStruct(
+            FORMAT_VERSION,
+            FIELD_IDS,
+            LOCATION,
+            FILE_FORMAT,
+            FILE_SIZE_IN_BYTES,
+            KEY_METADATA,
+            SPLIT_OFFSETS);
+
+    ColumnFile deserialized = roundTripSerializer.apply(columnFile);
+
+    assertThat((StructLike) deserialized)
+        .usingComparator(Comparators.forType(ColumnFile.schema()))
+        .isEqualTo(columnFile);
+  }
+
+  @Test
+  void invalidBuilderValues() {
+    assertThatThrownBy(() -> ColumnFileStruct.builder().fieldIds(null).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field IDs: null");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().fieldIds(Lists.newArrayList()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field IDs: empty");
+
+    assertThatThrownBy(
+            () -> ColumnFileStruct.builder().fieldIds(Lists.newArrayList(1, 2, 1)).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field IDs: duplicated IDs found in: [1, 2, 1]");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().location(null).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid location: null");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().location("").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid location: empty");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().fileFormat(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid file format: null");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().fileSizeInBytes(-1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid file size in bytes: -1 (must be >= 0)");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().formatVersion(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid format version: -1 (must be >= 0)");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().keyMetadata(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid key metadata: null");
+
+    assertThatThrownBy(() -> ColumnFileStruct.builder().splitOffsets(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid split offsets: null");
+  }
+
+  @Test
+  void missingBuilderValues() {
+    assertThatThrownBy(
+            () ->
+                ColumnFileStruct.builder()
+                    .fieldIds(FIELD_IDS)
+                    .location(LOCATION)
+                    .fileFormat(FILE_FORMAT)
+                    .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: formatVersion");
+
+    assertThatThrownBy(
+            () ->
+                ColumnFileStruct.builder()
+                    .formatVersion(FORMAT_VERSION)
+                    .location(LOCATION)
+                    .fileFormat(FILE_FORMAT)
+                    .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: fieldIds");
+
+    assertThatThrownBy(
+            () ->
+                ColumnFileStruct.builder()
+                    .formatVersion(FORMAT_VERSION)
+                    .fieldIds(FIELD_IDS)
+                    .fileFormat(FILE_FORMAT)
+                    .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: location");
+
+    assertThatThrownBy(
+            () ->
+                ColumnFileStruct.builder()
+                    .formatVersion(FORMAT_VERSION)
+                    .fieldIds(FIELD_IDS)
+                    .location(LOCATION)
+                    .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: fileFormat");
+
+    assertThatThrownBy(
+            () ->
+                ColumnFileStruct.builder()
+                    .formatVersion(FORMAT_VERSION)
+                    .fieldIds(FIELD_IDS)
+                    .location(LOCATION)
+                    .fileFormat(FILE_FORMAT)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: fileSizeInBytes");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
@@ -61,7 +61,8 @@ public class TestTrackedFile {
             "manifest_info",
             "key_metadata",
             "split_offsets",
-            "equality_ids");
+            "equality_ids",
+            "column_files");
   }
 
   @Test
@@ -72,7 +73,7 @@ public class TestTrackedFile {
     assertThat(fields)
         .extracting(Types.NestedField::fieldId)
         .containsExactly(
-            147, 134, 157, 100, 101, 103, 104, 141, 102, 146, 140, 148, 150, 131, 132, 135);
+            147, 134, 157, 100, 101, 103, 104, 141, 102, 146, 140, 148, 150, 131, 132, 135, 158);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -94,6 +94,7 @@ class TestTrackedFileAdapters {
             null,
             FIRST_ROW_ID,
             null,
+            null,
             null);
     tracking.setManifestLocation(MANIFEST_LOCATION);
     tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
@@ -115,6 +116,7 @@ class TestTrackedFileAdapters {
             null,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L, 100L),
+            null,
             null);
 
     DataFile dataFile = TrackedFileAdapters.asDataFile(file, specsById(PARTITIONED_SPEC));
@@ -170,6 +172,7 @@ class TestTrackedFileAdapters {
             null,
             FIRST_ROW_ID,
             null,
+            null,
             null);
     tracking.setManifestLocation(MANIFEST_LOCATION);
     tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
@@ -191,7 +194,8 @@ class TestTrackedFileAdapters {
             null,
             ByteBuffer.wrap(new byte[] {4, 5}),
             ImmutableList.of(200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            null);
 
     DeleteFile deleteFile =
         TrackedFileAdapters.asEqualityDeleteFile(file, specsById(PARTITIONED_SPEC));
@@ -256,6 +260,7 @@ class TestTrackedFileAdapters {
             42L,
             FIRST_ROW_ID,
             null,
+            null,
             null);
     tracking.setManifestLocation(MANIFEST_LOCATION);
     tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
@@ -274,6 +279,7 @@ class TestTrackedFileAdapters {
             null,
             null,
             dv,
+            null,
             null,
             null,
             null,
@@ -374,6 +380,7 @@ class TestTrackedFileAdapters {
             null,
             null,
             null,
+            null,
             null);
     assertNullTrackingFields(TrackedFileAdapters.asDVDeleteFile(fileWithDV, UNPARTITIONED));
   }
@@ -428,6 +435,7 @@ class TestTrackedFileAdapters {
             null,
             null,
             null,
+            null,
             null);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDataFile(file, ImmutableMap.of()))
@@ -447,6 +455,7 @@ class TestTrackedFileAdapters {
             0L,
             0L,
             PARTITIONED_SPEC_ID,
+            null,
             null,
             null,
             null,
@@ -501,6 +510,7 @@ class TestTrackedFileAdapters {
         FileFormat.PARQUET,
         1L,
         1L,
+        null,
         null,
         null,
         null,

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -52,12 +52,19 @@ class TestTrackedFileStruct {
   private static final ManifestInfo MANIFEST_INFO = Mockito.mock(ManifestInfo.class);
   private static final ManifestInfo MANIFEST_INFO_COPY = Mockito.mock(ManifestInfo.class);
 
+  private static final ColumnFile COLUMN_FILE_1 = Mockito.mock(ColumnFile.class);
+  private static final ColumnFile COLUMN_FILE_2 = Mockito.mock(ColumnFile.class);
+  private static final ColumnFile COLUMN_FILE_1_COPY = Mockito.mock(ColumnFile.class);
+  private static final ColumnFile COLUMN_FILE_2_COPY = Mockito.mock(ColumnFile.class);
+
   static {
     Mockito.when(TRACKING.copy()).thenReturn(TRACKING_COPY);
     Mockito.when(PARTITION.copy()).thenReturn(PARTITION_COPY);
     Mockito.when(CONTENT_STATS.copy()).thenReturn(CONTENT_STATS_COPY);
     Mockito.when(DELETION_VECTOR.copy()).thenReturn(DELETION_VECTOR_COPY);
     Mockito.when(MANIFEST_INFO.copy()).thenReturn(MANIFEST_INFO_COPY);
+    Mockito.when(COLUMN_FILE_1.copy()).thenReturn(COLUMN_FILE_1_COPY);
+    Mockito.when(COLUMN_FILE_2.copy()).thenReturn(COLUMN_FILE_2_COPY);
   }
 
   @Test
@@ -79,7 +86,8 @@ class TestTrackedFileStruct {
             MANIFEST_INFO,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(100L, 200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     assertThat(file.tracking()).isSameAs(TRACKING);
     assertThat(file.contentType()).isEqualTo(FileContent.DATA);
@@ -97,6 +105,7 @@ class TestTrackedFileStruct {
     assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(file.splitOffsets()).containsExactly(100L, 200L);
     assertThat(file.equalityIds()).containsExactly(1, 2, 3);
+    assertThat(file.columnFiles()).containsExactly(COLUMN_FILE_1, COLUMN_FILE_2);
   }
 
   @Test
@@ -156,7 +165,8 @@ class TestTrackedFileStruct {
             MANIFEST_INFO,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(100L, 200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     assertThat(file.get(pos("tracking"), Tracking.class)).isSameAs(TRACKING);
     assertThat(file.get(pos("content_type"), Integer.class)).isEqualTo(FileContent.DATA.id());
@@ -197,7 +207,8 @@ class TestTrackedFileStruct {
             MANIFEST_INFO,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(100L, 200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     TrackedFile copy = file.copy();
 
@@ -218,6 +229,7 @@ class TestTrackedFileStruct {
     assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
     assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
     assertThat(copy.partition()).isSameAs(PARTITION_COPY);
+    assertThat(copy.columnFiles()).containsExactly(COLUMN_FILE_1_COPY, COLUMN_FILE_2_COPY);
 
     // mutable fields are deep-copied, not shared with the original
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
@@ -246,7 +258,8 @@ class TestTrackedFileStruct {
             MANIFEST_INFO,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(100L, 200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     TrackedFile copy = file.copyWithStats(ImmutableSet.of(1));
 
@@ -267,6 +280,7 @@ class TestTrackedFileStruct {
     assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
     assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
     assertThat(copy.partition()).isSameAs(PARTITION_COPY);
+    assertThat(copy.columnFiles()).containsExactly(COLUMN_FILE_1_COPY, COLUMN_FILE_2_COPY);
 
     // mutable fields are deep-copied, not shared with the original
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
@@ -293,7 +307,8 @@ class TestTrackedFileStruct {
             MANIFEST_INFO,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(100L, 200L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     TrackedFile copy = file.copyWithoutStats();
 
@@ -317,9 +332,11 @@ class TestTrackedFileStruct {
     assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
     assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
     assertThat(copy.partition()).isSameAs(PARTITION_COPY);
+    assertThat(copy.columnFiles()).containsExactly(COLUMN_FILE_1_COPY, COLUMN_FILE_2_COPY);
 
     // mutable fields are deep-copied, not shared with the original
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
+    assertThat(copy.columnFiles()).isNotSameAs(file.columnFiles());
   }
 
   @Test
@@ -366,7 +383,8 @@ class TestTrackedFileStruct {
             null, // ManifestInfo has its own serialization tests
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L),
-            ImmutableList.of(1, 2, 3));
+            ImmutableList.of(1, 2, 3),
+            null); // ColumnFile has its own serialization tests
 
     TrackedFileStruct deserialized = serializer.apply(file);
 
@@ -385,6 +403,7 @@ class TestTrackedFileStruct {
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.equalityIds()).containsExactly(1, 2, 3);
+    assertThat(deserialized.columnFiles()).isNull();
   }
 
   private static int pos(String fieldName) {

--- a/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
@@ -58,6 +58,8 @@ class TestTrackingBuilder {
     assertThat(existing.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
     assertThat(existing.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
     assertThat(existing.firstRowId()).isEqualTo(source.firstRowId());
+    assertThat(existing.latestColumnFileSnapshotId())
+        .isEqualTo(source.latestColumnFileSnapshotId());
   }
 
   @Test
@@ -72,6 +74,7 @@ class TestTrackingBuilder {
     assertThat(deleted.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
     assertThat(deleted.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
     assertThat(deleted.firstRowId()).isEqualTo(source.firstRowId());
+    assertThat(deleted.latestColumnFileSnapshotId()).isEqualTo(source.latestColumnFileSnapshotId());
   }
 
   @Test
@@ -86,13 +89,23 @@ class TestTrackingBuilder {
     assertThat(replaced.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
     assertThat(replaced.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
     assertThat(replaced.firstRowId()).isEqualTo(source.firstRowId());
+    assertThat(replaced.latestColumnFileSnapshotId())
+        .isEqualTo(source.latestColumnFileSnapshotId());
   }
 
   @Test
   void sourceDvPositionsAreNotCarriedForward() {
     Tracking source =
         new TrackingStruct(
-            EntryStatus.ADDED, 42L, 10L, 10L, 43L, 1000L, new byte[] {1, 2}, new byte[] {3, 4});
+            EntryStatus.ADDED,
+            42L,
+            10L,
+            10L,
+            43L,
+            1000L,
+            new byte[] {1, 2},
+            new byte[] {3, 4},
+            null);
 
     Tracking existing = TrackingBuilder.from(source, 1L).build();
     assertThat(existing.deletedPositions()).isNull();
@@ -177,7 +190,7 @@ class TestTrackingBuilder {
         .hasMessage("Invalid tracking source: data sequence number is null");
 
     TrackingStruct missingFileSeq =
-        new TrackingStruct(EntryStatus.ADDED, 42L, 10L, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, 42L, 10L, null, null, null, null, null, null);
 
     assertThatThrownBy(() -> TrackingBuilder.from(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
@@ -256,6 +269,8 @@ class TestTrackingBuilder {
     assertThat(carried.dataSequenceNumber()).isEqualTo(modifiedSource.dataSequenceNumber());
     assertThat(carried.fileSequenceNumber()).isEqualTo(modifiedSource.fileSequenceNumber());
     assertThat(carried.firstRowId()).isEqualTo(modifiedSource.firstRowId());
+    assertThat(carried.latestColumnFileSnapshotId())
+        .isEqualTo(modifiedSource.latestColumnFileSnapshotId());
   }
 
   @Test
@@ -272,15 +287,44 @@ class TestTrackingBuilder {
     assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
   }
 
+  @Test
+  void manifestPositionsWithColumnFilesUpdated() {
+    ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1});
+    Tracking withDeletedPositions =
+        TrackingBuilder.from(manifestSourceTracking(), 999L)
+            .columnFilesUpdated()
+            .deletedPositions(deletedBytes)
+            .build();
+
+    assertThat(withDeletedPositions.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(withDeletedPositions.latestColumnFileSnapshotId()).isEqualTo(999L);
+    assertThat(withDeletedPositions.dvSnapshotId()).isEqualTo(999L);
+    assertThat(withDeletedPositions.deletedPositions()).isEqualTo(deletedBytes);
+    assertThat(withDeletedPositions.dataSequenceNumber()).isNull();
+
+    ByteBuffer replacedBytes = ByteBuffer.wrap(new byte[] {2});
+    Tracking withReplacedPositions =
+        TrackingBuilder.from(manifestSourceTracking(), 999L)
+            .columnFilesUpdated()
+            .replacedPositions(replacedBytes)
+            .build();
+
+    assertThat(withReplacedPositions.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(withReplacedPositions.latestColumnFileSnapshotId()).isEqualTo(999L);
+    assertThat(withReplacedPositions.dvSnapshotId()).isEqualTo(999L);
+    assertThat(withReplacedPositions.replacedPositions()).isEqualTo(replacedBytes);
+    assertThat(withReplacedPositions.dataSequenceNumber()).isNull();
+  }
+
   private static TrackingStruct sourceTracking() {
     return sourceTrackingWithStatus(EntryStatus.ADDED);
   }
 
   private static TrackingStruct sourceTrackingWithStatus(EntryStatus status) {
-    return new TrackingStruct(status, 42L, 10L, 10L, 43L, 1000L, null, null);
+    return new TrackingStruct(status, 42L, 10L, 10L, 43L, 1000L, null, null, 15L);
   }
 
   private static TrackingStruct manifestSourceTracking() {
-    return new TrackingStruct(EntryStatus.ADDED, 42L, 10L, 10L, null, 1000L, null, null);
+    return new TrackingStruct(EntryStatus.ADDED, 42L, 10L, 10L, null, 1000L, null, null, null);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -40,7 +40,15 @@ class TestTrackingStruct {
   void fieldAccess() {
     TrackingStruct tracking =
         new TrackingStruct(
-            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+            EntryStatus.ADDED,
+            42L,
+            10L,
+            11L,
+            43L,
+            1000L,
+            DELETED_POSITIONS,
+            REPLACED_POSITIONS,
+            15L);
     tracking.setManifestLocation("manifest-location");
     tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
@@ -54,6 +62,7 @@ class TestTrackingStruct {
     assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
     assertThat(tracking.manifestLocation()).isEqualTo("manifest-location");
     assertThat(tracking.manifestPos()).isEqualTo(7L);
+    assertThat(tracking.latestColumnFileSnapshotId()).isEqualTo(15L);
   }
 
   @Test
@@ -68,6 +77,7 @@ class TestTrackingStruct {
     tracking.set(pos("first_row_id"), 1000L);
     tracking.set(pos("deleted_positions"), ByteBuffer.wrap(DELETED_POSITIONS));
     tracking.set(pos("replaced_positions"), ByteBuffer.wrap(REPLACED_POSITIONS));
+    tracking.set(pos("latest_column_file_snapshot_id"), 15L);
     tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
@@ -79,13 +89,22 @@ class TestTrackingStruct {
     assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
     assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
     assertThat(tracking.manifestPos()).isEqualTo(7L);
+    assertThat(tracking.latestColumnFileSnapshotId()).isEqualTo(15L);
   }
 
   @Test
   void getByPosition() {
     TrackingStruct tracking =
         new TrackingStruct(
-            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+            EntryStatus.ADDED,
+            42L,
+            10L,
+            11L,
+            43L,
+            1000L,
+            DELETED_POSITIONS,
+            REPLACED_POSITIONS,
+            15L);
     tracking.setManifestLocation("manifest-location");
     tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
@@ -100,13 +119,22 @@ class TestTrackingStruct {
     assertThat(tracking.get(pos("replaced_positions"), ByteBuffer.class))
         .isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
     assertThat(tracking.get(MANIFEST_POSITION_ORDINAL, Long.class)).isEqualTo(7L);
+    assertThat(tracking.get(pos("latest_column_file_snapshot_id"), Long.class)).isEqualTo(15L);
   }
 
   @Test
   void copy() {
     TrackingStruct tracking =
         new TrackingStruct(
-            EntryStatus.MODIFIED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+            EntryStatus.MODIFIED,
+            42L,
+            10L,
+            11L,
+            43L,
+            1000L,
+            DELETED_POSITIONS,
+            REPLACED_POSITIONS,
+            20L);
     tracking.setManifestLocation("manifest-location");
     tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
@@ -122,6 +150,7 @@ class TestTrackingStruct {
     assertThat(copy.replacedPositions()).isEqualTo(tracking.replacedPositions());
     assertThat(copy.manifestLocation()).isEqualTo(tracking.manifestLocation());
     assertThat(copy.manifestPos()).isEqualTo(tracking.manifestPos());
+    assertThat(copy.latestColumnFileSnapshotId()).isEqualTo(20L);
 
     // verify deep copy of ByteBuffer backing arrays
     assertThat(copy.deletedPositions().array()).isNotSameAs(tracking.deletedPositions().array());
@@ -131,7 +160,7 @@ class TestTrackingStruct {
   @Test
   void inheritSnapshotId() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -142,7 +171,7 @@ class TestTrackingStruct {
   @Test
   void inheritSequenceNumberForAddedEntries() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -154,7 +183,7 @@ class TestTrackingStruct {
   @Test
   void doNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.EXISTING, 42L, 5L, 6L, null, null, null, null);
+        new TrackingStruct(EntryStatus.EXISTING, 42L, 5L, 6L, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -166,7 +195,7 @@ class TestTrackingStruct {
   @Test
   void doNotInheritSequenceNumberForModifiedEntries() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.MODIFIED, 42L, 5L, 6L, null, null, null, null);
+        new TrackingStruct(EntryStatus.MODIFIED, 42L, 5L, 6L, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -176,9 +205,20 @@ class TestTrackingStruct {
   }
 
   @Test
+  void inheritDataSequenceNumberWithModifiedStatus() {
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.MODIFIED, 42L, null, 6L, null, null, null, null, 7L);
+
+    tracking.inheritFrom(createManifestTracking(100L, 60L));
+
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(60L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(6);
+  }
+
+  @Test
   void explicitValuesOverrideInheritance() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, 200L, 75L, 76L, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, 200L, 75L, 76L, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -191,10 +231,10 @@ class TestTrackingStruct {
   @Test
   void inheritFromRejectsUnequalSequenceNumbers() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null, null);
 
     TrackingStruct manifestTracking =
-        new TrackingStruct(EntryStatus.ADDED, 100L, 50L, 60L, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, 100L, 50L, 60L, null, null, null, null, null);
 
     assertThatThrownBy(() -> tracking.inheritFrom(manifestTracking))
         .isInstanceOf(IllegalArgumentException.class)
@@ -204,7 +244,7 @@ class TestTrackingStruct {
   @Test
   void noDefaultingWithoutInheritance() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null, null);
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -215,7 +255,7 @@ class TestTrackingStruct {
   @Test
   void inheritFromNullIsNoOp() {
     TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null, null);
 
     tracking.inheritFrom(null);
 
@@ -227,13 +267,22 @@ class TestTrackingStruct {
 
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
     return new TrackingStruct(
-        EntryStatus.ADDED, snapshotId, sequenceNumber, sequenceNumber, null, null, null, null);
+        EntryStatus.ADDED,
+        snapshotId,
+        sequenceNumber,
+        sequenceNumber,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   @ParameterizedTest
   @EnumSource(EntryStatus.class)
   void isLiveDelegatesToStatus(EntryStatus status) {
-    TrackingStruct tracking = new TrackingStruct(status, null, null, null, null, null, null, null);
+    TrackingStruct tracking =
+        new TrackingStruct(status, null, null, null, null, null, null, null, null);
 
     assertThat(tracking.isLive()).isEqualTo(status.isLive());
   }
@@ -242,7 +291,15 @@ class TestTrackingStruct {
   void internalSetIgnoresUnknownOrdinal() {
     TrackingStruct tracking =
         new TrackingStruct(
-            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+            EntryStatus.ADDED,
+            42L,
+            10L,
+            11L,
+            43L,
+            1000L,
+            DELETED_POSITIONS,
+            REPLACED_POSITIONS,
+            49L);
 
     // unknown ordinals from a newer format version are silently ignored
     tracking.internalSet(99, "value from a newer format");
@@ -256,6 +313,7 @@ class TestTrackingStruct {
     assertThat(tracking.firstRowId()).isEqualTo(1000L);
     assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
     assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
+    assertThat(tracking.latestColumnFileSnapshotId()).isEqualTo(49L);
   }
 
   @Test
@@ -283,7 +341,15 @@ class TestTrackingStruct {
       throws IOException, ClassNotFoundException {
     TrackingStruct tracking =
         new TrackingStruct(
-            EntryStatus.MODIFIED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+            EntryStatus.MODIFIED,
+            42L,
+            10L,
+            11L,
+            43L,
+            1000L,
+            DELETED_POSITIONS,
+            REPLACED_POSITIONS,
+            1L);
     tracking.setManifestLocation("manifest-location");
     tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
@@ -299,6 +365,7 @@ class TestTrackingStruct {
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
     assertThat(deserialized.manifestLocation()).isEqualTo("manifest-location");
     assertThat(deserialized.manifestPos()).isEqualTo(7L);
+    assertThat(deserialized.latestColumnFileSnapshotId()).isEqualTo(1L);
   }
 
   // Returns the positions of fields within the Tracking schema by name. For internal fields like

--- a/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
@@ -81,6 +81,23 @@ class TestV4ManifestReader {
   private static final List<FileFormat> MANIFEST_FORMATS =
       ImmutableList.of(FileFormat.AVRO, FileFormat.PARQUET);
 
+  private static final ColumnFile COLUMN_FILE_1 =
+      ColumnFileStruct.builder()
+          .formatVersion(FORMAT_VERSION_V4)
+          .fieldIds(List.of(1, 3))
+          .location("s3a://bucket/column_file_1.parquet")
+          .fileFormat(FileFormat.PARQUET)
+          .fileSizeInBytes(1024L)
+          .build();
+  private static final ColumnFile COLUMN_FILE_2 =
+      ColumnFileStruct.builder()
+          .formatVersion(FORMAT_VERSION_V4)
+          .fieldIds(List.of(2))
+          .location("s3a://bucket/column_file_2.parquet")
+          .fileFormat(FileFormat.PARQUET)
+          .fileSizeInBytes(512L)
+          .build();
+
   // a data file whose tracking carries every inheritable and change-tracking value set
   private static final TrackedFile FILE_WITH_FULL_TRACKING =
       new TrackedFileStruct(
@@ -93,7 +110,7 @@ class TestV4ManifestReader {
               8L, // first row id
               new byte[] {1, 2}, // deleted positions
               new byte[] {3, 4}, // replaced positions
-              null), // column files snapshot id
+              5L), // column files snapshot id
           FileContent.DATA,
           FORMAT_VERSION_V4,
           "s3://bucket/file.parquet",
@@ -109,7 +126,7 @@ class TestV4ManifestReader {
           null,
           null,
           null,
-          null);
+          ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
   // shared data files: FILE_A is in partition id=1, FILE_B in partition id=2. Locations are stored
   // relative to the table location (the default), so the reader resolves them against the table
@@ -147,7 +164,7 @@ class TestV4ManifestReader {
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L, 100L),
             null,
-            null);
+            ImmutableList.of(COLUMN_FILE_1, COLUMN_FILE_2));
 
     InputFile manifest = writeManifest(format, ID_PARTITION_TYPE, ImmutableList.of(file));
 
@@ -290,6 +307,7 @@ class TestV4ManifestReader {
       assertThat(actual.keyMetadata()).isNull();
       assertThat(actual.splitOffsets()).isNull();
       assertThat(actual.equalityIds()).isNull();
+      assertThat(actual.columnFiles()).isNull();
     }
   }
 
@@ -402,6 +420,7 @@ class TestV4ManifestReader {
       assertThat(actual.dvSnapshotId()).isNull();
       assertThat(actual.deletedPositions()).isNull();
       assertThat(actual.replacedPositions()).isNull();
+      assertThat(actual.latestColumnFileSnapshotId()).isNull();
     }
   }
 
@@ -426,6 +445,7 @@ class TestV4ManifestReader {
       assertThat(actual.dvSnapshotId()).isNull();
       assertThat(actual.deletedPositions()).isNull();
       assertThat(actual.replacedPositions()).isNull();
+      assertThat(actual.latestColumnFileSnapshotId()).isNull();
     }
   }
 
@@ -448,6 +468,7 @@ class TestV4ManifestReader {
       assertThat(actual.dvSnapshotId()).isEqualTo(7L);
       assertThat(actual.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
       assertThat(actual.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
+      assertThat(actual.latestColumnFileSnapshotId()).isEqualTo(5L);
     }
   }
 
@@ -467,6 +488,10 @@ class TestV4ManifestReader {
       assertThat(actual.fileFormat()).isEqualTo(FileFormat.PARQUET);
       assertThat(actual.recordCount()).isEqualTo(RECORD_COUNT);
       assertThat(actual.fileSizeInBytes()).isEqualTo(FILE_SIZE_IN_BYTES);
+      assertThat(actual.columnFiles())
+          .map(StructLike.class::cast)
+          .usingElementComparator(Comparators.forType(ColumnFile.schema()))
+          .containsExactly((StructLike) COLUMN_FILE_1, (StructLike) COLUMN_FILE_2);
     }
   }
 
@@ -772,6 +797,58 @@ class TestV4ManifestReader {
   public void resolvesLeafManifestLocation(FileFormat format) throws IOException {
     TrackedFile leaf = manifestRef(FileContent.DATA_MANIFEST, "metadata/leaf.avro");
     verifyLocationAfterWriteReadRoundTrip(format, leaf, resolved(leaf));
+  }
+
+  @ParameterizedTest
+  @FieldSource("MANIFEST_FORMATS")
+  public void resolvesColumnFileLocations(FileFormat format) throws IOException {
+    ColumnFile columnFile1 =
+        ColumnFileStruct.builder()
+            .formatVersion(FORMAT_VERSION_V4)
+            .fieldIds(List.of(1))
+            .location("data/col-1.parquet")
+            .fileFormat(FileFormat.PARQUET)
+            .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+            .build();
+    ColumnFile columnFile2 =
+        ColumnFileStruct.builder()
+            .formatVersion(FORMAT_VERSION_V4)
+            .fieldIds(List.of(2))
+            .location("other/col-2.parquet")
+            .fileFormat(FileFormat.PARQUET)
+            .fileSizeInBytes(FILE_SIZE_IN_BYTES)
+            .build();
+    TrackedFile file =
+        new TrackedFileStruct(
+            addedTracking(),
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            "s3://data/00000-0.parquet",
+            FileFormat.PARQUET,
+            RECORD_COUNT,
+            FILE_SIZE_IN_BYTES,
+            0, // spec_id
+            EMPTY_PARTITION_DATA,
+            null, // content_stats
+            null, // sort_order_id
+            null, // deletion_vector
+            null, // manifest_info
+            null, // key_metadata
+            null, // split_offsets
+            null, // equality_ids
+            ImmutableList.of(columnFile1, columnFile2));
+
+    InputFile manifest = writeManifest(format, EMPTY_PARTITION, ImmutableList.of(file));
+
+    try (V4ManifestReader reader =
+        V4ManifestReader.builder(manifest, UNPARTITIONED_SPECS, TABLE_LOCATION).build()) {
+      TrackedFile actual = Iterables.getOnlyElement(reader);
+      assertThat(actual.columnFiles())
+          .extracting(ColumnFile::location)
+          .containsExactly(
+              LocationUtil.resolveLocation(TABLE_LOCATION, "data/col-1.parquet"),
+              LocationUtil.resolveLocation(TABLE_LOCATION, "other/col-2.parquet"));
+    }
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestV4ManifestReader.java
@@ -92,7 +92,8 @@ class TestV4ManifestReader {
               7L, // dv snapshot id
               8L, // first row id
               new byte[] {1, 2}, // deleted positions
-              new byte[] {3, 4}), // replaced positions
+              new byte[] {3, 4}, // replaced positions
+              null), // column files snapshot id
           FileContent.DATA,
           FORMAT_VERSION_V4,
           "s3://bucket/file.parquet",
@@ -101,6 +102,7 @@ class TestV4ManifestReader {
           FILE_SIZE_IN_BYTES,
           0,
           EMPTY_PARTITION_DATA,
+          null,
           null,
           null,
           null,
@@ -144,6 +146,7 @@ class TestV4ManifestReader {
             null,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L, 100L),
+            null,
             null);
 
     InputFile manifest = writeManifest(format, ID_PARTITION_TYPE, ImmutableList.of(file));
@@ -183,7 +186,8 @@ class TestV4ManifestReader {
             null,
             null,
             null,
-            ImmutableList.of(1, 2));
+            ImmutableList.of(1, 2),
+            null);
 
     InputFile manifest = writeManifest(format, EMPTY_PARTITION, ImmutableList.of(delete));
 
@@ -893,7 +897,8 @@ class TestV4ManifestReader {
         null, // manifest_info
         null, // key_metadata
         null, // split_offsets
-        null); // equality_ids
+        null, // equality_ids
+        null); // column_files
   }
 
   private static TrackedFile dataFile(String location, Integer specId, PartitionData partition) {
@@ -913,7 +918,8 @@ class TestV4ManifestReader {
         null, // manifest_info
         null, // key_metadata
         null, // split_offsets
-        null); // equality_ids
+        null, // equality_ids
+        null); // column_files
   }
 
   private static TrackedFile deleteFile(String location, PartitionData partition) {
@@ -933,7 +939,8 @@ class TestV4ManifestReader {
         null, // manifest_info
         null, // key_metadata
         null, // split_offsets
-        ImmutableList.of(1)); // equality_ids
+        ImmutableList.of(1), // equality_ids
+        null); // column_files
   }
 
   private static TrackedFile manifestRef(FileContent content, String location) {
@@ -954,7 +961,8 @@ class TestV4ManifestReader {
         info,
         null, // key_metadata
         null, // split_offsets
-        null); // equality_ids
+        null, // equality_ids
+        null); // column_files
   }
 
   private static TrackedFile fileWithStatus(EntryStatus status, String location) {
@@ -967,7 +975,8 @@ class TestV4ManifestReader {
             null, // dv snapshot id
             null, // first row id
             null, // deleted positions
-            null); // replaced positions
+            null, // replaced positions
+            null); // column files snapshot id
     return new TrackedFileStruct(
         tracking,
         FileContent.DATA,
@@ -984,11 +993,13 @@ class TestV4ManifestReader {
         null,
         null,
         null,
+        null,
         null);
   }
 
   private static Tracking addedTracking() {
-    return new TrackingStruct(EntryStatus.ADDED, SNAPSHOT_ID, null, null, null, null, null, null);
+    return new TrackingStruct(
+        EntryStatus.ADDED, SNAPSHOT_ID, null, null, null, null, null, null, null);
   }
 
   private static PartitionData partition(int id) {


### PR DESCRIPTION
Locations of column files are resolved in the reader. Custom type for ColumnFile is mapped to field ID.