### PR TITLE
Flink: Add support for REST catalog in CatalogTestBase

### DIFF
--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -87,6 +87,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-orc', configuration: 'testArtifacts')
     testImplementation(testFixtures(project(':iceberg-parquet')))
+    testImplementation (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements'))
 
     // By default, hive-exec is a fat/uber jar and it exports a guava library
     // that's really old. We use the core classifier to be able to override our guava

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -33,11 +33,17 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTCatalogServer;
+import org.apache.iceberg.rest.RESTServerExtension;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(ParameterizedTestExtension.class)
@@ -46,7 +52,8 @@ public abstract class CatalogTestBase extends TestBase {
   /** Catalog implementations that SQL test suites can run against. */
   public enum CatalogType {
     HIVE("testhive"),
-    HADOOP("testhadoop");
+    HADOOP("testhadoop"),
+    REST("testrest");
 
     private final String catalogNamePrefix;
 
@@ -65,6 +72,21 @@ public abstract class CatalogTestBase extends TestBase {
   @TempDir protected File hiveWarehouse;
   @TempDir protected File hadoopWarehouse;
 
+  @RegisterExtension
+  private static final RESTServerExtension REST_SERVER_EXTENSION =
+      new RESTServerExtension(
+          ImmutableMap.of(
+              RESTCatalogServer.REST_PORT,
+              RESTServerExtension.FREE_PORT,
+              // In-memory sqlite database by default is private to the connection that created
+              // it. If more than 1 jdbc connection backs the catalog, the connections can see
+              // different database states, so limit the backend JdbcCatalog to a single
+              // connection.
+              CatalogProperties.CLIENT_POOL_SIZE,
+              "1"));
+
+  protected static RESTCatalog restCatalog;
+
   @Parameter(index = 0)
   protected CatalogType catalogType;
 
@@ -79,6 +101,7 @@ public abstract class CatalogTestBase extends TestBase {
   protected String flinkDatabase;
   protected Namespace icebergNamespace;
   protected boolean isHadoopCatalog;
+  protected boolean isRestCatalog;
 
   @Parameters(name = "catalogType={0}, baseNamespace={1}")
   protected static List<Object[]> parameters() {
@@ -88,14 +111,23 @@ public abstract class CatalogTestBase extends TestBase {
         new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1")});
   }
 
+  @BeforeAll
+  public static void initRestCatalog() {
+    restCatalog = REST_SERVER_EXTENSION.client();
+  }
+
   @BeforeEach
   public void before() {
     this.catalogName = catalogType.catalogName(baseNamespace);
     this.isHadoopCatalog = catalogType == CatalogType.HADOOP;
-    this.validationCatalog =
-        isHadoopCatalog
-            ? new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath())
-            : catalog;
+    this.isRestCatalog = catalogType == CatalogType.REST;
+    if (isHadoopCatalog) {
+      this.validationCatalog = new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath());
+    } else if (isRestCatalog) {
+      this.validationCatalog = restCatalog;
+    } else {
+      this.validationCatalog = catalog;
+    }
     this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
 
     config.put("type", "iceberg");
@@ -104,6 +136,12 @@ public abstract class CatalogTestBase extends TestBase {
     }
     if (isHadoopCatalog) {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
+    } else if (isRestCatalog) {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "rest");
+      config.put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI));
+      // disable Flink-side catalog caching so validations that write directly through
+      // restCatalog observe fresh metadata
+      config.put(CatalogProperties.CACHE_ENABLED, "false");
     } else {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
       config.put(CatalogProperties.URI, getURI(hiveConf));

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -43,12 +43,30 @@ import org.junit.jupiter.api.io.TempDir;
 @ExtendWith(ParameterizedTestExtension.class)
 public abstract class CatalogTestBase extends TestBase {
 
+  /** Catalog implementations that SQL test suites can run against. */
+  public enum CatalogType {
+    HIVE("testhive"),
+    HADOOP("testhadoop");
+
+    private final String catalogNamePrefix;
+
+    CatalogType(String catalogNamePrefix) {
+      this.catalogNamePrefix = catalogNamePrefix;
+    }
+
+    String catalogName(Namespace namespace) {
+      return namespace.isEmpty()
+          ? catalogNamePrefix
+          : catalogNamePrefix + "_" + Joiner.on('_').join(namespace.levels());
+    }
+  }
+
   protected static final String DATABASE = "db";
   @TempDir protected File hiveWarehouse;
   @TempDir protected File hadoopWarehouse;
 
   @Parameter(index = 0)
-  protected String catalogName;
+  protected CatalogType catalogType;
 
   @Parameter(index = 1)
   protected Namespace baseNamespace;
@@ -57,21 +75,23 @@ public abstract class CatalogTestBase extends TestBase {
   protected SupportsNamespaces validationNamespaceCatalog;
   protected Map<String, String> config = Maps.newHashMap();
 
+  protected String catalogName;
   protected String flinkDatabase;
   protected Namespace icebergNamespace;
   protected boolean isHadoopCatalog;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}")
   protected static List<Object[]> parameters() {
     return Arrays.asList(
-        new Object[] {"testhive", Namespace.empty()},
-        new Object[] {"testhadoop", Namespace.empty()},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+        new Object[] {CatalogType.HIVE, Namespace.empty()},
+        new Object[] {CatalogType.HADOOP, Namespace.empty()},
+        new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1")});
   }
 
   @BeforeEach
   public void before() {
-    this.isHadoopCatalog = catalogName.startsWith("testhadoop");
+    this.catalogName = catalogType.catalogName(baseNamespace);
+    this.isHadoopCatalog = catalogType == CatalogType.HADOOP;
     this.validationCatalog =
         isHadoopCatalog
             ? new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath())

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -47,16 +47,16 @@ public class TestFlinkCatalogTablePartitions extends CatalogTestBase {
   @Parameter(index = 3)
   private Boolean cacheEnabled;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
   protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
       for (Boolean cacheEnabled : new Boolean[] {true, false}) {
         for (Object[] catalogParams : CatalogTestBase.parameters()) {
-          String catalogName = (String) catalogParams[0];
+          CatalogType catalogType = (CatalogType) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
-          parameters.add(new Object[] {catalogName, baseNamespace, format, cacheEnabled});
+          parameters.add(new Object[] {catalogType, baseNamespace, format, cacheEnabled});
         }
       }
     }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkRESTCatalogDatabase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkRESTCatalogDatabase.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.catalog.Namespace;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Runs the {@link TestFlinkCatalogDatabase} suite against a REST catalog server backed by an
+ * in-memory JDBC catalog.
+ */
+public class TestFlinkRESTCatalogDatabase extends TestFlinkCatalogDatabase {
+
+  @Parameters(name = "catalogType={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
+    return Collections.singletonList(new Object[] {CatalogType.REST, Namespace.empty()});
+  }
+
+  @TestTemplate
+  @Override
+  public void testCreateNamespaceWithLocation() throws Exception {
+    // The JDBC-backed REST catalog stores the 'location' property verbatim instead of
+    // resolving it to a "file:" URI the way the Hive catalog does
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+        .as("Namespace should not already exist")
+        .isFalse();
+
+    Path location = temporaryDirectory;
+    sql("CREATE DATABASE %s WITH ('location'='%s')", flinkDatabase, location);
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+        .as("Namespace should exist")
+        .isTrue();
+    Map<String, String> nsMetadata =
+        validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
+    assertThat(nsMetadata).containsEntry("location", location.toString());
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -54,18 +54,18 @@ public class TestFlinkTableSink extends CatalogTestBase {
   private boolean useV2Sink;
 
   @Parameters(
-      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}, useV2Sink={4}")
+      name = "catalogType={0}, baseNamespace={1}, format={2}, isStreaming={3}, useV2Sink={4}")
   public static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
       for (Boolean isStreaming : new Boolean[] {true, false}) {
         for (Object[] catalogParams : CatalogTestBase.parameters()) {
-          String catalogName = (String) catalogParams[0];
+          CatalogType catalogType = (CatalogType) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
           parameters.add(
               new Object[] {
-                catalogName, baseNamespace, format, isStreaming, false /* don't use v2 sink */
+                catalogType, baseNamespace, format, isStreaming, false /* don't use v2 sink */
               });
         }
       }
@@ -74,10 +74,14 @@ public class TestFlinkTableSink extends CatalogTestBase {
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
       for (Boolean isStreaming : new Boolean[] {true, false}) {
-        String catalogName = "testhadoop_basenamespace";
-        Namespace baseNamespace = Namespace.of("l0", "l1");
         parameters.add(
-            new Object[] {catalogName, baseNamespace, format, isStreaming, true /* use v2 sink */});
+            new Object[] {
+              CatalogType.HADOOP,
+              Namespace.of("l0", "l1"),
+              format,
+              isStreaming,
+              true /* use v2 sink */
+            });
       }
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkCompaction.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkCompaction.java
@@ -90,20 +90,17 @@ public class TestFlinkTableSinkCompaction extends CatalogTestBase {
   @Parameter(index = 3)
   private String lockType;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, userSqlHint={2}, lockType={3}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}, userSqlHint={2}, lockType={3}")
   public static List<Object[]> parameters() {
     return Arrays.asList(
         new Object[] {
-          "testhadoop_basenamespace", Namespace.of("l0", "l1"), true, LockConfig.JdbcLockConfig.JDBC
+          CatalogType.HADOOP, Namespace.of("l0", "l1"), true, LockConfig.JdbcLockConfig.JDBC
         },
         new Object[] {
-          "testhadoop_basenamespace",
-          Namespace.of("l0", "l1"),
-          false,
-          LockConfig.JdbcLockConfig.JDBC
+          CatalogType.HADOOP, Namespace.of("l0", "l1"), false, LockConfig.JdbcLockConfig.JDBC
         },
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), true, ""},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), false, ""});
+        new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1"), true, ""},
+        new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1"), false, ""});
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
@@ -55,7 +55,7 @@ public class TestFlinkUpsert extends CatalogTestBase {
   private TableEnvironment tEnv;
 
   @Parameters(
-      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}, formatVersion={4} ")
+      name = "catalogType={0}, baseNamespace={1}, format={2}, isStreaming={3}, formatVersion={4} ")
   public static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
@@ -63,11 +63,10 @@ public class TestFlinkUpsert extends CatalogTestBase {
       for (int version : org.apache.iceberg.TestHelpers.V2_AND_ABOVE) {
         for (Boolean isStreaming : new Boolean[] {true, false}) {
           // Only test with one catalog as this is a file operation concern.
-          // FlinkCatalogTestBase requires the catalog name start with testhadoop if using hadoop
-          // catalog.
-          String catalogName = "testhadoop";
-          Namespace baseNamespace = Namespace.of("default");
-          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, version});
+          parameters.add(
+              new Object[] {
+                CatalogType.HADOOP, Namespace.of("default"), format, isStreaming, version
+              });
         }
       }
     }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUuidType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUuidType.java
@@ -72,12 +72,12 @@ class TestFlinkUuidType extends CatalogTestBase {
   @Parameter(index = 2)
   private FileFormat fileFormat;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, fileFormat={2}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}, fileFormat={2}")
   protected static List<Object[]> parameters() {
     return Arrays.asList(
-        new Object[] {"testhadoop", Namespace.empty(), FileFormat.PARQUET},
-        new Object[] {"testhadoop", Namespace.empty(), FileFormat.AVRO},
-        new Object[] {"testhadoop", Namespace.empty(), FileFormat.ORC});
+        new Object[] {CatalogType.HADOOP, Namespace.empty(), FileFormat.PARQUET},
+        new Object[] {CatalogType.HADOOP, Namespace.empty(), FileFormat.AVRO},
+        new Object[] {CatalogType.HADOOP, Namespace.empty(), FileFormat.ORC});
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
@@ -57,11 +57,11 @@ class TestFlinkVariantShreddingType extends CatalogTestBase {
   private static final String TABLE_NAME = "test_table";
   private Table icebergTable;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}")
   protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
-    parameters.add(new Object[] {"testhadoop", Namespace.empty()});
-    parameters.add(new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+    parameters.add(new Object[] {CatalogType.HADOOP, Namespace.empty()});
+    parameters.add(new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1")});
     return parameters;
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantType.java
@@ -55,12 +55,12 @@ class TestFlinkVariantType extends CatalogTestBase {
   private Table icebergTable;
   @TempDir private Path warehouseDir;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}")
   protected static List<Object[]> parameters() {
     return Arrays.asList(
         // For now hive metadata is not supported variant, so we only test hadoop catalog
-        new Object[] {"testhadoop", Namespace.empty()},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+        new Object[] {CatalogType.HADOOP, Namespace.empty()},
+        new Object[] {CatalogType.HADOOP, Namespace.of("l0", "l1")});
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -328,7 +328,7 @@ public class TestIcebergConnector extends TestBase {
   }
 
   private boolean isHiveCatalog() {
-    return "testhive".equalsIgnoreCase(catalogName);
+    return "hive".equals(properties.get("catalog-type"));
   }
 
   private boolean isDefaultDatabaseName() {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -94,16 +94,16 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
     return super.getTableEnv();
   }
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, formatVersion={3}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}, format={2}, formatVersion={3}")
   public static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.AVRO, FileFormat.ORC, FileFormat.PARQUET}) {
       for (Object[] catalogParams : CatalogTestBase.parameters()) {
         for (int version : TestHelpers.V2_AND_ABOVE) {
-          String catalogName = (String) catalogParams[0];
+          CatalogType catalogType = (CatalogType) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
-          parameters.add(new Object[] {catalogName, baseNamespace, format, version});
+          parameters.add(new Object[] {catalogType, baseNamespace, format, version});
         }
       }
     }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -81,14 +81,12 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
   @Parameter(index = 2)
   private Boolean isPartition;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, isPartition={2}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}, isPartition={2}")
   protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
 
     for (Boolean isPartition : new Boolean[] {true, false}) {
-      String catalogName = "testhadoop";
-      Namespace baseNamespace = Namespace.of("default");
-      parameters.add(new Object[] {catalogName, baseNamespace, isPartition});
+      parameters.add(new Object[] {CatalogType.HADOOP, Namespace.of("default"), isPartition});
     }
     return parameters;
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
@@ -59,12 +59,10 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestMetadataTableReadableMetrics extends CatalogTestBase {
   private static final String TABLE_NAME = "test_table";
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  @Parameters(name = "catalogType={0}, baseNamespace={1}")
   protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
-    String catalogName = "testhive";
-    Namespace baseNamespace = Namespace.empty();
-    parameters.add(new Object[] {catalogName, baseNamespace});
+    parameters.add(new Object[] {CatalogType.HIVE, Namespace.empty()});
     return parameters;
   }
 


### PR DESCRIPTION
The Flink catalog test harness `CatalogTestBase` currently runs only against Hive and Hadoop catalogs, while the REST catalog has become the standard way to deploy Iceberg and Flink already supports it in product code. Yet nothing under flink module ever exercises Flink SQL against a real REST catalog, so REST-specific behavior HTTP round-trips, error translation through RESTCatalogAdapter, property handling has zero test coverage in the Flink module.

The PR introduces test coverage for RestCatalog support.