### PR TITLE
Core, ORC: surface struct-level null counts for content stats

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -261,9 +261,26 @@ class StatsUtil {
 
   @VisibleForTesting
   static Types.StructType fieldStatsStruct(Type type, int baseId, MetricsModes.MetricsMode mode) {
-    if (null == mode || mode == MetricsModes.None.get() || type.isNestedType() || baseId < 0) {
+    if (null == mode || mode == MetricsModes.None.get() || baseId < 0) {
       return null;
     }
+
+    if (type.isStructType()) {
+      return Types.StructType.of(
+          optional(
+              baseId + VALUE_COUNT_OFFSET,
+              "value_count",
+              Types.LongType.get(),
+              "Number of values (including null)"),
+          optional(
+              baseId + NULL_VALUE_COUNT_OFFSET,
+              "null_value_count",
+              Types.LongType.get(),
+              "Number of null values"));
+    } else if (type.isNestedType()) {
+      return null;
+    }
+
 
     List<Types.NestedField> fields = Lists.newArrayList();
 

--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -281,7 +281,6 @@ class StatsUtil {
       return null;
     }
 
-
     List<Types.NestedField> fields = Lists.newArrayList();
 
     if (mode.hasBounds()) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -388,6 +388,7 @@ public class OrcMetrics {
           .filter(Optional::isPresent)
           .map(Optional::get)
           .forEach(result::add);
+      ORCSchemaUtil.icebergID(record).ifPresent(result::add);
       return result.build();
     }
   }


### PR DESCRIPTION
### Summary
Proposes one direction for #17463 (open investigation issue, no
consensus yet): let ORC surface struct-level null counts it already
computes, and let V4 content stats store them.

### Root Cause
- **ORC**: `ColumnStatistics[]` includes real null-count data for
  struct columns, but `StatsColumnsVisitor.record()` only ever added
  children's field IDs — the struct's own ID was discarded.
- **V4 stats**: `fieldStatsStruct()` excluded all nested types
  (struct, map, list) uniformly via `isNestedType()`, so structs had
  no way to store counts even when a writer could supply them.

Read side is unaffected — `InclusiveMetricsEvaluator` already does a
generic field-ID lookup with no leaf/struct distinction.

### Fix
- `OrcMetrics.java` — `StatsColumnsVisitor.record()` now also adds
  the struct's own field ID via `ORCSchemaUtil.icebergID(record)`.
  Bounds unaffected (struct `ColumnStatistics` matches no
  `instanceof` branch in `fromOrcMin`/`fromOrcMax`).
- `StatsUtil.java` — `fieldStatsStruct()` returns a reduced
  `value_count`/`null_value_count`-only struct for `StructType`
  instead of `null`. Map/list still excluded as before.
