### PR TITLE
Delta: Use POSIX separator for data file paths

### DIFF
--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -24,7 +24,6 @@ import io.delta.standalone.actions.Action;
 import io.delta.standalone.actions.AddFile;
 import io.delta.standalone.actions.RemoveFile;
 import io.delta.standalone.exceptions.DeltaStandaloneException;
-import java.io.File;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -448,13 +447,13 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
    *     (either absolute or relative)
    * @param tableRoot the root path of the delta table
    */
-  private static String getFullFilePath(String path, String tableRoot) {
+  static String getFullFilePath(String path, String tableRoot) {
     URI dataFileUri = URI.create(path);
     String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
     if (dataFileUri.isAbsolute()) {
       return decodedPath;
     } else {
-      return tableRoot + File.separator + decodedPath;
+      return tableRoot + "/" + decodedPath;
     }
   }
 }

--- a/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.delta;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -97,6 +98,14 @@ public class TestBaseSnapshotDeltaLakeTableAction {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Delta Lake table does not exist at the given location: %s", sourceTableLocation);
+  }
+
+  @Test
+  public void fullFilePathUsesUriSeparator() {
+    assertThat(
+            BaseSnapshotDeltaLakeTableAction.getFullFilePath(
+                "data/file.parquet", "s3://bucket/table"))
+        .isEqualTo("s3://bucket/table/data/file.parquet");
   }
 
   private static class TestCatalog extends BaseMetastoreCatalog {


### PR DESCRIPTION
### Summary

- build relative Delta data file paths with the URI separator instead of the host operating system separator
- add coverage for object-store URI path assembly

This keeps migrated paths valid when the action runs on Windows.

Closes #17050

### Testing

- `./gradlew :iceberg-delta-lake:test`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: fully reviewed
- Prompt Summary: A detailed, repository-specific prompt requested a focused cross-platform path fix, regression coverage, formatting, and full module validation.