### PR TITLE
Core: Deprecate Avro.ReadBuilder.createReaderFunc, ProjectionDatumReader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -618,6 +618,11 @@ public class Avro {
       return this;
     }
 
+    /**
+     * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+     *     #createResolvingReader(Function)} instead.
+     */
+    @Deprecated
     public ReadBuilder createReaderFunc(Function<Schema, DatumReader<?>> readerFunction) {
       Preconditions.checkState(
           createReaderBiFunc == null && createResolvingReaderFunc == null,
@@ -626,6 +631,11 @@ public class Avro {
       return this;
     }
 
+    /**
+     * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+     *     #createResolvingReader(Function)} instead.
+     */
+    @Deprecated
     public ReadBuilder createReaderFunc(
         BiFunction<org.apache.iceberg.Schema, Schema, DatumReader<?>> readerFunction) {
       Preconditions.checkState(

--- a/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
@@ -30,6 +30,11 @@ import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.TypeUtil;
 
+/**
+ * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+ *     org.apache.iceberg.data.avro.PlannedDataReader} instead.
+ */
+@Deprecated
 public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosition {
   private final Function<Schema, DatumReader<?>> getReader;
   private final org.apache.iceberg.Schema expectedSchema;

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadDefaultValues.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadDefaultValues.java
@@ -154,10 +154,7 @@ public class TestReadDefaultValues {
 
       List<Record> rows;
       try (AvroIterable<Record> reader =
-          Avro.read(Files.localInput(testFile))
-              .project(readerSchema)
-              .createReaderFunc(GenericAvroReader::create)
-              .build()) {
+          Avro.read(Files.localInput(testFile)).project(readerSchema).build()) {
         rows = Lists.newArrayList(reader);
       }
 


### PR DESCRIPTION
Possibly part of #16445.

It seems like `ProjectionDatumReader` was only used with `DataReader` via `Avro.ReadBuilder.createReaderFunc`. After `DataReader` removal (#17699) the `TestReadDefaultValues.testDefaultDoesNotOverrideExplicitValue` test is the only caller. And the test succeed without `.createReaderFunc(GenericAvroReader::create)` call, because `GenericAvroReader` is the default reader in `Avro.ReadBuilder`.