### PR TITLE
API: Add tests for CharSequenceUtil

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TestCharSequenceUtil {
+
+  @Test
+  void unequalPathsReturnsFalseForSameReference() {
+    CharSequence path = "s3://bucket/table/data/file.parquet";
+    assertThat(CharSequenceUtil.unequalPaths(path, path)).isFalse();
+  }
+
+  @Test
+  void unequalPathsReturnsFalseForEqualContentInDifferentInstances() {
+    String path = "s3://bucket/table/data/file.parquet";
+    // a distinct String instance and a different CharSequence implementation with equal content
+    assertThat(CharSequenceUtil.unequalPaths(path, new String(path.toCharArray()))).isFalse();
+    assertThat(CharSequenceUtil.unequalPaths(path, new StringBuilder(path))).isFalse();
+  }
+
+  @Test
+  void unequalPathsReturnsTrueForDifferentLengths() {
+    assertThat(CharSequenceUtil.unequalPaths("data/file.parquet", "data/file.parquet.crc"))
+        .isTrue();
+  }
+
+  @Test
+  void unequalPathsReturnsTrueWhenLastCharacterDiffers() {
+    // paths are compared from the end, so a trailing difference is found immediately
+    assertThat(CharSequenceUtil.unequalPaths("data/file-1.parquet", "data/file-2.parquet"))
+        .isTrue();
+  }
+
+  @Test
+  void unequalPathsReturnsTrueWhenFirstCharacterDiffers() {
+    // forces the scan to walk all the way back to the first character before differing
+    assertThat(CharSequenceUtil.unequalPaths("a/data/file.parquet", "b/data/file.parquet"))
+        .isTrue();
+  }
+
+  @Test
+  void unequalPathsReturnsFalseForTwoEmptySequences() {
+    assertThat(CharSequenceUtil.unequalPaths("", new StringBuilder())).isFalse();
+  }
+
+  @Test
+  void unequalPathsReturnsTrueWhenOnlyOneSequenceIsEmpty() {
+    assertThat(CharSequenceUtil.unequalPaths("", "data/file.parquet")).isTrue();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
@@ -45,17 +45,23 @@ class TestCharSequenceUtil {
   }
 
   @Test
-  void unequalPathsReturnsTrueWhenLastCharacterDiffers() {
-    // paths are compared from the end, so a trailing difference is found immediately
+  void unequalPathsReturnsTrueWhenTheFirstCharacterDiffers() {
+    // the sequences are the same length and differ only at the first character
+    assertThat(CharSequenceUtil.unequalPaths("a/data/file.parquet", "b/data/file.parquet"))
+        .isTrue();
+  }
+
+  @Test
+  void unequalPathsReturnsTrueWhenAMiddleCharacterDiffers() {
+    // the sequences are the same length and differ only at a character in the middle
     assertThat(CharSequenceUtil.unequalPaths("data/file-1.parquet", "data/file-2.parquet"))
         .isTrue();
   }
 
   @Test
-  void unequalPathsReturnsTrueWhenFirstCharacterDiffers() {
-    // forces the scan to walk all the way back to the first character before differing
-    assertThat(CharSequenceUtil.unequalPaths("a/data/file.parquet", "b/data/file.parquet"))
-        .isTrue();
+  void unequalPathsReturnsTrueWhenTheLastCharacterDiffers() {
+    // the sequences are the same length and differ only at the final character
+    assertThat(CharSequenceUtil.unequalPaths("data/part-00001", "data/part-00002")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
CharSequenceUtil.unequalPaths had no unit coverage even though it is used on the position delete write path in FileScopedPositionDeleteWriter. Add tests covering the same-reference and equal-content fast paths, differing lengths, differences at the first and last characters, and empty inputs.