### PR TITLE
Azure: Merge ContextAccessor service registrations in shaded bundle

### DIFF
--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -42,6 +42,7 @@ project(":iceberg-azure-bundle") {
   shadowJar {
     archiveClassifier.set(null)
     zip64 true
+    mergeServiceFiles()
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -55,6 +55,13 @@ project(":iceberg-azure-bundle") {
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.azure.shaded.com.fasterxml.jackson'
   }
 
+  test {
+    useJUnitPlatform()
+    dependsOn shadowJar
+    inputs.file shadowJar.archiveFile
+    systemProperty 'azure.test.bundle.jar', shadowJar.archiveFile.get().asFile.absolutePath
+  }
+
   jar {
     enabled = false
   }

--- a/azure-bundle/src/test/java/org/apache/iceberg/azure/TestAzureBundle.java
+++ b/azure-bundle/src/test/java/org/apache/iceberg/azure/TestAzureBundle.java
@@ -28,8 +28,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import org.junit.jupiter.api.Test;
 
-// this test ensures the azure bundle service registrations contain all entries across all bundled deps
-// for ContextAccessor specifically, we expect entries from reactor core and reactor netty
+// this test ensures the azure bundle service registrations contain all entries across all bundled
+// deps. For ContextAccessor specifically, we expect entries from reactor core and reactor netty
 class TestAzureBundle {
 
   @Test
@@ -38,7 +38,8 @@ class TestAzureBundle {
     assertThat(bundlePath).as("Azure bundle path").isNotNull();
 
     try (JarFile bundle = new JarFile(new File(bundlePath))) {
-      JarEntry serviceDescriptor = bundle.getJarEntry("META-INF/services/io.micrometer.context.ContextAccessor");
+      JarEntry serviceDescriptor =
+          bundle.getJarEntry("META-INF/services/io.micrometer.context.ContextAccessor");
       assertThat(serviceDescriptor).as("ContextAccessor service descriptor").isNotNull();
 
       try (InputStream input = bundle.getInputStream(serviceDescriptor)) {

--- a/azure-bundle/src/test/java/org/apache/iceberg/azure/TestAzureBundle.java
+++ b/azure-bundle/src/test/java/org/apache/iceberg/azure/TestAzureBundle.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.Test;
+
+// this test ensures the azure bundle service registrations contain all entries across all bundled deps
+// for ContextAccessor specifically, we expect entries from reactor core and reactor netty
+class TestAzureBundle {
+
+  @Test
+  void shadowJar_containsAllContextAccessorServiceRegistrations() throws IOException {
+    String bundlePath = System.getProperty("azure.test.bundle.jar");
+    assertThat(bundlePath).as("Azure bundle path").isNotNull();
+
+    try (JarFile bundle = new JarFile(new File(bundlePath))) {
+      JarEntry serviceDescriptor = bundle.getJarEntry("META-INF/services/io.micrometer.context.ContextAccessor");
+      assertThat(serviceDescriptor).as("ContextAccessor service descriptor").isNotNull();
+
+      try (InputStream input = bundle.getInputStream(serviceDescriptor)) {
+        assertThat(new String(input.readAllBytes(), UTF_8).split("\\R"))
+            .contains(
+                "reactor.netty.contextpropagation.ChannelContextAccessor",
+                "reactor.util.context.ReactorContextAccessor");
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Azure bundle shades Reactor Core and Reactor Netty, which both contribute implementations for `META-INF/services/io.micrometer.context.ContextAccessor`

Because duplicate service descriptors are [not merged by default](https://gradleup.com/shadow/configuration/merging/#__tabbed_2_1), the resulting bundle preserves the Reactor Netty registration but drops `reactor.util.context.ReactorContextAccessor`. The implementation class (ReactorContextAccessor) remains in the jar, micrometer cannot discover it through ServiceLoader, meaning we get "No ContextAccessor for contextType" failures at runtime during any azure operations that use ReactorContext when micrometer context propagation is active.

The two entries for the same service descriptor that are overwriting eachother:
* [reactor.netty.contextpropagation.ChannelContextAccessor](https://sourcegraph.com/r/github.com/reactor/reactor-netty/-/blob/reactor-netty-core/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor)
* [reactor.util.context.ReactorContextAccessor](https://sourcegraph.com/r/github.com/reactor/reactor-core/-/blob/reactor-core/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor?L1)

This PR should merge the ContextAccessor service descriptor to contain both of these implementation so service loader can find both [on load](https://sourcegraph.com/r/github.com/micrometer-metrics/context-propagation/-/blob/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java?L189) and ReactorContext can successfully be read.

A backport to the Iceberg 1.10.x release channel is also requested because affected downstream releases are based on Iceberg 1.10.0.