### PR TITLE
Flink: Allow independent parallelism bounds for DynamicIcebergSink committer

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -220,6 +220,20 @@ public class FlinkWriteConf {
     return confParser.intConf().option(FlinkWriteOptions.WRITE_PARALLELISM.key()).parseOptional();
   }
 
+  public Integer committerParallelism() {
+    return confParser
+        .intConf()
+        .option(FlinkWriteOptions.COMMITTER_PARALLELISM.key())
+        .parseOptional();
+  }
+
+  public Integer committerMaxParallelism() {
+    return confParser
+        .intConf()
+        .option(FlinkWriteOptions.COMMITTER_MAX_PARALLELISM.key())
+        .parseOptional();
+  }
+
   public boolean expireSnapshotsMode() {
     return confParser
         .booleanConf()

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -85,6 +85,12 @@ public class FlinkWriteOptions {
   public static final ConfigOption<Integer> WRITE_PARALLELISM =
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
 
+  public static final ConfigOption<Integer> COMMITTER_PARALLELISM =
+      ConfigOptions.key("committer-parallelism").intType().noDefaultValue();
+
+  public static final ConfigOption<Integer> COMMITTER_MAX_PARALLELISM =
+      ConfigOptions.key("committer-max-parallelism").intType().noDefaultValue();
+
   public static final ConfigOption<Boolean> COMPACTION_ENABLE =
       ConfigOptions.key(RewriteDataFilesConfig.PREFIX + "enabled")
           .booleanType()

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -154,22 +154,33 @@ public class DynamicIcebergSink
     DataStream<CommittableMessage<DynamicWriteResult>> allResults =
         writeResults.union(forwardWriteResults);
 
-    return allResults
-        .keyBy(
-            committable -> {
-              if (committable instanceof CommittableSummary) {
-                return "__summary";
-              } else {
-                CommittableWithLineage<DynamicWriteResult> result =
-                    (CommittableWithLineage<DynamicWriteResult>) committable;
-                return result.getCommittable().key().tableName();
-              }
-            })
-        .transform(
-            prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
-            typeInformation,
-            new DynamicWriteResultAggregator(catalogLoader, cacheMaximumSize))
-        .uid(prefixIfNotNull(uidPrefix, "-pre-commit-topology"));
+    SingleOutputStreamOperator<CommittableMessage<DynamicCommittable>> preCommitTopology =
+        allResults
+            .keyBy(
+                committable -> {
+                  if (committable instanceof CommittableSummary) {
+                    return "__summary";
+                  } else {
+                    CommittableWithLineage<DynamicWriteResult> result =
+                        (CommittableWithLineage<DynamicWriteResult>) committable;
+                    return result.getCommittable().key().tableName();
+                  }
+                })
+            .transform(
+                prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
+                typeInformation,
+                new DynamicWriteResultAggregator(catalogLoader, cacheMaximumSize))
+            .uid(prefixIfNotNull(uidPrefix, "-pre-commit-topology"));
+
+    FlinkWriteConf flinkWriteConf = new FlinkWriteConf(writeProperties, flinkConfig);
+    if (flinkWriteConf.committerParallelism() != null) {
+      preCommitTopology.setParallelism(flinkWriteConf.committerParallelism());
+    }
+    if (flinkWriteConf.committerMaxParallelism() != null) {
+      preCommitTopology.setMaxParallelism(flinkWriteConf.committerMaxParallelism());
+    }
+
+    return preCommitTopology;
   }
 
   @Override
@@ -307,6 +318,20 @@ public class DynamicIcebergSink
     public Builder<T> writeParallelism(int newWriteParallelism) {
       writeOptions.put(
           FlinkWriteOptions.WRITE_PARALLELISM.key(), Integer.toString(newWriteParallelism));
+      return this;
+    }
+
+    public Builder<T> committerParallelism(int newCommitterParallelism) {
+      writeOptions.put(
+          FlinkWriteOptions.COMMITTER_PARALLELISM.key(),
+          Integer.toString(newCommitterParallelism));
+      return this;
+    }
+
+    public Builder<T> committerMaxParallelism(int newCommitterMaxParallelism) {
+      writeOptions.put(
+          FlinkWriteOptions.COMMITTER_MAX_PARALLELISM.key(),
+          Integer.toString(newCommitterMaxParallelism));
       return this;
     }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -323,8 +323,7 @@ public class DynamicIcebergSink
 
     public Builder<T> committerParallelism(int newCommitterParallelism) {
       writeOptions.put(
-          FlinkWriteOptions.COMMITTER_PARALLELISM.key(),
-          Integer.toString(newCommitterParallelism));
+          FlinkWriteOptions.COMMITTER_PARALLELISM.key(), Integer.toString(newCommitterParallelism));
       return this;
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -49,6 +49,7 @@ import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.jobgraph.JobEdge;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -401,6 +402,54 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
 
     assertThat(shufflingWriterSSGApplied).isTrue();
     assertThat(generatorSSGApplied).isTrue();
+  }
+
+  @Test
+  void testCommitterParallelismAppliedToGeneratedCommitter() {
+    DataStream<DynamicIcebergDataImpl> dataStream =
+        env.fromData(Collections.emptyList(), TypeInformation.of(new TypeHint<>() {}));
+
+    DynamicIcebergSink.forInput(dataStream)
+        .generator(new ForwardGenerator())
+        .catalogLoader(CATALOG_EXTENSION.catalogLoader())
+        .writeParallelism(8)
+        .committerParallelism(1)
+        .committerMaxParallelism(1)
+        .immediateTableUpdate(false)
+        .overwrite(false)
+        .append();
+
+    List<JobVertex> vertices =
+        StreamSupport.stream(env.getStreamGraph().getJobGraph().getVertices().spliterator(), false)
+            .toList();
+
+    List<JobVertex> preCommitVertices =
+        vertices.stream()
+            .filter(
+                vertex ->
+                    vertex.getOperatorIDs().stream()
+                        .anyMatch(
+                            id ->
+                                id.getUserDefinedOperatorUid() != null
+                                    && id.getUserDefinedOperatorUid()
+                                        .endsWith("-pre-commit-topology")))
+            .toList();
+    assertThat(preCommitVertices).hasSize(1);
+
+    List<JobVertex> committerVertices =
+        vertices.stream()
+            .filter(vertex -> vertex.getName() != null && vertex.getName().contains("Committer"))
+            .toList();
+    assertThat(committerVertices).hasSize(1);
+
+    JobVertex preCommitVertex = preCommitVertices.get(0);
+    JobVertex committerVertex = committerVertices.get(0);
+    assertThat(committerVertex.getParallelism()).isEqualTo(1);
+    assertThat(committerVertex.getMaxParallelism()).isEqualTo(1);
+
+    List<JobEdge> committerInputs = committerVertex.getInputs();
+    assertThat(committerInputs).hasSize(1);
+    assertThat(committerInputs.get(0).getSource().getProducer()).isEqualTo(preCommitVertex);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds `committerParallelism(int)` and `committerMaxParallelism(int)` to
`DynamicIcebergSink.Builder`, letting the pre-commit/committer operator be
scaled independently of `writeParallelism(int)`. Both are optional; when
unset, the committer continues to inherit its parallelism from the upstream
writer topology (unchanged default behavior).

Closes #17863

## Root Cause

`DynamicIcebergSink` implements Flink's `SupportsPreCommitTopology`, and
builds its own pre-commit/committer operator via
`.keyBy(...).transform(...)` in `addPreCommitTopology()`. That
`.transform(...)` call never set an explicit parallelism, so the operator
silently inherited whatever parallelism the upstream writer chain had.

Since dynamic committers process checkpoint-batched, per-table metadata
rather than per-record data, their scaling needs differ from the writer's.
With no independent bound, autoscalers that estimate demand from edge rates
can scale the committer in lockstep with the writer even though its actual
load is far lower, and the only workarounds (`job.autoscaler.vertex.exclude.ids`,
a global autoscaler max, or changing job-wide max parallelism) are either
awkward or affect unrelated vertices/keyed-state compatibility.

## Fix

- Added `FlinkWriteOptions.COMMITTER_PARALLELISM` and
  `COMMITTER_MAX_PARALLELISM` config options.
- Added corresponding accessors to `FlinkWriteConf`.
- Added `DynamicIcebergSink.Builder#committerParallelism(int)` and
  `#committerMaxParallelism(int)`, writing into the same `writeOptions` map
  as the existing `writeParallelism(int)`.
- In `addPreCommitTopology()`, capture the `.transform(...)` result and
  conditionally call `.setParallelism(...)` / `.setMaxParallelism(...)` on
  it when the new options are set, leaving the operator's `.uid(...)`
  unchanged so existing checkpoint state remains restorable.

No Flink SinkV2 framework changes were needed — `addPreCommitTopology()` is
implemented entirely with the standard, public `DataStream` API, which
already exposes `setParallelism`/`setMaxParallelism` on the returned
operator.