### PR TITLE
Core, OpenAPI: Preserve content file sequence numbers in JSON serialization

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -48,6 +48,8 @@ public class ContentFileParser {
   private static final String EQUALITY_IDS = "equality-ids";
   private static final String SORT_ORDER_ID = "sort-order-id";
   private static final String FIRST_ROW_ID = "first-row-id";
+  private static final String DATA_SEQUENCE_NUMBER = "data-sequence-number";
+  private static final String FILE_SEQUENCE_NUMBER = "file-sequence-number";
   private static final String REFERENCED_DATA_FILE = "referenced-data-file";
   private static final String CONTENT_OFFSET = "content-offset";
   private static final String CONTENT_SIZE = "content-size-in-bytes";
@@ -122,6 +124,10 @@ public class ContentFileParser {
     }
 
     JsonUtil.writeLongFieldIfPresent(FIRST_ROW_ID, contentFile.firstRowId(), generator);
+    JsonUtil.writeLongFieldIfPresent(
+        DATA_SEQUENCE_NUMBER, contentFile.dataSequenceNumber(), generator);
+    JsonUtil.writeLongFieldIfPresent(
+        FILE_SEQUENCE_NUMBER, contentFile.fileSequenceNumber(), generator);
 
     if (contentFile instanceof DeleteFile) {
       DeleteFile deleteFile = (DeleteFile) contentFile;
@@ -173,35 +179,54 @@ public class ContentFileParser {
     String referencedDataFile = JsonUtil.getStringOrNull(REFERENCED_DATA_FILE, jsonNode);
     Long contentOffset = JsonUtil.getLongOrNull(CONTENT_OFFSET, jsonNode);
     Long contentSizeInBytes = JsonUtil.getLongOrNull(CONTENT_SIZE, jsonNode);
+    Long dataSequenceNumber = JsonUtil.getLongOrNull(DATA_SEQUENCE_NUMBER, jsonNode);
+    Long fileSequenceNumber = JsonUtil.getLongOrNull(FILE_SEQUENCE_NUMBER, jsonNode);
 
     if (fileContent == FileContent.DATA) {
-      return new GenericDataFile(
-          specId,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          keyMetadata,
-          splitOffsets,
-          sortOrderId,
-          firstRowId);
+      GenericDataFile dataFile =
+          new GenericDataFile(
+              specId,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              keyMetadata,
+              splitOffsets,
+              sortOrderId,
+              firstRowId);
+      setSequenceNumbers(dataFile, dataSequenceNumber, fileSequenceNumber);
+      return dataFile;
     } else {
-      return new GenericDeleteFile(
-          specId,
-          fileContent,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          equalityFieldIds,
-          sortOrderId,
-          splitOffsets,
-          keyMetadata,
-          referencedDataFile,
-          contentOffset,
-          contentSizeInBytes);
+      GenericDeleteFile deleteFile =
+          new GenericDeleteFile(
+              specId,
+              fileContent,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              equalityFieldIds,
+              sortOrderId,
+              splitOffsets,
+              keyMetadata,
+              referencedDataFile,
+              contentOffset,
+              contentSizeInBytes);
+      setSequenceNumbers(deleteFile, dataSequenceNumber, fileSequenceNumber);
+      return deleteFile;
+    }
+  }
+
+  private static void setSequenceNumbers(
+      BaseFile<?> file, Long dataSequenceNumber, Long fileSequenceNumber) {
+    if (dataSequenceNumber != null) {
+      file.setDataSequenceNumber(dataSequenceNumber);
+    }
+
+    if (fileSequenceNumber != null) {
+      file.setFileSequenceNumber(fileSequenceNumber);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
@@ -79,6 +79,38 @@ public class TestContentFileParser {
     assertContentFileEquals(dataFile, deserialized, spec);
   }
 
+  @Test
+  public void testDataFileSequenceNumbers() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    GenericDataFile dataFile = (GenericDataFile) dataFileWithRequiredOnly(spec);
+    dataFile.setDataSequenceNumber(3L);
+    dataFile.setFileSequenceNumber(2L);
+
+    String jsonStr = ContentFileParser.toJson(dataFile, spec);
+    assertThat(jsonStr).contains("\"data-sequence-number\":3");
+    assertThat(jsonStr).contains("\"file-sequence-number\":2");
+
+    JsonNode jsonNode = JsonUtil.mapper().readTree(jsonStr);
+    ContentFile<?> deserialized = ContentFileParser.fromJson(jsonNode, Map.of(spec.specId(), spec));
+    assertContentFileEquals(dataFile, deserialized, spec);
+  }
+
+  @Test
+  public void testDeleteFileSequenceNumbers() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    GenericDeleteFile deleteFile = (GenericDeleteFile) deleteFileWithRequiredOnly(spec);
+    deleteFile.setDataSequenceNumber(3L);
+    deleteFile.setFileSequenceNumber(2L);
+
+    String jsonStr = ContentFileParser.toJson(deleteFile, spec);
+    assertThat(jsonStr).contains("\"data-sequence-number\":3");
+    assertThat(jsonStr).contains("\"file-sequence-number\":2");
+
+    JsonNode jsonNode = JsonUtil.mapper().readTree(jsonStr);
+    ContentFile<?> deserialized = ContentFileParser.fromJson(jsonNode, Map.of(spec.specId(), spec));
+    assertContentFileEquals(deleteFile, deserialized, spec);
+  }
+
   @ParameterizedTest
   @MethodSource("provideSpecAndDataFile")
   public void testDataFile(PartitionSpec spec, DataFile dataFile, String expectedJson)
@@ -611,5 +643,7 @@ public class TestContentFileParser {
     assertThat(actual.splitOffsets()).isEqualTo(expected.splitOffsets());
     assertThat(actual.equalityFieldIds()).isEqualTo(expected.equalityFieldIds());
     assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
+    assertThat(actual.dataSequenceNumber()).isEqualTo(expected.dataSequenceNumber());
+    assertThat(actual.fileSequenceNumber()).isEqualTo(expected.fileSequenceNumber());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
@@ -74,6 +74,33 @@ public class TestFileScanTaskParser {
     assertFileScanTaskEquals(expected, deserializedTask, spec, caseSensitive);
   }
 
+  @Test
+  public void testSequenceNumbersPreserved() {
+    boolean caseSensitive = true;
+    PartitionSpec spec = TestBase.SPEC;
+    GenericDataFile dataFile = (GenericDataFile) TestBase.FILE_A.copy();
+    dataFile.setDataSequenceNumber(5L);
+    dataFile.setFileSequenceNumber(4L);
+    GenericDeleteFile deleteFile = (GenericDeleteFile) TestBase.FILE_A_DELETES.copy();
+    deleteFile.setDataSequenceNumber(6L);
+    deleteFile.setFileSequenceNumber(6L);
+
+    FileScanTask fileScanTask =
+        new BaseFileScanTask(
+            dataFile,
+            new DeleteFile[] {deleteFile},
+            SchemaParser.toJson(TestBase.SCHEMA),
+            PartitionSpecParser.toJson(spec),
+            ResidualEvaluator.of(spec, Expressions.equal("id", 1), caseSensitive));
+
+    FileScanTask deserializedTask =
+        ScanTaskParser.fromJson(ScanTaskParser.toJson(fileScanTask), caseSensitive);
+
+    assertFileScanTaskEquals(fileScanTask, deserializedTask, spec, caseSensitive);
+    assertThat(deserializedTask.file().dataSequenceNumber()).isEqualTo(5L);
+    assertThat(deserializedTask.deletes().get(0).dataSequenceNumber()).isEqualTo(6L);
+  }
+
   private FileScanTask createFileScanTask(PartitionSpec spec, boolean caseSensitive) {
     ResidualEvaluator residualEvaluator;
     if (spec.isUnpartitioned()) {

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1101,6 +1101,16 @@ class ContentFile(BaseModel):
         None, alias='split-offsets', description='List of splittable offsets'
     )
     sort_order_id: int | None = Field(None, alias='sort-order-id')
+    data_sequence_number: int | None = Field(
+        None,
+        alias='data-sequence-number',
+        description='The data sequence number of the file, assigned when the file was added to the table. Delete files apply only to data files with an equal or smaller data sequence number, so this field is needed to correctly apply deletes when file scan tasks are exchanged between services, such as in server-side scan planning responses',
+    )
+    file_sequence_number: int | None = Field(
+        None,
+        alias='file-sequence-number',
+        description='The sequence number of the snapshot in which the file was added to the table',
+    )
 
 
 class PositionDeleteFile(ContentFile):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5222,6 +5222,20 @@ components:
           description: "List of splittable offsets"
         sort-order-id:
           type: integer
+        data-sequence-number:
+          type: integer
+          format: int64
+          description:
+            The data sequence number of the file, assigned when the file was added to the
+            table. Delete files apply only to data files with an equal or smaller data
+            sequence number, so this field is needed to correctly apply deletes when file
+            scan tasks are exchanged between services, such as in server-side scan planning
+            responses
+        file-sequence-number:
+          type: integer
+          format: int64
+          description:
+            The sequence number of the snapshot in which the file was added to the table
 
     DataFile:
       allOf:


### PR DESCRIPTION
Closes #17833 

ContentFileParser omits `dataSequenceNumber` and `fileSequenceNumber` when
serializing content files, and the REST `ContentFile` schema does not define
them. Any file scan task that crosses through the
server-side scan planning endpoints arrives with null sequence numbers on
its delete files.

Delete files apply only to data files with an equal or smaller data sequence
number, so a merge-on-read scan built from such tasks cannot evaluate delete
applicability. 

I hit this running an engine's full connector test suite
against a REST catalog that implements the scan planning endpoints: every
DELETE/UPDATE/MERGE-related test failed with an NPE unboxing
`DeleteFile.dataSequenceNumber()`, while append-only tables were unaffected.
With this fix applied on both sides, the same suite passes: 76 tests,
0 failures (previously 7 merge-on-read errors).

Changes:
- `ContentFileParser` writes `data-sequence-number` and
  `file-sequence-number` when present, and restores them on read
- The REST `ContentFile` schema documents both optional fields
  (regenerated model included)
- Round-trip coverage in `TestContentFileParser` (the comparator now also
  checks sequence numbers for every existing case) and a scan task
  round-trip in `TestFileScanTaskParser`

Both directions stay compatible: readers ignore unknown fields, and JSON
written without the fields deserializes exactly as before.