### PR TITLE
Core: Remove deprecated ThreadPools.WORKER_THREAD_POOL_SIZE_PROP

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -948,6 +948,9 @@ acceptedBreaks:
       new: "method void org.apache.iceberg.rest.responses.PlanTableScanResponse.Builder::<init>()"
       justification: "Reducing visibility of scan-planning response internals deprecated\
         \ in 1.11.0 for 1.12.0"
+    - code: "java.field.removed"
+      old: "field org.apache.iceberg.util.ThreadPools.WORKER_THREAD_POOL_SIZE_PROP"
+      justification: "Removing deprecated field scheduled for removal in 1.12.0"
     org.apache.iceberg:iceberg-data:
     - code: "java.class.removed"
       old: "class org.apache.iceberg.data.BaseFileWriterFactory<T extends java.lang.Object>"

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -34,14 +34,6 @@ public class ThreadPools {
 
   private ThreadPools() {}
 
-  /**
-   * @deprecated Use {@link SystemConfigs#WORKER_THREAD_POOL_SIZE} instead. will be removed in
-   *     1.12.0
-   */
-  @Deprecated
-  public static final String WORKER_THREAD_POOL_SIZE_PROP =
-      SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey();
-
   public static final int WORKER_THREAD_POOL_SIZE = SystemConfigs.WORKER_THREAD_POOL_SIZE.value();
 
   private static final ExecutorService WORKER_POOL =


### PR DESCRIPTION
Closes #16445.

Searched the codebase for every method or field marked `@deprecated ... will be
removed in 1.12.0` (the specific removal target, not the ones freshly
deprecated during 1.12.0's own development cycle with a later removal
version). Only one matched: `ThreadPools.WORKER_THREAD_POOL_SIZE_PROP`, an
alias for `SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey()` that's had no
callers anywhere in the repo for a while.

Removed it and added the corresponding accepted-break entry to
`.palantir/revapi.yml`, filed under the same `1.11.0` section other
deprecations scheduled for 1.12.0 removal are already tracked under, to match
existing convention.

Verified: `iceberg-core` compiles cleanly, `revapi` passes (confirms the
accepted-break entry is correctly formatted), and there's no dedicated test
file for `ThreadPools` since this field was never covered by one.

---
**AI Disclosure**
- Model: Claude Sonnet 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Find and remove Iceberg methods/fields deprecated with a
  removal target of 1.12.0, since 1.11.0 has shipped, per issue #16445.