### PR TITLE
Core: Detect metadata tables by identifier, not table name

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -97,13 +97,12 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
   }
 
   private Table loadMetadataTable(TableIdentifier identifier) {
-    String tableName = identifier.name();
-    MetadataTableType type = MetadataTableType.from(tableName);
+    MetadataTableType type = MetadataTableType.from(identifier);
     if (type != null) {
       TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace().levels());
       TableOperations ops = newTableOps(baseTableIdentifier);
       if (ops.current() == null) {
-        throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
+        throw new NoSuchTableException("Table does not exist: %s", identifier);
       }
 
       return MetadataTableUtils.createMetadataTableInstance(
@@ -114,7 +113,7 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
   }
 
   protected boolean isValidMetadataIdentifier(TableIdentifier identifier) {
-    return MetadataTableType.from(identifier.name()) != null
+    return MetadataTableType.from(identifier) != null
         && isValidIdentifier(TableIdentifier.of(identifier.namespace().levels()));
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.util.Locale;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 public enum MetadataTableType {
   ENTRIES,
@@ -44,5 +45,17 @@ public enum MetadataTableType {
     } catch (IllegalArgumentException ignored) {
       return null;
     }
+  }
+
+  public static MetadataTableType from(TableIdentifier identifier) {
+    // An identifier only refers to a metadata table when its base table (the identifier without
+    // its last part) still has a namespace, which requires at least two namespace levels here.
+    // This lets a regular table reuse a metadata table name (e.g. "db.files") without being
+    // mistaken for the "files" metadata table of namespace "db".
+    if (identifier.namespace().levels().length >= 2) {
+      return from(identifier.name());
+    }
+
+    return null;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -26,7 +26,7 @@ public class MetadataTableUtils {
   private MetadataTableUtils() {}
 
   public static boolean hasMetadataTableName(TableIdentifier identifier) {
-    return MetadataTableType.from(identifier.name()) != null;
+    return MetadataTableType.from(identifier) != null;
   }
 
   public static Table createMetadataTableInstance(Table table, MetadataTableType type) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -491,7 +491,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       metadataType = null;
 
     } catch (NoSuchTableException original) {
-      metadataType = MetadataTableType.from(identifier.name());
+      metadataType = MetadataTableType.from(identifier);
       if (metadataType != null) {
         // attempt to load a metadata table using the identifier's namespace as the base table
         TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableType.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class TestMetadataTableType {
+
+  @ParameterizedTest
+  @EnumSource(MetadataTableType.class)
+  void singleLevelNamespaceIsNotAMetadataTable(MetadataTableType type) {
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("ns"), type.name());
+    // a single namespace level names a regular table whose base table has no namespace
+    assertThat(MetadataTableType.from(identifier)).isNull();
+    // the plain name still resolves to the metadata table type
+    assertThat(MetadataTableType.from(identifier.name())).isEqualTo(type);
+  }
+
+  @ParameterizedTest
+  @EnumSource(MetadataTableType.class)
+  void nestedNamespaceIsAMetadataTable(MetadataTableType type) {
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("ns", "tbl"), type.name());
+    assertThat(MetadataTableType.from(identifier)).isEqualTo(type);
+    assertThat(MetadataTableType.from(identifier.name())).isEqualTo(type);
+  }
+
+  @ParameterizedTest
+  @EnumSource(MetadataTableType.class)
+  void identifierWithoutNamespaceIsNotAMetadataTable(MetadataTableType type) {
+    TableIdentifier identifier = TableIdentifier.of(type.name());
+    assertThat(MetadataTableType.from(identifier)).isNull();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -35,12 +35,15 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
@@ -51,6 +54,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.FilesTable;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.HistoryEntry;
+import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.ReplaceSortOrder;
@@ -93,6 +97,8 @@ import org.apache.iceberg.util.CharSequenceSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
@@ -1123,6 +1129,61 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     table.refresh();
 
     assertThat(table.name()).isEqualTo(catalog.name() + "." + metaIdent);
+  }
+
+  @ParameterizedTest
+  @MethodSource("metadataTableNamesAndNamespaces")
+  public void tableSharingMetadataTableName(Namespace namespace, MetadataTableType type) {
+    assumeThat(supportsNestedNamespaces() || namespace.levels().length < 2)
+        .as("Only valid for catalogs that support nested namespaces")
+        .isTrue();
+
+    C catalog = catalog();
+    String metadataName = type.name().toLowerCase(Locale.ROOT);
+    TableIdentifier identifier = TableIdentifier.of(namespace, metadataName);
+
+    if (requiresNamespaceCreate()) {
+      for (int level = 1; level <= namespace.levels().length; level++) {
+        Namespace parent = Namespace.of(Arrays.copyOf(namespace.levels(), level));
+        if (!catalog.namespaceExists(parent)) {
+          catalog.createNamespace(parent);
+        }
+      }
+    }
+
+    assertThat(catalog.tableExists(identifier)).as("Table should not exist").isFalse();
+
+    // the base table does not exist, so loading names the requested identifier rather than the
+    // namespace-derived base table
+    assertThatThrownBy(() -> catalog.loadTable(identifier))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageContaining(identifier.toString());
+
+    catalog.buildTable(identifier, SCHEMA).create();
+
+    Table table = catalog.loadTable(identifier);
+    assertThat(catalog.tableExists(identifier)).as("Table should exist").isTrue();
+    assertThat(table)
+        .as("Should load a regular table, not a metadata table")
+        .isInstanceOf(BaseTable.class);
+    assertThat(table.name()).isEqualTo(catalog.name() + "." + identifier);
+
+    // the metadata table of the new base table remains reachable
+    List<String> metadataLevels = Lists.newArrayList(namespace.levels());
+    metadataLevels.add(metadataName);
+    TableIdentifier metadataIdentifier =
+        TableIdentifier.of(Namespace.of(metadataLevels.toArray(new String[0])), metadataName);
+    Table metadataTable = catalog.loadTable(metadataIdentifier);
+    assertThat(metadataTable).isInstanceOf(BaseMetadataTable.class);
+    assertThat(metadataTable.name()).isEqualTo(catalog.name() + "." + metadataIdentifier);
+  }
+
+  private static Stream<Arguments> metadataTableNamesAndNamespaces() {
+    return Stream.of(Namespace.of("ns"), Namespace.of("ns1", "ns2"))
+        .flatMap(
+            namespace ->
+                Arrays.stream(MetadataTableType.values())
+                    .map(type -> Arguments.of(namespace, type)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -486,7 +486,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
 
           assertThatThrownBy(() -> catalog.loadTable(metadataTableIdentifier))
               .isInstanceOf(NoSuchTableException.class)
-              .hasMessage("Table does not exist: %s", TABLE);
+              .hasMessage("Table does not exist: %s", metadataTableIdentifier);
         },
         1);
 


### PR DESCRIPTION
## What & Why

Metadata tables were detected from the **last part of an identifier alone** (`MetadataTableType.from(identifier.name())`). This caused three related problems:

1. **A regular table that shares a metadata table name was unusable (#10550).** A table like `db.files` was interpreted as the `files` metadata table of namespace `db`, so it could not be created, loaded, or written — in Spark it surfaced as `Cannot write into v1 table` / appeared as a non-Iceberg table.
2. **Wrong identifier in the "not found" error (#13115).** Loading `ns1.ns2.snapshots` when the base table `ns1.ns2` doesn't exist reported `Table does not exist: ns1.ns2` instead of the identifier the caller actually requested.
3. **REST catalog failure on a shallow metadata identifier (#13115).** `loadTable("ns1", "snapshots")` fell back to loading a base table with an **empty namespace**, producing `Malformed request: Ambiguous URI empty segment` instead of a normal `NoSuchTableException`.

## Approach

Introduce `MetadataTableType.from(TableIdentifier)` that treats an identifier as a metadata table **only when its namespace has at least two levels** — i.e. the base table (the identifier without its last part) still has a namespace. Route the catalog code through it:

- `BaseMetastoreCatalog.loadMetadataTable` / `isValidMetadataIdentifier`
- `MetadataTableUtils.hasMetadataTableName`
- `RESTSessionCatalog.loadTable` (metadata-table fallback)

and report the **requested identifier** when the base table is missing.

Because all metastore-backed catalogs (Hive, JDBC, Hadoop, Glue, DynamoDB, Nessie, BigQuery, Snowflake, ECS, InMemory) extend `BaseMetastoreCatalog`, they inherit the fix; `RESTSessionCatalog` is the only catalog that reimplements `loadTable`, so it gets the equivalent change. Spark/Flink use explicit `$`/`#` delimiters and are unaffected.

| Identifier | Before | After |
|---|---|---|
| `db.files` (real table, 1-level ns) | hijacked as metadata of `db` | regular table `db.files` |
| `ns1.ns2.snapshots`, base missing | `Table does not exist: ns1.ns2` | `Table does not exist: ns1.ns2.snapshots` |
| `ns1.snapshots` via REST | `Ambiguous URI empty segment` | clean `NoSuchTableException` |
| `db.tbl.snapshots` (normal metadata table) | works | works (unchanged) |

## Behavior change / limitation

Metadata tables of a **root-namespace (empty-namespace) base table** accessed via dotted syntax (e.g. `tbl.snapshots` where `tbl` lives at the catalog root) are no longer recognized — a table sharing a metadata name in a single-level namespace now wins. This ambiguity is inherent (`X.snapshots` can't mean both) and matches the direction agreed in the prior PRs; it is not reachable on REST, which rejects empty-namespace identifiers.

## Tests

- New `TestMetadataTableType` unit tests for `from(TableIdentifier)`.
- New parameterized `CatalogTests.tableSharingMetadataTableName` (all 16 metadata-table types × `{ns, ns1.ns2}`) covering create/load of a table that shares a metadata name, resolution of its own metadata table, and correct "not found" messaging. Inherited by every catalog suite; verified on InMemory, JDBC, Hadoop, and REST. `spotlessCheck` and `:iceberg-core:revapi` pass.

## Credits

Builds on prior work by @nastra in #11963 and @adutra in #13223, which stalled via the stale bot.

Closes #10550
Closes #13115

