### PR TITLE
API, Core: Fix typos in test comments

### DIFF
--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -135,7 +135,7 @@ public class TestBucketing {
     assertThat(BucketUtil.hash(bytes))
         .as("Spec example: hash([00 01 02 03]) = -188683207")
         .isEqualTo(-188683207);
-    // another assertion for confirming that hashing a ByteBuffer again doesnt modify its value.
+    // another assertion for confirming that hashing a ByteBuffer again doesn't modify its value.
     assertThat(BucketUtil.hash(bytes))
         .as("Spec example: hash([00 01 02 03]) = -188683207")
         .isEqualTo(-188683207);

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -141,7 +141,7 @@ public class TestSplitPlanning extends TestBase {
     List<DataFile> file128Mb = newFiles(1, 128 * 1024 * 1024);
     Iterable<DataFile> files = Iterables.concat(files120Mb, file128Mb);
     appendFiles(files);
-    // we expect 2 bins from non-overriden table properties
+    // we expect 2 bins from non-overridden table properties
     TableScan scan = table.newScan().option(TableProperties.SPLIT_LOOKBACK, "1");
     CloseableIterable<CombinedScanTask> tasks = scan.planTasks();
     assertThat(tasks).hasSize(2);

--- a/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
@@ -56,8 +56,7 @@ public class TestTableIdentifierParser {
 
     String identifierMissingNamespace = "{\"name\":\"paid\"}";
     assertThat(TableIdentifierParser.fromJson(identifierMissingNamespace))
-        .as(
-            "Should implicitly convert a missing namespace into the the empty namespace when parsing")
+        .as("Should implicitly convert a missing namespace into the empty namespace when parsing")
         .isEqualTo(identifierWithEmptyNamespace);
   }
 


### PR DESCRIPTION
Fix a duplicated "the", "overriden" -> "overridden", and "doesnt" -> "doesn't" in test comments. Comment-only changes, no behavior change.