### PR TITLE
REST: re-install lazy snapshots supplier on refresh in refs mode

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1302,7 +1302,16 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableMetadata current,
       Set<Endpoint> supportedEndpoints) {
     return new RESTTableOperations(
-        restClient, path, readHeaders, mutationHeaderSupplier, fileIO, current, supportedEndpoints);
+        restClient,
+        path,
+        readHeaders,
+        mutationHeaderSupplier,
+        fileIO,
+        RESTTableOperations.UpdateType.SIMPLE,
+        Lists.newArrayList(),
+        current,
+        supportedEndpoints,
+        snapshotMode);
   }
 
   /**
@@ -1344,7 +1353,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         updateType,
         createChanges,
         current,
-        supportedEndpoints);
+        supportedEndpoints,
+        snapshotMode);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -38,7 +39,9 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -62,6 +65,7 @@ class RESTTableOperations implements TableOperations {
   private final TableMetadata replaceBase;
   private final Set<Endpoint> endpoints;
   private UpdateType updateType;
+  private final SnapshotMode snapshotMode;
   private TableMetadata current;
 
   RESTTableOperations(
@@ -80,7 +84,8 @@ class RESTTableOperations implements TableOperations {
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
-        endpoints);
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -92,7 +97,17 @@ class RESTTableOperations implements TableOperations {
       List<MetadataUpdate> createChanges,
       TableMetadata current,
       Set<Endpoint> endpoints) {
-    this(client, path, headers, headers, io, updateType, createChanges, current, endpoints);
+    this(
+        client,
+        path,
+        headers,
+        headers,
+        io,
+        updateType,
+        createChanges,
+        current,
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -112,7 +127,8 @@ class RESTTableOperations implements TableOperations {
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
-        endpoints);
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -124,7 +140,8 @@ class RESTTableOperations implements TableOperations {
       UpdateType updateType,
       List<MetadataUpdate> createChanges,
       TableMetadata current,
-      Set<Endpoint> endpoints) {
+      Set<Endpoint> endpoints,
+      SnapshotMode snapshotMode) {
     this.client = client;
     this.path = path;
     this.readHeaders = readHeaders;
@@ -139,6 +156,7 @@ class RESTTableOperations implements TableOperations {
       this.current = current;
     }
     this.endpoints = endpoints;
+    this.snapshotMode = snapshotMode != null ? snapshotMode : SnapshotMode.ALL;
   }
 
   @Override
@@ -150,7 +168,12 @@ class RESTTableOperations implements TableOperations {
   public TableMetadata refresh() {
     Endpoint.check(endpoints, Endpoint.V1_LOAD_TABLE);
     return updateCurrentMetadata(
-        client.get(path, LoadTableResponse.class, readHeaders, ErrorHandlers.tableErrorHandler()));
+        client.get(
+            path,
+            snapshotModeToParam(snapshotMode),
+            LoadTableResponse.class,
+            readHeaders,
+            ErrorHandlers.tableErrorHandler()));
   }
 
   @Override
@@ -291,10 +314,34 @@ class RESTTableOperations implements TableOperations {
     // safely ignored. there is no requirement to update config on refresh or commit.
     if (current == null
         || !Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
-      this.current = checkUUID(current, response.tableMetadata());
+      TableMetadata refreshed = checkUUID(current, response.tableMetadata());
+      if (snapshotMode == SnapshotMode.REFS) {
+        refreshed =
+            TableMetadata.buildFrom(refreshed)
+                .withMetadataLocation(response.metadataLocation())
+                .setPreviousFileLocation(null)
+                .setSnapshotsSupplier(
+                    () ->
+                        client.get(
+                                path,
+                                snapshotModeToParam(SnapshotMode.ALL),
+                                LoadTableResponse.class,
+                                readHeaders,
+                                ErrorHandlers.tableErrorHandler())
+                            .tableMetadata()
+                            .snapshots())
+                .discardChanges()
+                .build();
+      }
+      this.current = refreshed;
     }
 
     return current;
+  }
+
+  private static Map<String, String> snapshotModeToParam(SnapshotMode mode) {
+    return ImmutableMap.of(
+        RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, mode.name().toLowerCase(Locale.US));
   }
 
   private static TableMetadata checkUUID(TableMetadata currentMetadata, TableMetadata newMetadata) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1123,6 +1123,73 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
   }
 
+  @Test
+  public void testTableSnapshotLoadingRefreshKeepsLazySupplier() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            // default loading to refs only
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            SnapshotMode.REFS.name()));
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(TABLE.namespace());
+    }
+
+    Table table = catalog.createTable(TABLE, SCHEMA);
+
+    for (int i = 0; i < 3; i++) {
+      table
+          .newFastAppend()
+          .appendFile(
+              DataFiles.builder(PartitionSpec.unpartitioned())
+                  .withPath(String.format("/path/to/data-%s.parquet", i))
+                  .withFileSizeInBytes(10)
+                  .withRecordCount(2)
+                  .build())
+          .commit();
+    }
+
+    Table refsTable = catalog.loadTable(TABLE);
+
+    // load in refs mode: only the retained ref snapshot is loaded eagerly
+    assertThat(((BaseTable) refsTable).operations().current())
+        .extracting("snapshots")
+        .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
+        .hasSize(1);
+
+    // advance the table so the metadata location changes, then refresh
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-adv.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    // refresh must re-install the lazy snapshots supplier in refs mode
+    refsTable.refresh();
+
+    // still partial after refresh (refs mode) -- supplier must be re-installed
+    assertThat(((BaseTable) refsTable).operations().current())
+        .extracting("snapshots")
+        .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
+        .hasSize(1);
+
+    // resolving all snapshots must lazy-load the full history via the reinstalled supplier
+    assertThat(refsTable.snapshots()).hasSize(4);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"1", "2"})
   public void testTableSnapshotLoadingWithDivergedBranches(String formatVersion) {


### PR DESCRIPTION
## Problem

When a table is loaded with `snapshot-loading-mode=refs`, `RESTSessionCatalog.loadTable()` wraps the returned `TableMetadata` with a lazy `snapshotsSupplier` so that resolving a snapshot outside the retained-refs window transparently re-fetches the full snapshot history (`snapshots=all`). That lazy fallback is **lost on every subsequent `table.refresh()` (and commit)**, because `RESTTableOperations` neither sends the snapshot mode on refresh nor re-installs the supplier. The refreshed metadata is therefore partial with no fallback, and any code path that resolves a snapshot outside the refs window returns `null` and throws.

Spark Structured Streaming and Flink streaming are affected, because both call `table.refresh()` every micro-batch/cycle and then walk snapshot ancestry incrementally.

## Fix

Thread the `SnapshotMode` into `RESTTableOperations` (constructor param, passed from the `newTableOps(...)` builders in `RESTSessionCatalog`), send it as the `snapshots` query parameter on `refresh()`, and re-install the lazy `snapshotsSupplier` in `REFS` mode whenever the metadata location changes (`updateCurrentMetadata`).

- In the default (`ALL`) mode this is a **no-op** — identical to today.
- In `refs` mode it is a correctness improvement: a lagging streaming job triggers one full `snapshots=all` fetch only on the refresh cycle that actually needs history.

## Test

Added `testTableSnapshotLoadingRefreshKeepsLazySupplier` in `TestRESTCatalog` which loads a table in `refs` mode, advances the table so the metadata location changes, refreshes, and asserts the lazy supplier is re-installed and can still resolve the full snapshot history.

Fixes #17830
