### PR TITLE
Dell: Preserve known ECS input file lengths

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -59,6 +59,11 @@ public class EcsFileIO implements FileIO {
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return EcsInputFile.fromLocation(path, length, client(), dellProperties, metrics);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return EcsOutputFile.fromLocation(path, client(), dellProperties, metrics);
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
@@ -20,11 +20,14 @@ package org.apache.iceberg.dell.ecs;
 
 import com.emc.object.s3.S3Client;
 import org.apache.iceberg.dell.DellProperties;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsInputFile extends BaseEcsFile implements InputFile {
+
+  private Long length;
 
   public static EcsInputFile fromLocation(String location, S3Client client) {
     return new EcsInputFile(
@@ -42,8 +45,28 @@ class EcsInputFile extends BaseEcsFile implements InputFile {
     return new EcsInputFile(client, new EcsURI(location), dellProperties, metrics);
   }
 
+  static EcsInputFile fromLocation(
+      String location,
+      long length,
+      S3Client client,
+      DellProperties dellProperties,
+      MetricsContext metrics) {
+    return new EcsInputFile(client, new EcsURI(location), dellProperties, length, metrics);
+  }
+
   EcsInputFile(S3Client client, EcsURI uri, DellProperties dellProperties, MetricsContext metrics) {
     super(client, uri, dellProperties, metrics);
+  }
+
+  EcsInputFile(
+      S3Client client,
+      EcsURI uri,
+      DellProperties dellProperties,
+      long length,
+      MetricsContext metrics) {
+    super(client, uri, dellProperties, metrics);
+    ValidationException.check(length >= 0, "Invalid file length: %s", length);
+    this.length = length;
   }
 
   /**
@@ -53,7 +76,11 @@ class EcsInputFile extends BaseEcsFile implements InputFile {
    */
   @Override
   public long getLength() {
-    return getObjectMetadata().getContentLength();
+    if (length == null) {
+      this.length = getObjectMetadata().getContentLength();
+    }
+
+    return length;
   }
 
   @Override

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
@@ -19,13 +19,17 @@
 package org.apache.iceberg.dell.ecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.emc.object.s3.S3Client;
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.dell.DellProperties;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
-import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -63,11 +67,12 @@ public class TestEcsInputFile {
   @Test
   public void knownLengthAvoidsMetadataRequest() {
     String location = new EcsURI(rule.bucket(), rule.randomObjectName()).toString();
-    EcsFileIO fileIO = new EcsFileIO();
-    fileIO.initialize(rule.clientProperties());
-
-    InputFile inputFile = fileIO.newInputFile(location, 10L);
+    S3Client client = mock(S3Client.class);
+    EcsInputFile inputFile =
+        EcsInputFile.fromLocation(
+            location, 10L, client, new DellProperties(), MetricsContext.nullMetrics());
 
     assertThat(inputFile.getLength()).as("File length should use the known value").isEqualTo(10L);
+    verifyNoInteractions(client);
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -57,5 +58,16 @@ public class TestEcsInputFile {
           .as("The file content should be 0123456789")
           .isEqualTo("0123456789");
     }
+  }
+
+  @Test
+  public void knownLengthAvoidsMetadataRequest() {
+    String location = new EcsURI(rule.bucket(), rule.randomObjectName()).toString();
+    EcsFileIO fileIO = new EcsFileIO();
+    fileIO.initialize(rule.clientProperties());
+
+    InputFile inputFile = fileIO.newInputFile(location, 10L);
+
+    assertThat(inputFile.getLength()).as("File length should use the known value").isEqualTo(10L);
   }
 }


### PR DESCRIPTION
### Summary

- pass known file lengths from EcsFileIO into EcsInputFile
- cache the supplied length and validate that it is non-negative
- verify that reading a known length does not request object metadata

This avoids redundant ECS HEAD requests when Iceberg already knows a data, delete, or manifest file size.

Closes #17054

### Testing

- `./gradlew :iceberg-dell:test`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: fully reviewed
- Prompt Summary: A detailed, repository-specific prompt requested a minimal known-length propagation fix, a no-network regression test, formatting, and full Dell module validation.