### PR TITLE
Core, Arrow: Add tests for DecimalUtil and DecimalVectorUtil.setBigEndian

### DIFF
--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestDecimalVectorUtil.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestDecimalVectorUtil.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.DecimalVector;
 import org.junit.jupiter.api.Test;
 
 public class TestDecimalVectorUtil {
@@ -71,5 +74,52 @@ public class TestDecimalVectorUtil {
     assertThatThrownBy(() -> DecimalVectorUtil.padBigEndianBytes(bytes, 16))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Buffer size of 17 is larger than requested size of 16");
+  }
+
+  @Test
+  public void testSetBigEndian() {
+    BigDecimal value = new BigDecimal("12345.67");
+    try (RootAllocator allocator = new RootAllocator();
+        DecimalVector vector = new DecimalVector("decimal", allocator, 20, value.scale())) {
+      vector.allocateNew(1);
+
+      DecimalVectorUtil.setBigEndian(vector, 0, value.unscaledValue().toByteArray());
+      vector.setValueCount(1);
+
+      assertThat(vector.getObject(0)).isEqualTo(value);
+    }
+  }
+
+  @Test
+  public void testSetBigEndianNegative() {
+    BigDecimal value = new BigDecimal("-12345.67");
+    try (RootAllocator allocator = new RootAllocator();
+        DecimalVector vector = new DecimalVector("decimal", allocator, 20, value.scale())) {
+      vector.allocateNew(1);
+
+      // the unscaled value is negative, so padBigEndianBytes has to sign-extend with 0xFF
+      DecimalVectorUtil.setBigEndian(vector, 0, value.unscaledValue().toByteArray());
+      vector.setValueCount(1);
+
+      assertThat(vector.getObject(0)).isEqualTo(value);
+    }
+  }
+
+  @Test
+  public void testSetBigEndianWithFullWidthInput() {
+    BigDecimal value = new BigDecimal(BigInteger.ONE.shiftLeft(120));
+    byte[] bigEndianBytes = value.unscaledValue().toByteArray();
+    // the input already fills the 16-byte decimal width, so no padding is applied
+    assertThat(bigEndianBytes).hasSize(DecimalVector.TYPE_WIDTH);
+
+    try (RootAllocator allocator = new RootAllocator();
+        DecimalVector vector = new DecimalVector("decimal", allocator, 38, 0)) {
+      vector.allocateNew(1);
+
+      DecimalVectorUtil.setBigEndian(vector, 0, bigEndianBytes);
+      vector.setValueCount(1);
+
+      assertThat(vector.getObject(0)).isEqualTo(value);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestDecimalUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestDecimalUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class TestDecimalUtil {
+
+  @Test
+  void toReusedFixLengthBytesLeftPadsPositiveValueWithZeros() {
+    byte[] reuseBuf = new byte[4];
+    byte[] result = DecimalUtil.toReusedFixLengthBytes(5, 2, new BigDecimal("1.23"), reuseBuf);
+
+    // unscaled value 123 fits in a single byte and is right-aligned in the buffer
+    assertThat(result).isEqualTo(new byte[] {0x00, 0x00, 0x00, 0x7B});
+    // the provided buffer is reused rather than a new array being allocated
+    assertThat(result).isSameAs(reuseBuf);
+  }
+
+  @Test
+  void toReusedFixLengthBytesLeftPadsNegativeValueWithOnes() {
+    byte[] reuseBuf = new byte[4];
+    byte[] result = DecimalUtil.toReusedFixLengthBytes(5, 2, new BigDecimal("-1.23"), reuseBuf);
+
+    // negative values are sign-extended with 0xFF padding bytes
+    assertThat(result).isEqualTo(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x85});
+    assertThat(result).isSameAs(reuseBuf);
+  }
+
+  @Test
+  void toReusedFixLengthBytesPadsZeroValueWithZeros() {
+    byte[] reuseBuf = new byte[4];
+    byte[] result = DecimalUtil.toReusedFixLengthBytes(5, 2, new BigDecimal("0.00"), reuseBuf);
+
+    assertThat(result).isEqualTo(new byte[] {0x00, 0x00, 0x00, 0x00});
+    assertThat(result).isSameAs(reuseBuf);
+  }
+
+  @Test
+  void toReusedFixLengthBytesReturnsUnscaledBytesWhenLengthAlreadyMatches() {
+    byte[] reuseBuf = new byte[2];
+    // unscaled value 258 serializes to exactly two bytes, so no padding is needed
+    byte[] result = DecimalUtil.toReusedFixLengthBytes(5, 2, new BigDecimal("2.58"), reuseBuf);
+
+    assertThat(result).isEqualTo(new byte[] {0x01, 0x02});
+    // the exact-length path returns the freshly serialized array, leaving the buffer untouched
+    assertThat(result).isNotSameAs(reuseBuf);
+    assertThat(reuseBuf).isEqualTo(new byte[] {0x00, 0x00});
+  }
+
+  @Test
+  void toReusedFixLengthBytesRejectsWrongScale() {
+    assertThatThrownBy(
+            () -> DecimalUtil.toReusedFixLengthBytes(5, 2, new BigDecimal("1.234"), new byte[4]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("wrong scale");
+  }
+
+  @Test
+  void toReusedFixLengthBytesRejectsValueLargerThanPrecision() {
+    assertThatThrownBy(
+            () -> DecimalUtil.toReusedFixLengthBytes(3, 2, new BigDecimal("1234.56"), new byte[4]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("too large");
+  }
+}


### PR DESCRIPTION
DecimalUtil.toReusedFixLengthBytes had no direct unit coverage even though it backs the decimal value writers in Avro, Parquet, ORC, Flink, and Spark. Add tests covering zero, positive, and negative left-padding, the reused-buffer contract, the exact-length short-circuit, and the scale and precision precondition checks.

Also add DecimalVector backed round-trip tests for the arrow-module counterpart, DecimalVectorUtil.setBigEndian, covering a positive value, a negative value that must be sign-extended, and an input that already fills the 16 byte decimal width. Its padBigEndianBytes helper was already covered by TestDecimalVectorUtil.