### PR TITLE
Flink: Enable Cost Based Optimizaton in Flink's planner for batch jobs

### DIFF
--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -142,9 +142,11 @@ counts may overestimate live rows.
 | table.exec.iceberg.report-column-statistics  | true    | Include column-level statistics (null counts, min/max, NDV) in addition to the row count. Column statistics require reading manifest metadata during planning; disable for very large tables if planning latency matters. |
 
 Statistics reporting can be disabled entirely with Flink's
-`table.optimizer.source.report-statistics-enabled` option. Streaming queries and reads
-using time-travel options (`snapshot-id`, `branch`, `tag`, `as-of-timestamp`, incremental
-start/end options) always report unknown statistics.
+`table.optimizer.source.report-statistics-enabled` option. Point-in-time reads
+(`snapshot-id`, `branch`, `tag`, `as-of-timestamp`) report statistics for the snapshot
+being read. Streaming queries and incremental reads (`start-snapshot-id`,
+`start-snapshot-timestamp`, `start-tag`, `end-snapshot-id`, `end-tag`) always report
+unknown statistics.
 
 ### Write options
 

--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -127,6 +127,25 @@ env.getConfig()
 | watermark-column              | connector.iceberg.watermark-column              | N/A                          | null                             | Specifies the watermark column to use for watermark generation. If this option is present, the `splitAssignerFactory` will be overridden with `OrderedSplitAssignerFactory`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | watermark-column-time-unit    | connector.iceberg.watermark-column-time-unit    | N/A                          | TimeUnit.MICROSECONDS            | Specifies the watermark time unit to use for watermark generation. The possible values are  DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
+### Statistics reporting
+
+In batch execution mode, the Iceberg connector reports table statistics to the Flink
+planner through `SupportsStatisticReport`: the row count, and per-column null counts,
+min/max values, and NDV (when a Puffin statistics file produced by `ANALYZE TABLE` in
+Spark or the `compute_table_stats` action is present for the current snapshot). These
+statistics enable cost-based optimizations such as join reordering and broadcast-join
+selection. Statistics are estimates: when delete files are present, row counts and null
+counts may overestimate live rows.
+
+| Flink configuration                          | Default | Description                                                                                       |
+| -------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| table.exec.iceberg.report-column-statistics  | true    | Include column-level statistics (null counts, min/max, NDV) in addition to the row count. Column statistics require reading manifest metadata during planning; disable for very large tables if planning latency matters. |
+
+Statistics reporting can be disabled entirely with Flink's
+`table.optimizer.source.report-statistics-enabled` option. Streaming queries and reads
+using time-travel options (`snapshot-id`, `branch`, `tag`, `as-of-timestamp`, incremental
+start/end options) always report unknown statistics.
+
 ### Write options
 
 Flink write options are passed when configuring the FlinkSink, like this:

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -97,6 +97,15 @@ public class FlinkConfigOptions {
           .defaultValue(false)
           .withDescription("Use the SinkV2 API based Iceberg sink implementation.");
 
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_REPORT_COLUMN_STATISTICS =
+      ConfigOptions.key("table.exec.iceberg.report-column-statistics")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription(
+              "When reporting statistics to the Flink planner in batch mode, whether to include "
+                  + "column-level statistics (null counts, min/max, NDV) computed from table "
+                  + "metadata in addition to the row count.");
+
   public static final ConfigOption<SplitAssignerType> TABLE_EXEC_SPLIT_ASSIGNER_TYPE =
       ConfigOptions.key("table.exec.iceberg.split-assigner-type")
           .enumType(SplitAssignerType.class)

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/FlinkTableStatistics.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/FlinkTableStatistics.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.expressions.AggregateEvaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.flink.FlinkReadConf;
 import org.apache.iceberg.puffin.StandardBlobTypes;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -50,6 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.SnapshotUtil;
 
 /**
  * Computes Flink {@link TableStats} from Iceberg metadata only (snapshot summary and manifests).
@@ -85,10 +87,21 @@ class FlinkTableStatistics {
   private FlinkTableStatistics() {}
 
   static TableStats reportStatistics(
-      Table table, List<Expression> filters, boolean columnStatsEnabled) {
-    Snapshot snapshot = table.currentSnapshot();
+      Table table, FlinkReadConf readConf, List<Expression> filters, boolean columnStatsEnabled) {
+    if (readConf.streaming() || isIncrementalRead(readConf)) {
+      return TableStats.UNKNOWN;
+    }
+
+    boolean timeTravel =
+        readConf.snapshotId() != null
+            || readConf.tag() != null
+            || readConf.branch() != null
+            || readConf.asOfTimestamp() != null;
+    Snapshot snapshot = resolveSnapshot(table, readConf);
     if (snapshot == null) {
-      return new TableStats(0L);
+      // null means either an empty table (report 0 rows) or a time-travel reference
+      // that does not exist (report unknown; the scan will fail with a proper error)
+      return timeTravel ? TableStats.UNKNOWN : new TableStats(0L);
     }
 
     boolean filtered = filters != null && !filters.isEmpty();
@@ -102,6 +115,38 @@ class FlinkTableStatistics {
     }
 
     return statsFromManifests(table, snapshot, filters, filtered, columnStatsEnabled);
+  }
+
+  private static boolean isIncrementalRead(FlinkReadConf readConf) {
+    return readConf.startSnapshotId() != null
+        || readConf.startSnapshotTimestamp() != null
+        || readConf.startTag() != null
+        || readConf.endSnapshotId() != null
+        || readConf.endTag() != null;
+  }
+
+  private static Snapshot resolveSnapshot(Table table, FlinkReadConf readConf) {
+    if (readConf.snapshotId() != null) {
+      return table.snapshot(readConf.snapshotId());
+    }
+
+    if (readConf.tag() != null) {
+      return table.snapshot(readConf.tag());
+    }
+
+    if (readConf.branch() != null) {
+      return SnapshotUtil.latestSnapshot(table, readConf.branch());
+    }
+
+    if (readConf.asOfTimestamp() != null) {
+      try {
+        return table.snapshot(SnapshotUtil.snapshotIdAsOfTime(table, readConf.asOfTimestamp()));
+      } catch (IllegalArgumentException e) {
+        return null; // no snapshot as of that time
+      }
+    }
+
+    return table.currentSnapshot();
   }
 
   private static TableStats statsFromManifests(
@@ -149,16 +194,16 @@ class FlinkTableStatistics {
       }
     }
 
-    return new TableStats(rowCount, buildColumnStats(table, collectors));
+    return new TableStats(rowCount, buildColumnStats(table, snapshot, collectors));
   }
 
   private static Map<String, ColumnStats> buildColumnStats(
-      Table table, List<ColumnStatsCollector> collectors) {
+      Table table, Snapshot snapshot, List<ColumnStatsCollector> collectors) {
     if (collectors.isEmpty()) {
       return ImmutableMap.of();
     }
 
-    Map<Integer, Long> ndvs = ndvFromStatisticsFiles(table, table.currentSnapshot().snapshotId());
+    Map<Integer, Long> ndvs = ndvFromStatisticsFiles(table, snapshot.snapshotId());
     Map<String, ColumnStats> colStats = Maps.newHashMap();
     for (ColumnStatsCollector collector : collectors) {
       ColumnStats columnStats = collector.toColumnStats(ndvs.get(collector.fieldId()));

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/FlinkTableStatistics.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/FlinkTableStatistics.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.iceberg.BlobMetadata;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.AggregateEvaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+
+/**
+ * Computes Flink {@link TableStats} from Iceberg metadata only (snapshot summary and manifests).
+ *
+ * <p>Manifests are read directly instead of through a table scan so that computing statistics
+ * during query planning produces no observable side effects: no {@code ScanEvent} is fired and no
+ * scan-planning metrics are reported. The same pruning as scan planning is applied via {@link
+ * ManifestEvaluator} at the manifest level and the manifest reader's row filter at the file level.
+ *
+ * <p>Reported values are planner estimates: when delete files are present, row counts and null
+ * counts are overestimates because manifest metrics describe files as written.
+ *
+ * <p>Min/max values for DATE, TIME, TIMESTAMP and TIMESTAMP_NANO columns are reported as Iceberg's
+ * numeric internal representations (days/micros/nanos since epoch) — monotonic, {@link Number}
+ * -typed values that are safe for the planner's interval arithmetic. String and binary columns
+ * never report min/max because manifest bounds may be truncated.
+ */
+class FlinkTableStatistics {
+
+  private static final Set<Type.TypeID> MIN_MAX_TYPES =
+      EnumSet.of(
+          Type.TypeID.BOOLEAN,
+          Type.TypeID.INTEGER,
+          Type.TypeID.LONG,
+          Type.TypeID.FLOAT,
+          Type.TypeID.DOUBLE,
+          Type.TypeID.DATE,
+          Type.TypeID.TIME,
+          Type.TypeID.TIMESTAMP,
+          Type.TypeID.TIMESTAMP_NANO,
+          Type.TypeID.DECIMAL);
+
+  private FlinkTableStatistics() {}
+
+  static TableStats reportStatistics(
+      Table table, List<Expression> filters, boolean columnStatsEnabled) {
+    Snapshot snapshot = table.currentSnapshot();
+    if (snapshot == null) {
+      return new TableStats(0L);
+    }
+
+    boolean filtered = filters != null && !filters.isEmpty();
+    if (!filtered && !columnStatsEnabled) {
+      long totalRecords =
+          PropertyUtil.propertyAsLong(snapshot.summary(), SnapshotSummary.TOTAL_RECORDS_PROP, -1L);
+      if (totalRecords >= 0) {
+        return new TableStats(totalRecords);
+      }
+      // very old writers may not have written total-records; fall through to the manifest path
+    }
+
+    return statsFromManifests(table, snapshot, filters, filtered, columnStatsEnabled);
+  }
+
+  private static TableStats statsFromManifests(
+      Table table,
+      Snapshot snapshot,
+      List<Expression> filters,
+      boolean filtered,
+      boolean columnStatsEnabled) {
+    Expression rowFilter =
+        filtered
+            ? filters.stream().reduce(Expressions.alwaysTrue(), Expressions::and)
+            : Expressions.alwaysTrue();
+    List<ColumnStatsCollector> collectors =
+        columnStatsEnabled ? createCollectors(table.schema()) : ImmutableList.of();
+
+    long rowCount = 0L;
+    for (ManifestFile manifest : snapshot.dataManifests(table.io())) {
+      if (filtered
+          && !ManifestEvaluator.forRowFilter(
+                  rowFilter, table.specs().get(manifest.partitionSpecId()), true)
+              .eval(manifest)) {
+        continue;
+      }
+
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs()).filterRows(rowFilter)) {
+        for (DataFile file : reader) {
+          long recordCount = file.recordCount();
+          if (recordCount <= 0) {
+            return TableStats.UNKNOWN;
+          }
+
+          try {
+            rowCount = Math.addExact(rowCount, recordCount);
+          } catch (ArithmeticException e) {
+            return TableStats.UNKNOWN;
+          }
+
+          for (ColumnStatsCollector collector : collectors) {
+            collector.update(file);
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to read manifest for statistics", e);
+      }
+    }
+
+    return new TableStats(rowCount, buildColumnStats(table, collectors));
+  }
+
+  private static Map<String, ColumnStats> buildColumnStats(
+      Table table, List<ColumnStatsCollector> collectors) {
+    if (collectors.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    Map<Integer, Long> ndvs = ndvFromStatisticsFiles(table, table.currentSnapshot().snapshotId());
+    Map<String, ColumnStats> colStats = Maps.newHashMap();
+    for (ColumnStatsCollector collector : collectors) {
+      ColumnStats columnStats = collector.toColumnStats(ndvs.get(collector.fieldId()));
+      if (columnStats != null) {
+        colStats.put(collector.columnName(), columnStats);
+      }
+    }
+
+    return colStats;
+  }
+
+  private static Map<Integer, Long> ndvFromStatisticsFiles(Table table, long snapshotId) {
+    Map<Integer, Long> ndvs = Maps.newHashMap();
+    for (StatisticsFile statisticsFile : table.statisticsFiles()) {
+      if (statisticsFile.snapshotId() != snapshotId) {
+        continue;
+      }
+
+      for (BlobMetadata blob : statisticsFile.blobMetadata()) {
+        if (StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1.equals(blob.type())
+            && blob.fields().size() == 1) {
+          String ndv = blob.properties().get("ndv");
+          if (!Strings.isNullOrEmpty(ndv)) {
+            ndvs.put(blob.fields().get(0), Long.parseLong(ndv));
+          }
+        }
+      }
+    }
+
+    return ndvs;
+  }
+
+  private static List<ColumnStatsCollector> createCollectors(Schema schema) {
+    List<ColumnStatsCollector> collectors = Lists.newArrayList();
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        collectors.add(new ColumnStatsCollector(schema, field));
+      }
+    }
+
+    return collectors;
+  }
+
+  /** Folds per-file manifest metrics for one top-level column. */
+  private static class ColumnStatsCollector {
+    private final Types.NestedField field;
+    private final AggregateEvaluator minMaxEvaluator; // null when the type is not eligible
+    private long nullCount = 0L;
+    private boolean nullCountValid = true;
+
+    ColumnStatsCollector(Schema schema, Types.NestedField field) {
+      this.field = field;
+      this.minMaxEvaluator =
+          MIN_MAX_TYPES.contains(field.type().typeId())
+              ? AggregateEvaluator.create(
+                  schema,
+                  ImmutableList.of(Expressions.min(field.name()), Expressions.max(field.name())))
+              : null;
+    }
+
+    String columnName() {
+      return field.name();
+    }
+
+    int fieldId() {
+      return field.fieldId();
+    }
+
+    void update(DataFile file) {
+      Map<Integer, Long> nullCounts = file.nullValueCounts();
+      Long fileNullCount = nullCounts == null ? null : nullCounts.get(field.fieldId());
+      if (fileNullCount == null) {
+        this.nullCountValid = false;
+      } else {
+        this.nullCount += fileNullCount;
+      }
+
+      if (minMaxEvaluator != null) {
+        minMaxEvaluator.update(file);
+      }
+    }
+
+    ColumnStats toColumnStats(Long ndv) {
+      ColumnStats.Builder builder = ColumnStats.Builder.builder();
+      boolean hasAnyStat = false;
+      if (ndv != null) {
+        builder.setNdv(ndv);
+        hasAnyStat = true;
+      }
+
+      if (nullCountValid) {
+        builder.setNullCount(nullCount);
+        hasAnyStat = true;
+      }
+
+      if (minMaxEvaluator != null && minMaxEvaluator.allAggregatorsValid()) {
+        StructLike result = minMaxEvaluator.result();
+        Object min = result.get(0, Object.class);
+        Object max = result.get(1, Object.class);
+        if (min instanceof Comparable && max instanceof Comparable) {
+          builder.setMin((Comparable<?>) min);
+          builder.setMax((Comparable<?>) max);
+          hasAnyStat = true;
+        }
+      }
+
+      return hasAnyStat ? builder.build() : null;
+    }
+  }
+}

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.flink.source;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
@@ -50,12 +51,12 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.FlinkFilters;
+import org.apache.iceberg.flink.FlinkReadConf;
 import org.apache.iceberg.flink.FlinkReadOptions;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.source.assigner.SplitAssignerType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -73,22 +74,10 @@ public class IcebergTableSource
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergTableSource.class);
 
-  // statistics are computed for the current table state only; these options change what is read
-  private static final Set<String> TIME_TRAVEL_OPTIONS =
-      ImmutableSet.of(
-          "snapshot-id",
-          "branch",
-          "tag",
-          "as-of-timestamp",
-          "start-snapshot-id",
-          "end-snapshot-id",
-          "start-tag",
-          "end-tag",
-          "start-snapshot-timestamp");
-
   private int[] projectedFields;
   private Long limit;
   private List<Expression> filters;
+  private Table table;
 
   private final TableLoader loader;
   private final ResolvedSchema schema;
@@ -105,6 +94,7 @@ public class IcebergTableSource
     this.limit = toCopy.limit;
     this.filters = toCopy.filters;
     this.readableConfig = toCopy.readableConfig;
+    this.table = toCopy.table;
   }
 
   public IcebergTableSource(
@@ -144,11 +134,26 @@ public class IcebergTableSource
     }
   }
 
+  /** Loads the table once; reused by statistics reporting and both datastream builders. */
+  private Table table() {
+    if (table == null) {
+      try (TableLoader tableLoader = loader.clone()) {
+        tableLoader.open();
+        this.table = tableLoader.loadTable();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to load table with loader: " + loader, e);
+      }
+    }
+
+    return table;
+  }
+
   @SuppressWarnings("deprecation")
   private DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv) {
     return FlinkSource.forRowData()
         .env(execEnv)
         .tableLoader(loader)
+        .table(table())
         .setAll(properties)
         .project(TableSchema.fromResolvedSchema(getProjectedSchema()))
         .limit(limit)
@@ -162,6 +167,7 @@ public class IcebergTableSource
         readableConfig.get(FlinkConfigOptions.TABLE_EXEC_SPLIT_ASSIGNER_TYPE);
     return IcebergSource.forRowData()
         .tableLoader(loader)
+        .table(table())
         .assignerFactory(assignerType.factory())
         .setAll(properties)
         .project(getProjectedSchema())
@@ -254,21 +260,12 @@ public class IcebergTableSource
   @Override
   public TableStats reportStatistics() {
     try {
-      if (!FlinkSource.isBounded(properties)) {
-        return TableStats.UNKNOWN;
-      }
-
-      if (TIME_TRAVEL_OPTIONS.stream().anyMatch(properties::containsKey)) {
-        return TableStats.UNKNOWN;
-      }
-
       boolean columnStatsEnabled =
           readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_REPORT_COLUMN_STATISTICS);
-      try (TableLoader tableLoader = loader.clone()) {
-        tableLoader.open();
-        Table table = tableLoader.loadTable();
-        return FlinkTableStatistics.reportStatistics(table, filters, columnStatsEnabled);
-      }
+      Table loadedTable = table();
+      FlinkReadConf readConf = new FlinkReadConf(loadedTable, properties, readableConfig);
+      return FlinkTableStatistics.reportStatistics(
+          loadedTable, readConf, filters, columnStatsEnabled);
     } catch (Exception e) {
       LOG.warn("Failed to report statistics for Iceberg table, returning unknown stats", e);
       return TableStats.UNKNOWN;

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -77,8 +77,8 @@ public class IcebergTableSource
   private int[] projectedFields;
   private Long limit;
   private List<Expression> filters;
-  private Table table;
 
+  private final Table table;
   private final TableLoader loader;
   private final ResolvedSchema schema;
   private final Map<String, String> properties;
@@ -122,6 +122,13 @@ public class IcebergTableSource
     this.limit = limit;
     this.filters = filters;
     this.readableConfig = readableConfig;
+
+    try (TableLoader clonedLoader = loader.clone()) {
+      clonedLoader.open();
+      this.table = clonedLoader.loadTable();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to load table with loader: " + loader, e);
+    }
   }
 
   @Override
@@ -134,26 +141,12 @@ public class IcebergTableSource
     }
   }
 
-  /** Loads the table once; reused by statistics reporting and both datastream builders. */
-  private Table table() {
-    if (table == null) {
-      try (TableLoader tableLoader = loader.clone()) {
-        tableLoader.open();
-        this.table = tableLoader.loadTable();
-      } catch (IOException e) {
-        throw new UncheckedIOException("Failed to load table with loader: " + loader, e);
-      }
-    }
-
-    return table;
-  }
-
   @SuppressWarnings("deprecation")
   private DataStream<RowData> createDataStream(StreamExecutionEnvironment execEnv) {
     return FlinkSource.forRowData()
         .env(execEnv)
         .tableLoader(loader)
-        .table(table())
+        .table(table)
         .setAll(properties)
         .project(TableSchema.fromResolvedSchema(getProjectedSchema()))
         .limit(limit)
@@ -167,7 +160,7 @@ public class IcebergTableSource
         readableConfig.get(FlinkConfigOptions.TABLE_EXEC_SPLIT_ASSIGNER_TYPE);
     return IcebergSource.forRowData()
         .tableLoader(loader)
-        .table(table())
+        .table(table)
         .assignerFactory(assignerType.factory())
         .setAll(properties)
         .project(getProjectedSchema())
@@ -262,10 +255,8 @@ public class IcebergTableSource
     try {
       boolean columnStatsEnabled =
           readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_REPORT_COLUMN_STATISTICS);
-      Table loadedTable = table();
-      FlinkReadConf readConf = new FlinkReadConf(loadedTable, properties, readableConfig);
-      return FlinkTableStatistics.reportStatistics(
-          loadedTable, readConf, filters, columnStatsEnabled);
+      FlinkReadConf readConf = new FlinkReadConf(table, properties, readableConfig);
+      return FlinkTableStatistics.reportStatistics(table, readConf, filters, columnStatsEnabled);
     } catch (Exception e) {
       LOG.warn("Failed to report statistics for Iceberg table, returning unknown stats", e);
       return TableStats.UNKNOWN;

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
@@ -38,11 +39,14 @@ import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
+import org.apache.flink.table.connector.source.abilities.SupportsStatisticReport;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.legacy.api.TableSchema;
+import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.FlinkFilters;
@@ -51,8 +55,11 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.source.assigner.SplitAssignerType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Flink Iceberg table source. */
 @Internal
@@ -61,7 +68,23 @@ public class IcebergTableSource
         SupportsProjectionPushDown,
         SupportsFilterPushDown,
         SupportsLimitPushDown,
-        SupportsSourceWatermark {
+        SupportsSourceWatermark,
+        SupportsStatisticReport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergTableSource.class);
+
+  // statistics are computed for the current table state only; these options change what is read
+  private static final Set<String> TIME_TRAVEL_OPTIONS =
+      ImmutableSet.of(
+          "snapshot-id",
+          "branch",
+          "tag",
+          "as-of-timestamp",
+          "start-snapshot-id",
+          "end-snapshot-id",
+          "start-tag",
+          "end-tag",
+          "start-snapshot-timestamp");
 
   private int[] projectedFields;
   private Long limit;
@@ -226,6 +249,30 @@ public class IcebergTableSource
             PropertyUtil.propertyAsNullableInt(properties, FactoryUtil.SOURCE_PARALLELISM.key()));
       }
     };
+  }
+
+  @Override
+  public TableStats reportStatistics() {
+    try {
+      if (!FlinkSource.isBounded(properties)) {
+        return TableStats.UNKNOWN;
+      }
+
+      if (TIME_TRAVEL_OPTIONS.stream().anyMatch(properties::containsKey)) {
+        return TableStats.UNKNOWN;
+      }
+
+      boolean columnStatsEnabled =
+          readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_REPORT_COLUMN_STATISTICS);
+      try (TableLoader tableLoader = loader.clone()) {
+        tableLoader.open();
+        Table table = tableLoader.loadTable();
+        return FlinkTableStatistics.reportStatistics(table, filters, columnStatsEnabled);
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to report statistics for Iceberg table, returning unknown stats", e);
+      return TableStats.UNKNOWN;
+    }
   }
 
   @Override

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableStatistics.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableStatistics.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
@@ -38,14 +39,17 @@ import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.FlinkReadConf;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.puffin.StandardBlobTypes;
@@ -92,6 +96,11 @@ public class TestFlinkTableStatistics {
     return record;
   }
 
+  private TableStats stats(List<Expression> filters, boolean columnStatsEnabled) {
+    FlinkReadConf readConf = new FlinkReadConf(table, ImmutableMap.of(), new Configuration());
+    return FlinkTableStatistics.reportStatistics(table, readConf, filters, columnStatsEnabled);
+  }
+
   /** Two files: ids 1-3 (one null data, one null score) and ids 4-5. */
   private void appendTwoFiles() throws Exception {
     appender.appendToTable(
@@ -101,23 +110,21 @@ public class TestFlinkTableStatistics {
 
   @Test
   public void testFreshTableReportsZeroRows() {
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    TableStats stats = stats(ImmutableList.of(), false);
     assertThat(stats.getRowCount()).isEqualTo(0L);
   }
 
   @Test
   public void testUnfilteredRowCountFromSnapshotSummary() throws Exception {
     appendTwoFiles();
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    TableStats stats = stats(ImmutableList.of(), false);
     assertThat(stats.getRowCount()).isEqualTo(5L);
   }
 
   @Test
   public void testFilteredRowCountFromPlannedFiles() throws Exception {
     appendTwoFiles();
-    TableStats stats =
-        FlinkTableStatistics.reportStatistics(
-            table, ImmutableList.of(Expressions.greaterThanOrEqual("id", 4)), false);
+    TableStats stats = stats(ImmutableList.of(Expressions.greaterThanOrEqual("id", 4)), false);
     // file with ids 1-3 is pruned by its column bounds
     assertThat(stats.getRowCount()).isEqualTo(2L);
   }
@@ -125,7 +132,7 @@ public class TestFlinkTableStatistics {
   @Test
   public void testColumnStatsFromManifests() throws Exception {
     appendTwoFiles();
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    TableStats stats = stats(ImmutableList.of(), true);
 
     assertThat(stats.getRowCount()).isEqualTo(5L);
     ColumnStats idStats = stats.getColumnStats().get("id");
@@ -148,7 +155,7 @@ public class TestFlinkTableStatistics {
   @Test
   public void testColumnStatsDisabled() throws Exception {
     appendTwoFiles();
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    TableStats stats = stats(ImmutableList.of(), false);
     assertThat(stats.getColumnStats()).isEmpty();
   }
 
@@ -156,7 +163,7 @@ public class TestFlinkTableStatistics {
   public void testMetricsModeNoneOmitsColumnStats() throws Exception {
     table.updateProperties().set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none").commit();
     appendTwoFiles();
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    TableStats stats = stats(ImmutableList.of(), true);
     // row count survives (recordCount is always present), column stats are absent
     assertThat(stats.getRowCount()).isEqualTo(5L);
     assertThat(stats.getColumnStats()).isEmpty();
@@ -175,7 +182,7 @@ public class TestFlinkTableStatistics {
             .first();
     table.newRowDelta().addDeletes(posDeletes).commit();
 
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    TableStats stats = stats(ImmutableList.of(), true);
     // overestimate: deleted row still counted (6, not 5) — documented estimate semantics
     assertThat(stats.getRowCount()).isEqualTo(6L);
   }
@@ -208,11 +215,69 @@ public class TestFlinkTableStatistics {
     assertThat(stats).isEqualTo(TableStats.UNKNOWN);
   }
 
+  /** First snapshot has 3 rows; a second append brings the table to 5. */
+  private Snapshot firstSnapshot() throws Exception {
+    appender.appendToTable(
+        ImmutableList.of(record(1, "a", 1.0), record(2, null, 2.5), record(3, "c", null)));
+    Snapshot snapshot = table.currentSnapshot();
+    Thread.sleep(2); // keep as-of-timestamp strictly between the two snapshots
+    appender.appendToTable(ImmutableList.of(record(4, "d", 4.0), record(5, "e", 5.0)));
+    return snapshot;
+  }
+
   @Test
-  public void testTimeTravelSourceReportsUnknown() throws Exception {
+  public void testSnapshotIdReportsStatsForThatSnapshot() throws Exception {
+    Snapshot first = firstSnapshot();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("snapshot-id", String.valueOf(first.snapshotId()));
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(3L);
+    assertThat(stats.getColumnStats().get("id").getMax()).isEqualTo(3);
+  }
+
+  @Test
+  public void testTagReportsStatsForTaggedSnapshot() throws Exception {
+    Snapshot first = firstSnapshot();
+    table.manageSnapshots().createTag("v1", first.snapshotId()).commit();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("tag", "v1");
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(3L);
+  }
+
+  @Test
+  public void testBranchReportsStatsForBranchHead() throws Exception {
+    Snapshot first = firstSnapshot();
+    table.manageSnapshots().createBranch("b1", first.snapshotId()).commit();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("branch", "b1");
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(3L);
+  }
+
+  @Test
+  public void testAsOfTimestampReportsStatsForThatTime() throws Exception {
+    Snapshot first = firstSnapshot();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("as-of-timestamp", String.valueOf(first.timestampMillis()));
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(3L);
+  }
+
+  @Test
+  public void testIncrementalReadReportsUnknown() throws Exception {
+    Snapshot first = firstSnapshot();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("start-snapshot-id", String.valueOf(first.snapshotId()));
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats).isEqualTo(TableStats.UNKNOWN);
+  }
+
+  @Test
+  public void testUnknownRefReportsUnknown() throws Exception {
     appendTwoFiles();
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("snapshot-id", String.valueOf(table.currentSnapshot().snapshotId()));
+    properties.put("tag", "does-not-exist");
     TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
     assertThat(stats).isEqualTo(TableStats.UNKNOWN);
   }
@@ -246,7 +311,7 @@ public class TestFlinkTableStatistics {
                     ImmutableMap.of("ndv", "5"))));
     table.updateStatistics().setStatistics(statisticsFile).commit();
 
-    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    TableStats stats = stats(ImmutableList.of(), true);
     assertThat(stats.getColumnStats().get("id").getNdv()).isEqualTo(5L);
     // no blob for field 2 → no NDV, other stats still present
     assertThat(stats.getColumnStats().get("data").getNdv()).isNull();
@@ -270,9 +335,7 @@ public class TestFlinkTableStatistics {
 
     // filtered → planned-files path; the fake files have no column bounds, so they cannot
     // be pruned, and summing their record counts must hit the overflow sentinel guard
-    TableStats stats =
-        FlinkTableStatistics.reportStatistics(
-            table, ImmutableList.of(Expressions.greaterThanOrEqual("id", 0)), false);
+    TableStats stats = stats(ImmutableList.of(Expressions.greaterThanOrEqual("id", 0)), false);
     assertThat(stats).isEqualTo(TableStats.UNKNOWN);
   }
 }

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableStatistics.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableStatistics.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.GenericBlobMetadata;
+import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestFlinkTableStatistics {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional(3, "score", Types.DoubleType.get()));
+
+  @TempDir private Path warehouse;
+  @TempDir private Path appendDir;
+
+  private Table table;
+  private GenericAppenderHelper appender;
+
+  @BeforeEach
+  public void createTable() {
+    this.table =
+        new HadoopTables()
+            .create(
+                SCHEMA,
+                PartitionSpec.unpartitioned(),
+                ImmutableMap.of("format-version", "2"),
+                warehouse.resolve("tbl").toString());
+    this.appender = new GenericAppenderHelper(table, FileFormat.PARQUET, appendDir);
+  }
+
+  private Record record(int id, String data, Double score) {
+    Record record = GenericRecord.create(SCHEMA);
+    record.setField("id", id);
+    record.setField("data", data);
+    record.setField("score", score);
+    return record;
+  }
+
+  /** Two files: ids 1-3 (one null data, one null score) and ids 4-5. */
+  private void appendTwoFiles() throws Exception {
+    appender.appendToTable(
+        ImmutableList.of(record(1, "a", 1.0), record(2, null, 2.5), record(3, "c", null)));
+    appender.appendToTable(ImmutableList.of(record(4, "d", 4.0), record(5, "e", 5.0)));
+  }
+
+  @Test
+  public void testFreshTableReportsZeroRows() {
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    assertThat(stats.getRowCount()).isEqualTo(0L);
+  }
+
+  @Test
+  public void testUnfilteredRowCountFromSnapshotSummary() throws Exception {
+    appendTwoFiles();
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    assertThat(stats.getRowCount()).isEqualTo(5L);
+  }
+
+  @Test
+  public void testFilteredRowCountFromPlannedFiles() throws Exception {
+    appendTwoFiles();
+    TableStats stats =
+        FlinkTableStatistics.reportStatistics(
+            table, ImmutableList.of(Expressions.greaterThanOrEqual("id", 4)), false);
+    // file with ids 1-3 is pruned by its column bounds
+    assertThat(stats.getRowCount()).isEqualTo(2L);
+  }
+
+  @Test
+  public void testColumnStatsFromManifests() throws Exception {
+    appendTwoFiles();
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+
+    assertThat(stats.getRowCount()).isEqualTo(5L);
+    ColumnStats idStats = stats.getColumnStats().get("id");
+    assertThat(idStats.getNullCount()).isEqualTo(0L);
+    assertThat(idStats.getMin()).isEqualTo(1);
+    assertThat(idStats.getMax()).isEqualTo(5);
+
+    ColumnStats scoreStats = stats.getColumnStats().get("score");
+    assertThat(scoreStats.getNullCount()).isEqualTo(1L);
+    assertThat(scoreStats.getMin()).isEqualTo(1.0);
+    assertThat(scoreStats.getMax()).isEqualTo(5.0);
+
+    // string column: nullCount yes, min/max never
+    ColumnStats dataStats = stats.getColumnStats().get("data");
+    assertThat(dataStats.getNullCount()).isEqualTo(1L);
+    assertThat(dataStats.getMin()).isNull();
+    assertThat(dataStats.getMax()).isNull();
+  }
+
+  @Test
+  public void testColumnStatsDisabled() throws Exception {
+    appendTwoFiles();
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), false);
+    assertThat(stats.getColumnStats()).isEmpty();
+  }
+
+  @Test
+  public void testMetricsModeNoneOmitsColumnStats() throws Exception {
+    table.updateProperties().set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none").commit();
+    appendTwoFiles();
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    // row count survives (recordCount is always present), column stats are absent
+    assertThat(stats.getRowCount()).isEqualTo(5L);
+    assertThat(stats.getColumnStats()).isEmpty();
+  }
+
+  @Test
+  public void testDeleteFilesTolerated() throws Exception {
+    appendTwoFiles();
+    DataFile dataFile = appender.writeFile(ImmutableList.of(record(6, "f", 6.0)));
+    appender.appendToTable(dataFile);
+    DeleteFile posDeletes =
+        FileHelpers.writeDeleteFile(
+                table,
+                Files.localOutput(File.createTempFile("junit", null, appendDir.toFile())),
+                ImmutableList.of(Pair.of((CharSequence) dataFile.location(), 0L)))
+            .first();
+    table.newRowDelta().addDeletes(posDeletes).commit();
+
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    // overestimate: deleted row still counted (6, not 5) — documented estimate semantics
+    assertThat(stats.getRowCount()).isEqualTo(6L);
+  }
+
+  private IcebergTableSource createTableSource(
+      Map<String, String> properties, Configuration flinkConf) {
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("id", DataTypes.INT().notNull()),
+            Column.physical("data", DataTypes.STRING()),
+            Column.physical("score", DataTypes.DOUBLE()));
+    return new IcebergTableSource(
+        TableLoader.fromHadoopTable(table.location()), flinkSchema, properties, flinkConf);
+  }
+
+  @Test
+  public void testSourceReportsStatistics() throws Exception {
+    appendTwoFiles();
+    TableStats stats = createTableSource(Maps.newHashMap(), new Configuration()).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(5L);
+    assertThat(stats.getColumnStats().get("id").getMax()).isEqualTo(5);
+  }
+
+  @Test
+  public void testStreamingSourceReportsUnknown() throws Exception {
+    appendTwoFiles();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("streaming", "true");
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats).isEqualTo(TableStats.UNKNOWN);
+  }
+
+  @Test
+  public void testTimeTravelSourceReportsUnknown() throws Exception {
+    appendTwoFiles();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("snapshot-id", String.valueOf(table.currentSnapshot().snapshotId()));
+    TableStats stats = createTableSource(properties, new Configuration()).reportStatistics();
+    assertThat(stats).isEqualTo(TableStats.UNKNOWN);
+  }
+
+  @Test
+  public void testColumnStatsFlagDisablesColumnStats() throws Exception {
+    appendTwoFiles();
+    Configuration flinkConf = new Configuration();
+    flinkConf.set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_REPORT_COLUMN_STATISTICS, false);
+    TableStats stats = createTableSource(Maps.newHashMap(), flinkConf).reportStatistics();
+    assertThat(stats.getRowCount()).isEqualTo(5L);
+    assertThat(stats.getColumnStats()).isEmpty();
+  }
+
+  @Test
+  public void testNdvFromPuffinStatistics() throws Exception {
+    appendTwoFiles();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    GenericStatisticsFile statisticsFile =
+        new GenericStatisticsFile(
+            snapshotId,
+            table.location() + "/metadata/stats.puffin",
+            100,
+            42,
+            ImmutableList.of(
+                new GenericBlobMetadata(
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    snapshotId,
+                    table.currentSnapshot().sequenceNumber(),
+                    ImmutableList.of(1),
+                    ImmutableMap.of("ndv", "5"))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    TableStats stats = FlinkTableStatistics.reportStatistics(table, ImmutableList.of(), true);
+    assertThat(stats.getColumnStats().get("id").getNdv()).isEqualTo(5L);
+    // no blob for field 2 → no NDV, other stats still present
+    assertThat(stats.getColumnStats().get("data").getNdv()).isNull();
+    assertThat(stats.getColumnStats().get("data").getNullCount()).isEqualTo(1L);
+  }
+
+  @Test
+  public void testRowCountOverflowReturnsUnknown() throws Exception {
+    appendTwoFiles();
+    // metadata-only files with huge record counts; their sum overflows a long
+    for (int i = 0; i < 2; i++) {
+      DataFile huge =
+          DataFiles.builder(PartitionSpec.unpartitioned())
+              .withPath(warehouse.resolve("tbl/data/fake-" + i + ".parquet").toString())
+              .withFileSizeInBytes(10)
+              .withFormat(FileFormat.PARQUET)
+              .withRecordCount(Long.MAX_VALUE - 1)
+              .build();
+      table.newAppend().appendFile(huge).commit();
+    }
+
+    // filtered → planned-files path; the fake files have no column bounds, so they cannot
+    // be pruned, and summing their record counts must hit the overflow sentinel guard
+    TableStats stats =
+        FlinkTableStatistics.reportStatistics(
+            table, ImmutableList.of(Expressions.greaterThanOrEqual("id", 0)), false);
+    assertThat(stats).isEqualTo(TableStats.UNKNOWN);
+  }
+}

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergTableSourceStatisticsReport.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergTableSourceStatisticsReport.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestIcebergTableSourceStatisticsReport extends TableSourceTestBase {
+
+  @TestTemplate
+  public void testExplainEstimatedCostUsesReportedRowCount() {
+    String plan =
+        (String)
+            sql("EXPLAIN ESTIMATED_COST SELECT * FROM %s WHERE id > 0", TABLE_NAME)
+                .get(0)
+                .getField(0);
+    // 3 seeded rows; without reported stats the planner prints its 1.0E8 default
+    assertThat(plan).contains("rowcount = 3");
+    assertThat(plan).doesNotContain("rowcount = 1.0E8");
+  }
+}


### PR DESCRIPTION
Implements `SupportsStatisticReport` in `IcebergTableSource` so that in **batch execution** mode the Flink planner receives table statistics computed from Iceberg metadata: the `row count`, and `per-column null counts`, `min/max values`, and `NDV`. These feed Flink's cost-based optimizations to filter selectivity estimation, join reordering, and broadcast-join selection. previously code ran on defaults because the Iceberg source reported no statistics at all.

All statistics come from metadata already maintained by Iceberg, **no data files are read**. For streaming reads, time-travel/incremental options, missing record counts, row-count overflow, and any exception I logged as `WARN` log and all report `TableStats.UNKNOWN` rather than failing or misleading the planner.

Because column statistics reporting is **enabled by default**, I measured the planning-time overhead with a local JMH benchmark to validate that default, I did not include for this PR. But If you want I can share. 

Setup: metadata-only data files appended in ~1000-entry manifests, so manifest I/O is measured without writing actual data files; single-shot mode, since planning is a once-per-query cost:
files | row count only | full column stats
-- | -- | --
100 | ~10 µs | 4 ms
1,000 | ~10 µs | 8 ms
10,000 | ~10 µs | 21 ms
100,000 | ~10 µs | 106 ms
1,000,000 | ~10 µs | 996 ms

The row-count-only path is constant time regardless of table size. Full column **stats cost ~1 µs per data file** single-digit milliseconds at typical table sizes, ~100 ms at 100K files, ~1 s at 1M files (warm-cache local FS, so this is manifest decode cost, a lower bound vs. object storage). 

I consider this acceptable for a default configuration: tables where the cost is noticeable (100K+ files) are exactly the tables that benefit most from statistics-driven plans, and latency-sensitive users can opt out with `table.exec.iceberg.report-column-statistics=false`. I am also happy your feedbacks. I dont have any strong preferences. 