### PR TITLE
Spark: Use the table's catalog Hadoop configuration when listing orphan files

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -320,6 +320,8 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
 | `prefix_listing` |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
 
+Unless `prefix_listing` is enabled, files are listed through the Hadoop `FileSystem` API, configured from the Spark session and the [catalog specific Hadoop configuration](spark-configuration.md#using-catalog-specific-hadoop-configuration-values) of the catalog on which the procedure is invoked. A catalog that reaches its storage with credentials other than the cluster's can be given the same credentials for the listing with `spark.sql.catalog.(catalog-name).hadoop.fs.s3a.*`.
+
 #### Output
 
 | Output Name | Type | Description |

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Files;
@@ -748,5 +749,78 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Drop table in afterEach has purge and fails due to invalid authority "localhost"
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
+  }
+
+  @TestTemplate
+  public void catalogHadoopConfOverridesApplyToListing() throws IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    String location = table.location().replaceFirst("file:", "");
+    new File(location + "/data/trashfile").createNewFile();
+
+    // registered for this catalog alone, so the location below resolves only when the catalog's
+    // Hadoop overrides reach the listing
+    spark
+        .conf()
+        .set(
+            String.format(
+                "spark.sql.catalog.%s.hadoop.fs.%s.impl",
+                catalogName, CatalogScopedFileSystem.SCHEME),
+            CatalogScopedFileSystem.class.getName());
+
+    waitUntilAfter(System.currentTimeMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.remove_orphan_files("
+                + "table => '%s',"
+                + "older_than => TIMESTAMP '%s',"
+                + "location => '%s',"
+                + "equal_schemes => map('%s', 'file'),"
+                + "dry_run => true)",
+            catalogName,
+            tableIdent,
+            currentTimestamp,
+            CatalogScopedFileSystem.SCHEME + "://" + location,
+            CatalogScopedFileSystem.SCHEME);
+
+    assertThat(output)
+        .as("trash file should be found")
+        .anyMatch(row -> ((String) row[0]).endsWith("/data/trashfile"));
+  }
+
+  @AfterEach
+  public void resetCatalogHadoopConfOverrides() {
+    spark
+        .conf()
+        .unset(
+            String.format(
+                "spark.sql.catalog.%s.hadoop.fs.%s.impl",
+                catalogName, CatalogScopedFileSystem.SCHEME));
+  }
+
+  /** Local file system reachable only under its own scheme, to tell the two configs apart. */
+  public static class CatalogScopedFileSystem extends RawLocalFileSystem {
+    static final String SCHEME = "catalogscopedfs";
+
+    @Override
+    public URI getUri() {
+      return URI.create(SCHEME + ":///");
+    }
+
+    @Override
+    public String getScheme() {
+      return SCHEME;
+    }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.util.FileSystemWalker;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
@@ -119,7 +120,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
   private static final int DELETE_GROUP_SIZE = 100000;
 
-  private final SerializableConfiguration hadoopConf;
+  private SerializableConfiguration hadoopConf;
   private final int listingParallelism;
   private final Table table;
   private Map<String, String> equalSchemes = flattenMap(EQUAL_SCHEMES_DEFAULT);
@@ -144,6 +145,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     ValidationException.check(
         PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
         "Cannot delete orphan files: GC is disabled (deleting files may corrupt other tables)");
+  }
+
+  /**
+   * Passes the name of the Spark catalog that owns the table, so that files are listed using the
+   * session Hadoop configuration plus that catalog's {@code spark.sql.catalog.<name>.hadoop.*}
+   * overrides. When not set, only the session Hadoop configuration is used.
+   */
+  public DeleteOrphanFilesSparkAction catalogName(String catalogName) {
+    this.hadoopConf =
+        new SerializableConfiguration(SparkUtil.hadoopConfCatalogOverrides(spark(), catalogName));
+    return this;
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -153,7 +153,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     return withIcebergTable(
         tableIdent,
         table -> {
-          DeleteOrphanFilesSparkAction action = actions().deleteOrphanFiles(table);
+          DeleteOrphanFilesSparkAction action =
+              actions().deleteOrphanFiles(table).catalogName(tableCatalog().name());
 
           if (olderThanMillis != null) {
             boolean isTesting = Boolean.parseBoolean(spark().conf().get("spark.testing", "false"));

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -21,8 +21,11 @@ package org.apache.iceberg.spark.actions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.net.URI;
 import java.util.stream.StreamSupport;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkSessionCatalog;
@@ -190,10 +193,121 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     assertThat(results.orphanFilesCount()).as("trash file should be removed").isEqualTo(1L);
   }
 
+  @TestTemplate
+  public void catalogHadoopConfOverridesApplyToListing() throws Exception {
+    spark.conf().set("spark.sql.catalog.overridecat", "org.apache.iceberg.spark.SparkCatalog");
+    spark.conf().set("spark.sql.catalog.overridecat.type", "hadoop");
+    spark.conf().set("spark.sql.catalog.overridecat.warehouse", tableLocation);
+    // registered for this catalog alone, so the location below resolves only when the catalog's
+    // Hadoop overrides reach the listing
+    spark
+        .conf()
+        .set(
+            String.format(
+                "spark.sql.catalog.overridecat.hadoop.fs.%s.impl", CatalogScopedFileSystem.SCHEME),
+            CatalogScopedFileSystem.class.getName());
+    SparkCatalog cat = (SparkCatalog) spark.sessionState().catalogManager().catalog("overridecat");
+
+    String[] database = {"default"};
+    Identifier id = Identifier.of(database, randomName("table"));
+    Transform[] transforms = {};
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
+    SparkTable table = (SparkTable) cat.loadTable(id);
+
+    sql("INSERT INTO overridecat.default.%s VALUES (1,1,1)", id.name());
+
+    String location = table.table().location().replaceFirst("file:", "");
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
+
+    DeleteOrphanFiles.Result results =
+        SparkActions.get()
+            .deleteOrphanFiles(table.table())
+            .catalogName("overridecat")
+            .location(CatalogScopedFileSystem.SCHEME + "://" + location)
+            .equalSchemes(ImmutableMap.of(CatalogScopedFileSystem.SCHEME, "file"))
+            .deleteWith(file -> {})
+            .olderThan(System.currentTimeMillis() + 1000)
+            .execute();
+
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be found")
+        .anyMatch(file -> file.endsWith(trashFile));
+    assertThat(results.orphanFilesCount()).as("only the trash file is an orphan").isEqualTo(1L);
+  }
+
+  @TestTemplate
+  public void sessionCatalogHadoopConfOverridesApplyToListing() throws Exception {
+    spark
+        .conf()
+        .set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
+    spark.conf().set("spark.sql.catalog.spark_catalog.type", "hadoop");
+    spark.conf().set("spark.sql.catalog.spark_catalog.warehouse", tableLocation);
+    spark
+        .conf()
+        .set(
+            String.format(
+                "spark.sql.catalog.spark_catalog.hadoop.fs.%s.impl",
+                CatalogScopedFileSystem.SCHEME),
+            CatalogScopedFileSystem.class.getName());
+    SparkSessionCatalog cat =
+        (SparkSessionCatalog) spark.sessionState().catalogManager().v2SessionCatalog();
+
+    String[] database = {"default"};
+    Identifier id = Identifier.of(database, randomName("table"));
+    Transform[] transforms = {};
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
+    SparkTable table = (SparkTable) cat.loadTable(id);
+
+    sql("INSERT INTO default.%s VALUES (1,1,1)", id.name());
+
+    String location = table.table().location().replaceFirst("file:", "");
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
+
+    DeleteOrphanFiles.Result results =
+        SparkActions.get()
+            .deleteOrphanFiles(table.table())
+            .catalogName("spark_catalog")
+            .location(CatalogScopedFileSystem.SCHEME + "://" + location)
+            .equalSchemes(ImmutableMap.of(CatalogScopedFileSystem.SCHEME, "file"))
+            .deleteWith(file -> {})
+            .olderThan(System.currentTimeMillis() + 1000)
+            .execute();
+
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be found")
+        .anyMatch(file -> file.endsWith(trashFile));
+    assertThat(results.orphanFilesCount()).as("only the trash file is an orphan").isEqualTo(1L);
+  }
+
   @AfterEach
-  public void resetSparkSessionCatalog() {
-    spark.conf().unset("spark.sql.catalog.spark_catalog");
-    spark.conf().unset("spark.sql.catalog.spark_catalog.type");
-    spark.conf().unset("spark.sql.catalog.spark_catalog.warehouse");
+  public void resetCatalogConfigOverrides() {
+    for (String catalog : new String[] {"spark_catalog", "overridecat"}) {
+      spark.conf().unset(String.format("spark.sql.catalog.%s", catalog));
+      spark.conf().unset(String.format("spark.sql.catalog.%s.type", catalog));
+      spark.conf().unset(String.format("spark.sql.catalog.%s.warehouse", catalog));
+      spark
+          .conf()
+          .unset(
+              String.format(
+                  "spark.sql.catalog.%s.hadoop.fs.%s.impl",
+                  catalog, CatalogScopedFileSystem.SCHEME));
+    }
+  }
+
+  /** Local file system reachable only under its own scheme, to tell the two configs apart. */
+  public static class CatalogScopedFileSystem extends RawLocalFileSystem {
+    static final String SCHEME = "catalogscopedfs";
+
+    @Override
+    public URI getUri() {
+      return URI.create(SCHEME + ":///");
+    }
+
+    @Override
+    public String getScheme() {
+      return SCHEME;
+    }
   }
 }


### PR DESCRIPTION
Closes #17860.

### Problem

`remove_orphan_files` lists the table location with a Hadoop `FileSystem` built from the session configuration alone, while every other file operation in the action goes through `table.io()`. On deployments where the catalog reaches its storage with credentials other than the cluster's — for example a catalog configured with an assumed role for another account — the two paths authenticate differently: reads and deletes through `table.io()` succeed, but the listing fails with `AccessDenied` (or silently sees no files).

### Change

- `DeleteOrphanFilesSparkAction` gains a `catalogName(String)` method. When set, the Hadoop configuration used for listing is built with `SparkUtil.hadoopConfCatalogOverrides`, i.e. the session configuration plus the `spark.sql.catalog.<name>.hadoop.*` overrides of that catalog. When not set, the action behaves exactly as before and uses the session configuration only.
- `RemoveOrphanFilesProcedure` passes the catalog it was invoked on (`tableCatalog().name()`), so `CALL <catalog>.system.remove_orphan_files(...)` picks up that catalog's Hadoop overrides without any new user-facing knob.

The catalog is passed explicitly rather than inferred, following the review discussion: `Table.name()` carries no contract that its first segment identifies the Spark catalog that produced the table, and `CatalogManager.isCatalogRegistered` can initialize catalogs as a side effect, so inference could apply another catalog's configuration to an unrelated table.

With this in place, a catalog that assumes a role can be given the same credentials for the listing:

```
spark.sql.catalog.mycat.client.assume-role.arn=arn:aws:iam::123456789012:role/my-role
...
spark.sql.catalog.mycat.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
spark.sql.catalog.mycat.hadoop.fs.s3a.assumed.role.arn=arn:aws:iam::123456789012:role/my-role
```

### Testing

Tests register a marker `FileSystem` implementation under a dedicated scheme in the catalog's `hadoop.*` overrides only, so listing under that scheme succeeds only when the catalog configuration reaches the listing:

- `TestRemoveOrphanFilesProcedure#catalogHadoopConfOverridesApplyToListing` goes through `CALL <catalog>.system.remove_orphan_files(...)` — the user-facing path from #17860 — across all four test catalogs (testhive, testhadoop, spark_catalog, testrest).
- `TestRemoveOrphanFilesAction3` covers the action API with both `SparkCatalog` and `SparkSessionCatalog` via `catalogName(...)`.

If the direction is agreed I will follow up with the v4.0 and v3.5 backports.
