### PR TITLE
Docs: Update documentation Flink versions and Flink lifecycle maintenance.

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -111,7 +111,7 @@ Iceberg is built using Gradle with Java 17 or 21.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style: `./gradlew spotlessApply`
-* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0,4.1 -DflinkVersions=1.20,2.0,2.1`
+* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0,4.1 -DflinkVersions=1.20,2.1,2.2,2.3`
 
 Iceberg table support is organized in library modules:
 

--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -83,7 +83,7 @@ Each engine version undergoes the following lifecycle stages:
 
 ### Apache Flink
 
-Based on the guideline of the Flink community, only the latest 2 minor versions are actively maintained.
+Based on the guideline of the Flink community, only the latest two minor versions and the current long-term support (LTS) version are actively maintained.
 Users should continuously upgrade their Flink version to stay up-to-date.
 
 <!-- markdown-link-check-disable -->
@@ -100,8 +100,10 @@ Users should continuously upgrade their Flink version to stay up-to-date.
 | 1.18    | End of Life     | 1.5.0                   | 1.9.2                  | [iceberg-flink-runtime-1.18](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.18/1.9.2/iceberg-flink-runtime-1.18-1.9.2.jar) |
 | 1.19    | End of Life     | 1.6.0                   | 1.10.2                 | [iceberg-flink-runtime-1.19](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.19/1.10.2/iceberg-flink-runtime-1.19-1.10.2.jar) |
 | 1.20    | Maintained      | 1.7.0                   | {{ icebergVersion }}   | [iceberg-flink-runtime-1.20](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.20/{{ icebergVersion }}/iceberg-flink-runtime-1.20-{{ icebergVersion }}.jar) |
-| 2.0     | Maintained      | 1.10.0                  | {{ icebergVersion }}   | [iceberg-flink-runtime-2.0](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.0/{{ icebergVersion }}/iceberg-flink-runtime-2.0-{{ icebergVersion }}.jar)    |
+| 2.0     | End of Life     | 1.10.0                  | 1.11.0                 | [iceberg-flink-runtime-2.0](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.0/1.11.0/iceberg-flink-runtime-2.0-1.11.0.jar)    |
 | 2.1     | Maintained      | 1.11.0                  | {{ icebergVersion }}   | [iceberg-flink-runtime-2.1](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.1/{{ icebergVersion }}/iceberg-flink-runtime-2.1-{{ icebergVersion }}.jar)    |
+| 2.2     | Maintained      | 1.12.0                  | {{ icebergVersion }}   | [iceberg-flink-runtime-2.2](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.2/{{ icebergVersion }}/iceberg-flink-runtime-2.2-{{ icebergVersion }}.jar)    |
+| 2.3     | Maintained      | 1.12.0                  | {{ icebergVersion }}   | [iceberg-flink-runtime-2.3](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.3/{{ icebergVersion }}/iceberg-flink-runtime-2.3-{{ icebergVersion }}.jar)    |
 
 <!-- markdown-link-check-enable -->
 


### PR DESCRIPTION
Follow-up to #17849, which added Flink 2.2/2.3 support and removed Flink 2.0.

- Mark Flink 2.0 as `End of Life` in the engine support matrix (last supported release: 1.11.0)
- Add Flink 2.2 and 2.3 as `Maintained`, with initial support in the upcoming 1.12.0 release
- Update the Flink section note to reflect the Flink community guideline (latest two minor versions + current LTS)
- Update the example build command in the contribution guide to `-DflinkVersions=1.20,2.1,2.2,2.3`

Note: the 2.2/2.3 runtime-jar links use the `{{ icebergVersion }}` template, so they will
resolve automatically once 1.12.0 is released — same approach as when Flink 2.0 was added
ahead of the 1.10.0 release (723d0998d6).