### PR TITLE
OpenAPI: Replace legacy nullable fields with OpenAPI 3.1 null types

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -96,7 +96,7 @@ class Namespace(RootModel[list[str]]):
 
 class PageToken(RootModel[str | None]):
     root: str | None = Field(
-        None,
+        ...,
         description='An opaque token that allows clients to make use of pagination for list APIs (e.g. ListTables). Clients may initiate the first paginated request by sending an empty query parameter `pageToken` to the server.\nServers that support pagination should identify the `pageToken` parameter and return a `next-page-token` in the response if there are more results available.  After the initial request, the value of `next-page-token` from each response must be used as the `pageToken` parameter value for the next request. The server must return `null` value for the `next-page-token` in the last response.\nServers that support pagination must return all results in a single response with the value of `next-page-token` set to `null` if the query parameter `pageToken` is not set in the request.\nServers that do not support pagination should ignore the `pageToken` parameter and return all results in a single response. The `next-page-token` must be omitted from the response.\nClients must interpret either `null` or missing response value of `next-page-token` as the end of the listing results.',
     )
 
@@ -578,7 +578,7 @@ class AssertRefSnapshotId(TableRequirement):
 
     type: Literal['assert-ref-snapshot-id']
     ref: str
-    snapshot_id: int = Field(..., alias='snapshot-id')
+    snapshot_id: int | None = Field(..., alias='snapshot-id')
 
 
 class AssertLastAssignedFieldId(TableRequirement):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2395,8 +2395,9 @@ components:
         Clients must interpret either `null` or missing response value of `next-page-token` as
         the end of the listing results.
 
-      type: string
-      nullable: true
+      type:
+        - string
+        - "null"
 
     TableIdentifier:
       type: object
@@ -2408,7 +2409,6 @@ components:
           $ref: '#/components/schemas/Namespace'
         name:
           type: string
-          nullable: false
 
     CatalogObjectIdentifier:
       description:
@@ -3724,9 +3724,10 @@ components:
         ref:
           type: string
         snapshot-id:
-          type: integer
+          type:
+            - integer
+            - "null"
           format: int64
-          nullable: true
 
     AssertLastAssignedFieldId:
       description:
@@ -3902,9 +3903,10 @@ components:
         - metadata
       properties:
         metadata-location:
-          type: string
+          type:
+            - string
+            - "null"
           description: May be null if the table is staged as part of a transaction
-          nullable: true
         metadata:
           $ref: '#/components/schemas/TableMetadata'
         config:
@@ -4581,16 +4583,17 @@ components:
         namespace:
           $ref: '#/components/schemas/Namespace'
         properties:
-          type: object
+          anyOf:
+            - type: object
+              additionalProperties:
+                type: string
+            - type: "null"
           description:
             Properties stored on the namespace, if supported by the server.
             If the server does not support namespace properties, it should return null for this field.
             If namespace properties are supported, but none are set, it should return an empty object.
-          additionalProperties:
-            type: string
           example: { "owner": "Ralph", 'transient_lastDdlTime': '1452120468' }
           default: { }
-          nullable: true
 
     ListTablesResponse:
       type: object
@@ -4919,14 +4922,15 @@ components:
           items:
             type: string
         missing:
-          type: array
+          type:
+            - array
+            - "null"
           items:
             type: string
           description:
             List of properties requested for removal that were not found
             in the namespace's properties. Represents a partial success response.
             Server's do not need to implement this.
-          nullable: true
 
     CommitTableResponse:
       type: object


### PR DESCRIPTION
## Description

Updates the REST Catalog OpenAPI schema to use OpenAPI 3.1 null types instead of the legacy `nullable` keyword.

This ensures generated models correctly handle nullable values, including the required but nullable `snapshot-id` field. The generated Python models are updated accordingly.