### PR TITLE
Spark 4.1: Add rewrite option to enable executor cache for delete files

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -415,7 +415,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `output-spec-id` | current partition spec id | Identifier of the output partition spec. Data will be reorganized during the rewrite to align with the output partitioning. |
 | `remove-dangling-deletes` | false | Remove dangling position and equality deletes after rewriting. A delete file is considered dangling if it does not apply to any live data files. Enabling this will generate an additional commit for the removal. |
 | `max-files-to-rewrite` | null | This option sets an upper limit on the number of eligible files that will be rewritten. If this option is not specified, all eligible files will be rewritten. |
-| `executor-cache.delete-files.enabled` | false | Use the executor cache for delete files while rewriting. Enable this when the same delete file applies to many data files, which is common with equality deletes |
+| `cache-delete-files` | false | Use the executor cache for delete files while rewriting. Enable this when the same delete file applies to many data files, which is common with equality deletes |
 
 !!! info
     Dangling delete files are removed based solely on data sequence numbers. This action does not apply to global

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -415,6 +415,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `output-spec-id` | current partition spec id | Identifier of the output partition spec. Data will be reorganized during the rewrite to align with the output partitioning. |
 | `remove-dangling-deletes` | false | Remove dangling position and equality deletes after rewriting. A delete file is considered dangling if it does not apply to any live data files. Enabling this will generate an additional commit for the removal. |
 | `max-files-to-rewrite` | null | This option sets an upper limit on the number of eligible files that will be rewritten. If this option is not specified, all eligible files will be rewritten. |
+| `executor-cache.delete-files.enabled` | false | Use the executor cache for delete files while rewriting. Enable this when the same delete file applies to many data files, which is common with equality deletes |
 
 !!! info
     Dangling delete files are removed based solely on data sequence numbers. This action does not apply to global

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -72,10 +72,7 @@ public class RewriteDataFilesSparkAction
   private static final Logger LOG = LoggerFactory.getLogger(RewriteDataFilesSparkAction.class);
 
   /**
-   * Use the executor cache for delete files while rewriting.
-   *
-   * <p>Enable this when the same delete file applies to many data files, which is common with
-   * equality deletes.
+   * When true, the executor cache is used for delete files while rewriting.
    *
    * <p>This option sets {@link SparkSQLProperties#EXECUTOR_CACHE_DELETE_FILES_ENABLED} for the
    * rewrite, so any value configured for that property in the session is ignored.

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -82,10 +82,9 @@ public class RewriteDataFilesSparkAction
    *
    * <p>Defaults to false.
    */
-  public static final String EXECUTOR_CACHE_DELETE_FILES_ENABLED =
-      "executor-cache.delete-files.enabled";
+  public static final String CACHE_DELETE_FILES = "cache-delete-files";
 
-  public static final boolean EXECUTOR_CACHE_DELETE_FILES_ENABLED_DEFAULT = false;
+  public static final boolean CACHE_DELETE_FILES_DEFAULT = false;
 
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
@@ -99,7 +98,7 @@ public class RewriteDataFilesSparkAction
           REWRITE_JOB_ORDER,
           OUTPUT_SPEC_ID,
           REMOVE_DANGLING_DELETES,
-          EXECUTOR_CACHE_DELETE_FILES_ENABLED,
+          CACHE_DELETE_FILES,
           BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE);
 
   private static final RewriteDataFilesSparkAction.Result EMPTY_RESULT =
@@ -439,10 +438,7 @@ public class RewriteDataFilesSparkAction
             options(), REMOVE_DANGLING_DELETES, REMOVE_DANGLING_DELETES_DEFAULT);
 
     boolean cacheDeleteFiles =
-        PropertyUtil.propertyAsBoolean(
-            options(),
-            EXECUTOR_CACHE_DELETE_FILES_ENABLED,
-            EXECUTOR_CACHE_DELETE_FILES_ENABLED_DEFAULT);
+        PropertyUtil.propertyAsBoolean(options(), CACHE_DELETE_FILES, CACHE_DELETE_FILES_DEFAULT);
     spark()
         .conf()
         .set(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -224,7 +224,8 @@ public class RewriteDataFilesSparkAction
     return result;
   }
 
-  private void init(long startingSnapshotId) {
+  @VisibleForTesting
+  void init(long startingSnapshotId) {
     this.planner =
         runner instanceof SparkShufflingFileRewriteRunner
             ? new SparkShufflingDataRewritePlanner(table, filter, startingSnapshotId, caseSensitive)

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -70,6 +70,23 @@ public class RewriteDataFilesSparkAction
     extends BaseSnapshotUpdateSparkAction<RewriteDataFilesSparkAction> implements RewriteDataFiles {
 
   private static final Logger LOG = LoggerFactory.getLogger(RewriteDataFilesSparkAction.class);
+
+  /**
+   * Use the executor cache for delete files while rewriting.
+   *
+   * <p>Enable this when the same delete file applies to many data files, which is common with
+   * equality deletes.
+   *
+   * <p>This option sets {@link SparkSQLProperties#EXECUTOR_CACHE_DELETE_FILES_ENABLED} for the
+   * rewrite, so any value configured for that property in the session is ignored.
+   *
+   * <p>Defaults to false.
+   */
+  public static final String EXECUTOR_CACHE_DELETE_FILES_ENABLED =
+      "executor-cache.delete-files.enabled";
+
+  public static final boolean EXECUTOR_CACHE_DELETE_FILES_ENABLED_DEFAULT = false;
+
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
           MAX_CONCURRENT_FILE_GROUP_REWRITES,
@@ -82,6 +99,7 @@ public class RewriteDataFilesSparkAction
           REWRITE_JOB_ORDER,
           OUTPUT_SPEC_ID,
           REMOVE_DANGLING_DELETES,
+          EXECUTOR_CACHE_DELETE_FILES_ENABLED,
           BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE);
 
   private static final RewriteDataFilesSparkAction.Result EMPTY_RESULT =
@@ -105,10 +123,6 @@ public class RewriteDataFilesSparkAction
     super(((org.apache.spark.sql.classic.SparkSession) spark).cloneSession());
     // Disable Adaptive Query Execution as this may change the output partitioning of our write
     spark().conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
-    // Disable executor cache for delete files as each partition is rewritten separately.
-    // Note: when compacting to a different target spec, data from multiple partitions
-    // may be grouped together, but caching is still disabled to avoid connection pool issues.
-    spark().conf().set(SparkSQLProperties.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "false");
     this.caseSensitive = SparkUtil.caseSensitive(spark);
     this.table = table;
   }
@@ -423,6 +437,17 @@ public class RewriteDataFilesSparkAction
     removeDanglingDeletes =
         PropertyUtil.propertyAsBoolean(
             options(), REMOVE_DANGLING_DELETES, REMOVE_DANGLING_DELETES_DEFAULT);
+
+    boolean cacheDeleteFiles =
+        PropertyUtil.propertyAsBoolean(
+            options(),
+            EXECUTOR_CACHE_DELETE_FILES_ENABLED,
+            EXECUTOR_CACHE_DELETE_FILES_ENABLED_DEFAULT);
+    spark()
+        .conf()
+        .set(
+            SparkSQLProperties.EXECUTOR_CACHE_DELETE_FILES_ENABLED,
+            String.valueOf(cacheDeleteFiles));
 
     Preconditions.checkArgument(
         maxConcurrentFileGroupRewrites >= 1,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -219,7 +219,7 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
   }
 
   @TestTemplate
-  void rewriteOpensDeletesPerDataFileByDefault() throws Exception {
+  void cacheDeleteFilesDisabledByDefault() throws Exception {
     List<DeleteFile> deleteFiles = createAndInitTable(TableProperties.DELETE_MODE, MERGE_ON_READ);
 
     RewriteDataFiles.Result result =
@@ -235,14 +235,14 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
   }
 
   @TestTemplate
-  void rewriteOpensDeletesOnceWhenCacheEnabledByOption() throws Exception {
+  void cacheDeleteFilesEnabledByOption() throws Exception {
     List<DeleteFile> deleteFiles = createAndInitTable(TableProperties.DELETE_MODE, MERGE_ON_READ);
 
     RewriteDataFiles.Result result =
         SparkActions.get(spark)
             .rewriteDataFiles(Spark3Util.loadIcebergTable(spark, targetTableName))
             .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
-            .option(RewriteDataFilesSparkAction.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "true")
+            .option(RewriteDataFilesSparkAction.CACHE_DELETE_FILES, "true")
             .execute();
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(2);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -49,6 +49,8 @@ import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.RewriteDataFiles;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
@@ -68,6 +70,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkExecutorCache.CacheValue;
 import org.apache.iceberg.spark.SparkExecutorCache.Conf;
+import org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.SparkEnv;
@@ -212,6 +216,38 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
           SparkReadConf readConf = new SparkReadConf(spark, table);
           assertThat(readConf.cacheDeleteFilesOnExecutors()).isFalse();
         });
+  }
+
+  @TestTemplate
+  void rewriteOpensDeletesPerDataFileByDefault() throws Exception {
+    List<DeleteFile> deleteFiles = createAndInitTable(TableProperties.DELETE_MODE, MERGE_ON_READ);
+
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(Spark3Util.loadIcebergTable(spark, targetTableName))
+            .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
+            .execute();
+
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(2);
+
+    // both delete files apply to both data files and the cache is off, so each is opened per file
+    assertThat(deleteFiles).allMatch(deleteFile -> streamCount(deleteFile) == 2);
+  }
+
+  @TestTemplate
+  void rewriteOpensDeletesOnceWhenCacheEnabledByOption() throws Exception {
+    List<DeleteFile> deleteFiles = createAndInitTable(TableProperties.DELETE_MODE, MERGE_ON_READ);
+
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(Spark3Util.loadIcebergTable(spark, targetTableName))
+            .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
+            .option(RewriteDataFilesSparkAction.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "true")
+            .execute();
+
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(2);
+
+    assertThat(deleteFiles).allMatch(deleteFile -> streamCount(deleteFile) == 1);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -111,7 +111,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
-import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
@@ -2240,33 +2239,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 4);
     List<Object[]> actualRecordsWithLineage = currentDataWithLineage();
     assertEquals("Rows must match", expectedRecords, actualRecordsWithLineage);
-  }
-
-  @TestTemplate
-  public void testExecutorCacheForDeleteFilesDisabled() {
-    Table table = createTablePartitioned(1, 1);
-    RewriteDataFilesSparkAction action = SparkActions.get(spark).rewriteDataFiles(table);
-    action.execute();
-
-    SparkReadConf readConf = new SparkReadConf(action.spark(), table);
-    assertThat(readConf.cacheDeleteFilesOnExecutors())
-        .as("Executor cache for delete files should be disabled in RewriteDataFilesSparkAction")
-        .isFalse();
-  }
-
-  @TestTemplate
-  void executorCacheForDeleteFilesEnabledByOption() {
-    Table table = createTablePartitioned(1, 1);
-    RewriteDataFilesSparkAction action =
-        SparkActions.get(spark)
-            .rewriteDataFiles(table)
-            .option(RewriteDataFilesSparkAction.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "true");
-    action.execute();
-
-    SparkReadConf readConf = new SparkReadConf(action.spark(), table);
-    assertThat(readConf.cacheDeleteFilesOnExecutors())
-        .as("Executor cache for delete files should be enabled when the option requests it")
-        .isTrue();
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -111,6 +111,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
+import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
@@ -2239,6 +2240,29 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 4);
     List<Object[]> actualRecordsWithLineage = currentDataWithLineage();
     assertEquals("Rows must match", expectedRecords, actualRecordsWithLineage);
+  }
+
+  @TestTemplate
+  void cacheDeleteFilesOnExecutorsDisabledByDefault() {
+    Table table = createTablePartitioned(1, 1);
+    RewriteDataFilesSparkAction action = SparkActions.get(spark).rewriteDataFiles(table);
+    action.init(0L);
+
+    SparkReadConf readConf = new SparkReadConf(action.spark(), table);
+    assertThat(readConf.cacheDeleteFilesOnExecutors()).isFalse();
+  }
+
+  @TestTemplate
+  void cacheDeleteFilesOnExecutorsEnabledByOption() {
+    Table table = createTablePartitioned(1, 1);
+    RewriteDataFilesSparkAction action =
+        SparkActions.get(spark)
+            .rewriteDataFiles(table)
+            .option(RewriteDataFilesSparkAction.CACHE_DELETE_FILES, "true");
+    action.init(0L);
+
+    SparkReadConf readConf = new SparkReadConf(action.spark(), table);
+    assertThat(readConf.cacheDeleteFilesOnExecutors()).isTrue();
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2246,12 +2246,27 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testExecutorCacheForDeleteFilesDisabled() {
     Table table = createTablePartitioned(1, 1);
     RewriteDataFilesSparkAction action = SparkActions.get(spark).rewriteDataFiles(table);
+    action.execute();
 
-    // The constructor should have set the configuration to false
     SparkReadConf readConf = new SparkReadConf(action.spark(), table);
     assertThat(readConf.cacheDeleteFilesOnExecutors())
         .as("Executor cache for delete files should be disabled in RewriteDataFilesSparkAction")
         .isFalse();
+  }
+
+  @TestTemplate
+  void executorCacheForDeleteFilesEnabledByOption() {
+    Table table = createTablePartitioned(1, 1);
+    RewriteDataFilesSparkAction action =
+        SparkActions.get(spark)
+            .rewriteDataFiles(table)
+            .option(RewriteDataFilesSparkAction.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "true");
+    action.execute();
+
+    SparkReadConf readConf = new SparkReadConf(action.spark(), table);
+    assertThat(readConf.cacheDeleteFilesOnExecutors())
+        .as("Executor cache for delete files should be enabled when the option requests it")
+        .isTrue();
   }
 
   @TestTemplate


### PR DESCRIPTION
Related to #11648.

`RewriteDataFilesSparkAction` has disabled the executor cache for delete files unconditionally since #13820. As noted in the discussion on #11648, that is the right default for position deletes but costly for equality deletes, which cannot be narrowed to a single data file while reading and are therefore re-read in full for every data file whose bounds overlap.

This adds a rewrite option so users can opt back in, where a Spark executor cache setting is exposed as a rewrite option rather than a session property.

Existing Default behavior is unchanged. 

Usage from SQL:

```sql
CALL catalog_name.system.rewrite_data_files(
  table => 'db.sample',
  options => map('executor-cache.delete-files.enabled', 'true')
);
```

Usage from the action API:

```java
SparkActions.get(spark)
    .rewriteDataFiles(table)
    .option(RewriteDataFilesSparkAction.EXECUTOR_CACHE_DELETE_FILES_ENABLED, "true")
    .execute();
```

Tests added to `TestSparkExecutorCache` assert the number of times each delete file is opened during a rewrite: 2 per delete file with the option at its default, once per data file, and 1 with the option enabled.


---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed by me after the changes were made.
- Prompt Summary: Make the executor cache optional during `RewriteDataFiles` via a new rewrite option, keeping the existing default, then review the change against AGENTS.md and add tests.