### PR TITLE
Spark: Backport the branch write options to Spark 3.5 and Spark 4.0

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -2981,21 +2981,21 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     ImmutableList<Object[]> expectedRows =
         ImmutableList.of(row(-1), row(0), row(1), row(2), row(3), row(4));
 
+    // writing to explicit branch should succeed even with WAP branch set
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        sql(
-                            "MERGE INTO %s t USING source s ON t.id = s.id "
-                                + "WHEN MATCHED THEN UPDATE SET *"
-                                + "WHEN NOT MATCHED THEN INSERT *",
-                            commitTarget()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                    String.format(
-                        "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
-                        branch)));
+        () -> {
+          sql(
+              "MERGE INTO %s t USING source s ON t.id = s.id "
+                  + "WHEN MATCHED THEN UPDATE SET *"
+                  + "WHEN NOT MATCHED THEN INSERT *",
+              commitTarget());
+
+          assertEquals(
+              "Should have expected rows in explicit branch",
+              expectedRows,
+              sql("SELECT * FROM %s ORDER BY id", commitTarget()));
+        });
   }
 
   private void checkJoinAndFilterConditions(String query, String join, String icebergFilters) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -1501,15 +1501,17 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
         tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
 
+    // writing to explicit branch should succeed even with WAP branch set
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
-        () ->
-            assertThatThrownBy(() -> sql("UPDATE %s SET dep='hr' WHERE dep='a'", commitTarget()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                    String.format(
-                        "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
-                        branch)));
+        () -> {
+          sql("UPDATE %s SET dep='software' WHERE dep='hr'", commitTarget());
+
+          assertEquals(
+              "Should have updated row in explicit branch",
+              ImmutableList.of(row(1, "software")),
+              sql("SELECT * FROM %s ORDER BY id", commitTarget()));
+        });
   }
 
   private RowLevelOperationMode mode(Table table) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -490,6 +490,17 @@ public class SparkWriteConf {
   }
 
   public String branch() {
+    String optionBranch = confParser.stringConf().option(SparkWriteOptions.BRANCH).parseOptional();
+    ValidationException.check(
+        branch == null || optionBranch == null || optionBranch.equals(branch),
+        "Must not specify different branches in both table identifier and write option, "
+            + "got [%s] in identifier and [%s] in options",
+        branch,
+        optionBranch);
+    if (optionBranch != null) {
+      return optionBranch;
+    }
+
     if (wapEnabled()) {
       String wapId = wapId();
       String wapBranch =

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -497,8 +497,9 @@ public class SparkWriteConf {
             + "got [%s] in identifier and [%s] in options",
         branch,
         optionBranch);
-    if (optionBranch != null) {
-      return optionBranch;
+    String inputBranch = branch != null ? branch : optionBranch;
+    if (inputBranch != null) {
+      return inputBranch;
     }
 
     if (wapEnabled()) {
@@ -513,12 +514,6 @@ public class SparkWriteConf {
           wapBranch);
 
       if (wapBranch != null) {
-        ValidationException.check(
-            branch == null,
-            "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [%s]",
-            branch,
-            wapBranch);
-
         return wapBranch;
       }
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -23,6 +23,9 @@ public class SparkWriteOptions {
 
   private SparkWriteOptions() {}
 
+  // Overrides the target branch for write operations
+  public static final String BRANCH = "branch";
+
   // Fileformat for write operations(default: Table write.format.default )
   public static final String WRITE_FORMAT = "write-format";
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -115,6 +115,26 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void writeBranchOptionTakesPrecedenceOverWapBranch() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wapBranch"),
+        () -> {
+          // With WAP enabled and no write option, the session WAP branch is used.
+          SparkWriteConf wapConf = new SparkWriteConf(spark, table, null, ImmutableMap.of());
+          assertThat(wapConf.branch()).isEqualTo("wapBranch");
+
+          // The branch write option takes precedence over the session WAP branch.
+          SparkWriteConf optionConf =
+              new SparkWriteConf(
+                  spark, table, null, ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+          assertThat(optionConf.branch()).isEqualTo("branchA");
+        });
+  }
+
+  @TestTemplate
   public void testOptionCaseInsensitive() {
     Table table = validationCatalog.loadTable(tableIdent);
     Map<String, String> options = ImmutableMap.of("option", "value");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.deletes.DeleteGranularity;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.internal.SQLConf;
@@ -82,6 +83,35 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   @AfterEach
   public void after() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void writeBranchOption() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkWriteConf branchFromOption =
+        new SparkWriteConf(
+            spark, table, null, ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+    assertThat(branchFromOption.branch()).isEqualTo("branchA");
+
+    SparkWriteConf matchingIdentifierAndOption =
+        new SparkWriteConf(
+            spark, table, "branchA", ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+    assertThat(matchingIdentifierAndOption.branch()).isEqualTo("branchA");
+  }
+
+  @TestTemplate
+  public void writeBranchOptionConflictsWithIdentifier() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkWriteConf conflicting =
+        new SparkWriteConf(
+            spark, table, "branchB", ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+
+    assertThatThrownBy(conflicting::branch)
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+            "Must not specify different branches in both table identifier and write option");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -135,6 +135,21 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void writeIdentifierBranchTakesPrecedenceOverWapBranch() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wapBranch"),
+        () -> {
+          // The identifier branch takes precedence over the session WAP branch.
+          SparkWriteConf identifierConf =
+              new SparkWriteConf(spark, table, "branchA", ImmutableMap.of());
+          assertThat(identifierConf.branch()).isEqualTo("branchA");
+        });
+  }
+
+  @TestTemplate
   public void testOptionCaseInsensitive() {
     Table table = validationCatalog.loadTable(tableIdent);
     Map<String, String> options = ImmutableMap.of("option", "value");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -25,9 +25,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkTableProperties;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -54,6 +58,45 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void writeToBranchOptionTakesPrecedenceOverWapBranch()
+      throws NoSuchTableException, ParseException {
+    String branch = "branchA";
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+
+    // Seed the main branch so the target branch can fork from an existing snapshot.
+    jsonToDF("id bigint, data string", "{ \"id\": 1, \"data\": \"a\" }")
+        .writeTo(tableName)
+        .append();
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    table.manageSnapshots().createBranch(branch).commit();
+
+    // With a session WAP branch configured, the branch write option still routes the write to the
+    // branch named in the option.
+    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "wapBranch");
+    try {
+      jsonToDF("id bigint, data string", "{ \"id\": 2, \"data\": \"b\" }")
+          .writeTo(tableName)
+          .option(SparkWriteOptions.BRANCH, branch)
+          .append();
+    } finally {
+      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
+    }
+
+    assertEquals(
+        "Rows written through the branch option should land on that branch",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("SELECT * FROM %s VERSION AS OF '%s' ORDER BY id", tableName, branch));
+
+    assertEquals(
+        "The main branch should not see rows written to the option branch",
+        ImmutableList.of(row(1L, "a")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,15 +62,23 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
   }
 
   @TestTemplate
-  public void testBranchAndWapBranchCannotBothBeSetForWrite() {
+  public void testWriteToBranchWithWapBranchSet() {
     Table table = validationCatalog.loadTable(tableIdent);
     table.manageSnapshots().createBranch("test2", table.refs().get(BRANCH).snapshotId()).commit();
     sql("REFRESH TABLE " + tableName);
-    assertThatThrownBy(() -> sql("INSERT INTO %s.branch_test2 VALUES (4, 'd')", tableName))
-        .isInstanceOf(ValidationException.class)
-        .hasMessage(
-            "Cannot write to both branch and WAP branch, but got branch [test2] and WAP branch [%s]",
-            BRANCH);
+
+    // An explicit branch in the table identifier takes precedence over the session WAP branch.
+    sql("INSERT INTO %s.branch_test2 VALUES (4, 'd')", tableName);
+
+    assertEquals(
+        "Data should be written to the branch in the identifier",
+        ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d")),
+        sql("SELECT * FROM %s VERSION AS OF 'test2' ORDER BY id", tableName));
+
+    assertEquals(
+        "The session WAP branch should not be affected",
+        ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -3005,21 +3005,21 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     ImmutableList<Object[]> expectedRows =
         ImmutableList.of(row(-1), row(0), row(1), row(2), row(3), row(4));
 
+    // writing to explicit branch should succeed even with WAP branch set
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        sql(
-                            "MERGE INTO %s t USING source s ON t.id = s.id "
-                                + "WHEN MATCHED THEN UPDATE SET *"
-                                + "WHEN NOT MATCHED THEN INSERT *",
-                            commitTarget()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                    String.format(
-                        "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
-                        branch)));
+        () -> {
+          sql(
+              "MERGE INTO %s t USING source s ON t.id = s.id "
+                  + "WHEN MATCHED THEN UPDATE SET *"
+                  + "WHEN NOT MATCHED THEN INSERT *",
+              commitTarget());
+
+          assertEquals(
+              "Should have expected rows in explicit branch",
+              expectedRows,
+              sql("SELECT * FROM %s ORDER BY id", commitTarget()));
+        });
   }
 
   private void checkJoinAndFilterConditions(String query, String join, String icebergFilters) {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -1503,15 +1503,17 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
         tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
 
+    // writing to explicit branch should succeed even with WAP branch set
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
-        () ->
-            assertThatThrownBy(() -> sql("UPDATE %s SET dep='hr' WHERE dep='a'", commitTarget()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                    String.format(
-                        "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
-                        branch)));
+        () -> {
+          sql("UPDATE %s SET dep='software' WHERE dep='hr'", commitTarget());
+
+          assertEquals(
+              "Should have updated row in explicit branch",
+              ImmutableList.of(row(1, "software")),
+              sql("SELECT * FROM %s ORDER BY id", commitTarget()));
+        });
   }
 
   private RowLevelOperationMode mode(Table table) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -496,6 +496,17 @@ public class SparkWriteConf {
   }
 
   public String branch() {
+    String optionBranch = confParser.stringConf().option(SparkWriteOptions.BRANCH).parseOptional();
+    ValidationException.check(
+        branch == null || optionBranch == null || optionBranch.equals(branch),
+        "Must not specify different branches in both table identifier and write option, "
+            + "got [%s] in identifier and [%s] in options",
+        branch,
+        optionBranch);
+    if (optionBranch != null) {
+      return optionBranch;
+    }
+
     if (wapEnabled()) {
       String wapId = wapId();
       String wapBranch =

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -503,8 +503,9 @@ public class SparkWriteConf {
             + "got [%s] in identifier and [%s] in options",
         branch,
         optionBranch);
-    if (optionBranch != null) {
-      return optionBranch;
+    String inputBranch = branch != null ? branch : optionBranch;
+    if (inputBranch != null) {
+      return inputBranch;
     }
 
     if (wapEnabled()) {
@@ -519,12 +520,6 @@ public class SparkWriteConf {
           wapBranch);
 
       if (wapBranch != null) {
-        ValidationException.check(
-            branch == null,
-            "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [%s]",
-            branch,
-            wapBranch);
-
         return wapBranch;
       }
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -23,6 +23,9 @@ public class SparkWriteOptions {
 
   private SparkWriteOptions() {}
 
+  // Overrides the target branch for write operations
+  public static final String BRANCH = "branch";
+
   // Fileformat for write operations(default: Table write.format.default )
   public static final String WRITE_FORMAT = "write-format";
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -59,6 +59,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.deletes.DeleteGranularity;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.internal.SQLConf;
@@ -84,6 +85,35 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   @AfterEach
   public void after() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void writeBranchOption() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkWriteConf branchFromOption =
+        new SparkWriteConf(
+            spark, table, null, ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+    assertThat(branchFromOption.branch()).isEqualTo("branchA");
+
+    SparkWriteConf matchingIdentifierAndOption =
+        new SparkWriteConf(
+            spark, table, "branchA", ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+    assertThat(matchingIdentifierAndOption.branch()).isEqualTo("branchA");
+  }
+
+  @TestTemplate
+  public void writeBranchOptionConflictsWithIdentifier() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkWriteConf conflicting =
+        new SparkWriteConf(
+            spark, table, "branchB", ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+
+    assertThatThrownBy(conflicting::branch)
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+            "Must not specify different branches in both table identifier and write option");
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -117,6 +117,26 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void writeBranchOptionTakesPrecedenceOverWapBranch() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wapBranch"),
+        () -> {
+          // With WAP enabled and no write option, the session WAP branch is used.
+          SparkWriteConf wapConf = new SparkWriteConf(spark, table, null, ImmutableMap.of());
+          assertThat(wapConf.branch()).isEqualTo("wapBranch");
+
+          // The branch write option takes precedence over the session WAP branch.
+          SparkWriteConf optionConf =
+              new SparkWriteConf(
+                  spark, table, null, ImmutableMap.of(SparkWriteOptions.BRANCH, "branchA"));
+          assertThat(optionConf.branch()).isEqualTo("branchA");
+        });
+  }
+
+  @TestTemplate
   public void testOptionCaseInsensitive() {
     Table table = validationCatalog.loadTable(tableIdent);
     Map<String, String> options = ImmutableMap.of("option", "value");

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -137,6 +137,21 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void writeIdentifierBranchTakesPrecedenceOverWapBranch() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wapBranch"),
+        () -> {
+          // The identifier branch takes precedence over the session WAP branch.
+          SparkWriteConf identifierConf =
+              new SparkWriteConf(spark, table, "branchA", ImmutableMap.of());
+          assertThat(identifierConf.branch()).isEqualTo("branchA");
+        });
+  }
+
+  @TestTemplate
   public void testOptionCaseInsensitive() {
     Table table = validationCatalog.loadTable(tableIdent);
     Map<String, String> options = ImmutableMap.of("option", "value");

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -25,10 +25,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkTableProperties;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -55,6 +59,45 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void writeToBranchOptionTakesPrecedenceOverWapBranch()
+      throws NoSuchTableException, ParseException {
+    String branch = "branchA";
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+
+    // Seed the main branch so the target branch can fork from an existing snapshot.
+    jsonToDF("id bigint, data string", "{ \"id\": 1, \"data\": \"a\" }")
+        .writeTo(tableName)
+        .append();
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    table.manageSnapshots().createBranch(branch).commit();
+
+    // With a session WAP branch configured, the branch write option still routes the write to the
+    // branch named in the option.
+    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "wapBranch");
+    try {
+      jsonToDF("id bigint, data string", "{ \"id\": 2, \"data\": \"b\" }")
+          .writeTo(tableName)
+          .option(SparkWriteOptions.BRANCH, branch)
+          .append();
+    } finally {
+      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
+    }
+
+    assertEquals(
+        "Rows written through the branch option should land on that branch",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("SELECT * FROM %s VERSION AS OF '%s' ORDER BY id", tableName, branch));
+
+    assertEquals(
+        "The main branch should not see rows written to the option branch",
+        ImmutableList.of(row(1L, "a")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,15 +62,23 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
   }
 
   @TestTemplate
-  public void testBranchAndWapBranchCannotBothBeSetForWrite() {
+  public void testWriteToBranchWithWapBranchSet() {
     Table table = validationCatalog.loadTable(tableIdent);
     table.manageSnapshots().createBranch("test2", table.refs().get(BRANCH).snapshotId()).commit();
     sql("REFRESH TABLE " + tableName);
-    assertThatThrownBy(() -> sql("INSERT INTO %s.branch_test2 VALUES (4, 'd')", tableName))
-        .isInstanceOf(ValidationException.class)
-        .hasMessage(
-            "Cannot write to both branch and WAP branch, but got branch [test2] and WAP branch [%s]",
-            BRANCH);
+
+    // An explicit branch in the table identifier takes precedence over the session WAP branch.
+    sql("INSERT INTO %s.branch_test2 VALUES (4, 'd')", tableName);
+
+    assertEquals(
+        "Data should be written to the branch in the identifier",
+        ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d")),
+        sql("SELECT * FROM %s VERSION AS OF 'test2' ORDER BY id", tableName));
+
+    assertEquals(
+        "The session WAP branch should not be affected",
+        ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate


### PR DESCRIPTION
## Summary

Backport the branch write option added to Spark 4.1 in #15288 to the Spark **3.5** and **4.0** modules.

`SparkWriteOptions.BRANCH` (`"branch"`) lets a DataFrame write target a table branch via
`.option("branch", "...")`, mirroring the existing `SparkReadOptions.BRANCH` read option that has
been available in these modules since #5150.

## Motivation

`SparkReadOptions` exposes a `branch` read option in v3.5/v4.0/v4.1, but the corresponding write
option only exists in **v4.1** (added by #15288). This leaves v3.5 and v4.0 users unable to target a
branch through the DataFrame writer option — they can only use the `branch_<name>` identifier suffix
or a session-level WAP branch. This PR closes that read/write asymmetry for the older modules.

## Change

`SparkWriteConf.branch()` now resolves the write option first:

- If `branch` is set in both the table identifier and the write option, they must match
  (otherwise a `ValidationException` is raised, symmetric to the existing read-side check in
  `SparkReadConf.branch()`).
- The explicit option/identifier branch takes precedence over the session WAP branch.
- When no option/identifier branch is set, the existing WAP-branch resolution is unchanged.

This is intentionally the **minimal** backport: it does not pull in the larger v4.1
`SparkTableUtil` read/write resolution refactor from #15288 (which is v4.1-only and touched ~19
files). This mirrors the minimal-backport approach used in #16245.

## Tests

- `TestSparkWriteConf` (v3.5 + v4.0): `writeBranchOption` , `writeBranchOptionConflictsWithIdentifier` , `writeBranchOptionTakesPrecedenceOverWapBranch` , `writeIdentifierBranchTakesPrecedenceOverWapBranch` . 
- `TestPartitionedWritesToWapBranch` (v3.5 + v4.0): `testBranchAndWapBranchCannotBothBeSetForWrite` -> `testWriteToBranchWithWapBranchSet` (write lands on the identifier branch, WAP branch untouched) - as #15288 did on v4.1. 
- `TestDelete` / `TestMerge` / `TestUpdate` extensions (v3.5 + v4.0): `testDelete/Merge/UpdateToWapBranchWithTableBranchIdentifier` now assert the op succeeds on the explicit branch (matching v4.1), since they share SparkWriteConf.branch() . 
- `TestDataFrameWriterV2` (v3.5 + v4.0): added `writeToBranchOptionTakesPrecedenceOverWapBranch` , a `writeTo(...).option("branch", ...)` round-trip with a session WAP branch set, verifying precedence end-to-end. 

## Related

- #15288 — Spark 4.1: Align handling of branches in reads and writes (introduced the v4.1 write option)
- #16245 — precedent for a minimal branch backport to v3.4/v3.5/v4.0
- #5150 — original branch read option
