### PR TITLE
Core: Restrict GenericAvroReader class resolution to an explicit allowlist

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
@@ -30,12 +31,38 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 
 public class GenericAvroReader<T>
     implements DatumReader<T>, SupportsRowPosition, SupportsCustomRecords {
+
+  // Restricts record-name-based class resolution to a known-safe set. Record names come from
+  // Avro schemas, which can originate from untrusted input (e.g. AvroEncoderUtil.decode);
+  // without this check, any class name that happens to match something already on the classpath
+  // would be loaded and constructed. See https://github.com/apache/iceberg/issues/17802.
+  //
+  // NOTE: Kafka Connect's classes are listed by name (not Class literal) because iceberg-core
+  // cannot depend on iceberg-kafka-connect-events. Keep this in sync with that module's
+  // AvroUtil.FIELD_ID_TO_CLASS if either changes.
+  private static final Set<String> ALLOWED_RECORD_CLASSES =
+      ImmutableSet.of(
+          "org.apache.iceberg.GenericManifestFile",
+          "org.apache.iceberg.GenericPartitionFieldSummary",
+          "org.apache.iceberg.encryption.StandardKeyMetadata",
+          "org.apache.iceberg.PartitionData",
+          "org.apache.iceberg.GenericDataFile",
+          "org.apache.iceberg.GenericDeleteFile",
+          "org.apache.iceberg.connect.events.Event",
+          "org.apache.iceberg.connect.events.StartCommit",
+          "org.apache.iceberg.connect.events.DataWritten",
+          "org.apache.iceberg.connect.events.DataComplete",
+          "org.apache.iceberg.connect.events.CommitToTable",
+          "org.apache.iceberg.connect.events.CommitComplete",
+          "org.apache.iceberg.connect.events.TopicPartitionOffset",
+          "org.apache.iceberg.connect.events.TableReference");
 
   private final Types.StructType expectedType;
   private ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -123,7 +150,7 @@ public class GenericAvroReader<T>
     private ValueReader<?> recordReader(
         List<Pair<Integer, ValueReader<?>>> readPlan, Schema avroSchema, String recordName) {
       String className = renames.getOrDefault(recordName, recordName);
-      if (className != null) {
+      if (className != null && ALLOWED_RECORD_CLASSES.contains(className)) {
         try {
           Class<?> recordClass = DynClasses.builder().loader(loader).impl(className).buildChecked();
           if (IndexedRecord.class.isAssignableFrom(recordClass)) {

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
@@ -28,6 +28,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.data.DataTestBase;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestAvroEncoderUtil extends DataTestBase {
@@ -81,5 +82,25 @@ public class TestAvroEncoderUtil extends DataTestBase {
     assertThatThrownBy(() -> AvroEncoderUtil.decode(new byte[] {(byte) 0x10, (byte) 0x20}))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Unrecognized header bytes: 0x10 0x20");
+  }
+
+  @Test
+  public void decodeIgnoresClassNotInAllowlist() throws IOException {
+    Types.StructType icebergSchema =
+        Types.StructType.of(Types.NestedField.required(1, "value", Types.StringType.get()));
+    Schema avroSchema = AvroSchemaUtil.convert(icebergSchema, UnapprovedTestRecord.class.getName());
+
+    GenericData.Record datum = new GenericData.Record(avroSchema);
+    datum.put(0, "hello");
+    byte[] data = AvroEncoderUtil.encode(datum, avroSchema);
+
+    // UnapprovedTestRecord is a real, loadable class implementing IndexedRecord with a
+    // constructor shape GenericAvroReader would otherwise accept -- proving rejection here comes
+    // from the allowlist, not from ClassNotFoundException.
+    Object decoded = AvroEncoderUtil.decode(data);
+    assertThat(decoded)
+        .isInstanceOf(GenericData.Record.class)
+        .isNotInstanceOf(UnapprovedTestRecord.class);
+    assertThat(((GenericData.Record) decoded).get(0).toString()).isEqualTo("hello");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/UnapprovedTestRecord.java
+++ b/core/src/test/java/org/apache/iceberg/avro/UnapprovedTestRecord.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+
+/**
+ * A real, loadable {@link IndexedRecord} implementation used only to prove that {@link
+ * GenericAvroReader} rejects record names that resolve to a real class but are not in its
+ * allowlist, rather than accepting any resolvable class.
+ */
+public class UnapprovedTestRecord implements IndexedRecord {
+  private final Schema schema;
+  private Object value;
+
+  public UnapprovedTestRecord(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    this.value = v;
+  }
+
+  @Override
+  public Object get(int i) {
+    return value;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return schema;
+  }
+}


### PR DESCRIPTION
GenericAvroReader.recordReader used an Avro schema's record name directly as a Java class name, loading and constructing it via reflection with no restriction. Two production paths feed this untrusted bytes/schemas: ManifestFiles.decode and Kafka Connect's AvroUtil.decode. If a schema named a class that happened to already be on the classpath and implement IndexedRecord, that class would be constructed regardless of whether it was ever intended to be reconstructed this way.

This adds a hardcoded allowlist (ALLOWED_RECORD_CLASSES) inside GenericAvroReader and only attempts class resolution for names on that list; anything else now falls back to the existing generic record reader. Kafka Connect's classes are listed by name rather than Class literal since iceberg-core cannot depend on iceberg-kafka-connect-events; a comment cross-references that module's FIELD_ID_TO_CLASS to keep the two from drifting apart.

This keeps the change self-contained to GenericAvroReader, with no changes to AvroEncoderUtil, ManifestFiles, or AvroUtil's method signatures or call sites.

Closes #17802