### PR TITLE
Core: Drop stale path avg sizes in rewrite_table_path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
@@ -161,6 +161,7 @@ public class ContentFileUtil {
         file.lowerBounds() == null ? null : Maps.newHashMap(file.lowerBounds());
     Map<Integer, ByteBuffer> upperBounds =
         file.upperBounds() == null ? null : Maps.newHashMap(file.upperBounds());
+    Map<Integer, Integer> avgValueSizes = avgValueSizesWithoutPath(file);
     if (lowerBounds != null) {
       lowerBounds.remove(PATH_ID);
     }
@@ -176,7 +177,7 @@ public class ContentFileUtil {
         file.nanValueCounts(),
         lowerBounds == null ? null : Collections.unmodifiableMap(lowerBounds),
         upperBounds == null ? null : Collections.unmodifiableMap(upperBounds),
-        file.avgValueSizes(),
+        avgValueSizes,
         null /* originalTypes */);
   }
 
@@ -185,6 +186,7 @@ public class ContentFileUtil {
         file.lowerBounds() == null ? null : Maps.newHashMap(file.lowerBounds());
     Map<Integer, ByteBuffer> upperBounds =
         file.upperBounds() == null ? null : Maps.newHashMap(file.upperBounds());
+    Map<Integer, Integer> avgValueSizes = avgValueSizesWithoutPath(file);
     if (lowerBounds != null) {
       lowerBounds.put(PATH_ID, bound);
     }
@@ -200,7 +202,17 @@ public class ContentFileUtil {
         file.nanValueCounts(),
         lowerBounds == null ? null : Collections.unmodifiableMap(lowerBounds),
         upperBounds == null ? null : Collections.unmodifiableMap(upperBounds),
-        file.avgValueSizes(),
+        avgValueSizes,
         null /* originalTypes */);
+  }
+
+  private static Map<Integer, Integer> avgValueSizesWithoutPath(DeleteFile file) {
+    if (file.avgValueSizes() == null) {
+      return null;
+    }
+
+    Map<Integer, Integer> avgValueSizes = Maps.newHashMap(file.avgValueSizes());
+    avgValueSizes.remove(PATH_ID);
+    return avgValueSizes.isEmpty() ? null : Collections.unmodifiableMap(avgValueSizes);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,8 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
@@ -220,6 +223,72 @@ public class TestRewriteTablePathUtil extends TestBase {
 
     assertThat(RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix).location())
         .isEqualTo(targetPrefix);
+  }
+
+  @Test
+  void replacePathBoundsDropsRewrittenPathAvgValueSize() {
+    int pathID = MetadataColumns.DELETE_FILE_PATH.fieldId();
+    int dataID = SCHEMA.findField("data").fieldId();
+    ByteBuffer path =
+        Conversions.toByteBuffer(
+            MetadataColumns.DELETE_FILE_PATH.type(), "/source/table/data/file.parquet");
+    Metrics metrics =
+        new Metrics(
+            1L,
+            null,
+            null,
+            null,
+            null,
+            ImmutableMap.of(pathID, path),
+            ImmutableMap.of(pathID, path),
+            ImmutableMap.of(pathID, 40, dataID, 8),
+            null /* originalTypes */);
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofPositionDeletes()
+            .withPath("/source/table/delete/file.parquet")
+            .withFileSizeInBytes(10)
+            .withMetrics(metrics)
+            .build();
+
+    Metrics rewritten =
+        ContentFileUtil.replacePathBounds(deleteFile, "/source/table", "/target/table");
+
+    assertThat(rewritten.avgValueSizes()).containsExactly(entry(dataID, 8));
+  }
+
+  @Test
+  void replacePathBoundsNormalizesEmptyAvgValueSizes() {
+    int pathID = MetadataColumns.DELETE_FILE_PATH.fieldId();
+    ByteBuffer lowerPath =
+        Conversions.toByteBuffer(
+            MetadataColumns.DELETE_FILE_PATH.type(), "/source/table/data/a.parquet");
+    ByteBuffer upperPath =
+        Conversions.toByteBuffer(
+            MetadataColumns.DELETE_FILE_PATH.type(), "/source/table/data/b.parquet");
+    Metrics metrics =
+        new Metrics(
+            2L,
+            null,
+            null,
+            null,
+            null,
+            ImmutableMap.of(pathID, lowerPath),
+            ImmutableMap.of(pathID, upperPath),
+            ImmutableMap.of(pathID, 40),
+            null /* originalTypes */);
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofPositionDeletes()
+            .withPath("/source/table/delete/file.parquet")
+            .withFileSizeInBytes(10)
+            .withMetrics(metrics)
+            .build();
+
+    Metrics rewritten =
+        ContentFileUtil.replacePathBounds(deleteFile, "/source/table", "/target/table");
+
+    assertThat(rewritten.avgValueSizes()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #17451. `rewrite_table_path` kept a stale average for the position-delete `file_path` column after rewriting that path.

Remove the `file_path` average value size when rewriting position-delete path bounds, preserve unrelated averages, and normalize an empty result to null.



## Test plan

- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestRewriteTablePathUtil`
- [x] `./gradlew :iceberg-core:spotlessCheck`

---
**AI Disclosure**
- Model: Cursor Grok 4.6
- Platform/Tool: Cursor
- Human Oversight: unreviewed
- Prompt Summary: Drop stale file_path avg value sizes in rewrite_table_path as a follow-up to #17451.