### PR TITLE
Core: Retry dropped JDBC connections reported as SQLRecoverableException

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.jdbc;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
 import java.sql.SQLTransientException;
 import java.util.Arrays;
 import java.util.Map;
@@ -106,9 +107,11 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
     }
   }
 
+  // Recovery from SQLRecoverableException requires a new connection, which reconnect() provides.
   @Override
   protected boolean isConnectionException(Exception e) {
     return super.isConnectionException(e)
+        || e instanceof SQLRecoverableException
         || (e instanceof SQLException
             && retryableStatusCodes.contains(((SQLException) e).getSQLState()));
   }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcClientPool.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcClientPool.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TestJdbcClientPool {
+
+  private final JdbcClientPool pool =
+      new JdbcClientPool("jdbc:sqlite:file::memory:", ImmutableMap.of());
+
+  @AfterEach
+  void closePool() {
+    pool.close();
+  }
+
+  @Test
+  void connectionIsReplacedAfterRecoverableFailure() throws Exception {
+    AtomicInteger attempts = new AtomicInteger();
+
+    boolean valid =
+        pool.run(
+            client -> {
+              if (attempts.getAndIncrement() == 0) {
+                throw new CommunicationsFailure();
+              }
+              return client.isValid(1);
+            });
+
+    assertThat(valid).isTrue();
+    assertThat(attempts).hasValue(2);
+  }
+
+  @Test
+  void recoverableExceptionIsRetried() {
+    assertThat(pool.isConnectionException(new SQLRecoverableException("connection closed")))
+        .isTrue();
+  }
+
+  @Test
+  void otherExceptionIsNotRetried() {
+    assertThat(pool.isConnectionException(new SQLNonTransientException("syntax error", "42000")))
+        .isFalse();
+  }
+
+  /**
+   * Mirrors {@code com.mysql.cj.jdbc.exceptions.CommunicationsException}, whose SQLSTATE is not in
+   * {@link JdbcClientPool#COMMON_RETRYABLE_CONNECTION_SQL_STATES}.
+   */
+  private static class CommunicationsFailure extends SQLRecoverableException {
+    CommunicationsFailure() {
+      super("Communications link failure", "08S01");
+    }
+  }
+}


### PR DESCRIPTION
Closes #17829

`JdbcClientPool` recovers from connection failures by reconnecting, but only for
`SQLTransientException` and the SQLSTATEs in `COMMON_RETRYABLE_CONNECTION_SQL_STATES`.
Drivers that report a dropped connection as `SQLRecoverableException` match neither, so
the operation fails and `ClientPoolImpl.release` returns the dead connection to the head
of the pool for the next caller.

MySQL is one such driver: `CommunicationsException` extends `SQLRecoverableException` and
carries SQLSTATE `08S01`, which is not in the default set.

This treats `SQLRecoverableException` as retryable. The JDBC contract for that type is that
recovery requires closing the connection and getting a new one, which is what `reconnect`
does. `maxRetries` is unchanged, so a non-recoverable case costs one reconnect attempt
before the original exception propagates.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: GitHub Copilot
- Human Oversight: Reviewed
- Prompt Summary: Diagnose why a MySQL-backed JDBC catalog never recovers from a dropped connection, and implement the fix with a test.
