### PR TITLE
Core, Spark: Introduce shared MultiColumnTerm to de-duplicate Z-order and Hilbert clustering

### DIFF
--- a/core/src/main/java/org/apache/iceberg/expressions/Hilbert.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/Hilbert.java
@@ -18,17 +18,10 @@
  */
 package org.apache.iceberg.expressions;
 
-import java.util.Arrays;
 import java.util.List;
 
-public class Hilbert implements Term {
-  private final NamedReference<?>[] refs;
-
+public class Hilbert extends MultiColumnTerm {
   public Hilbert(List<NamedReference<?>> refs) {
-    this.refs = refs.toArray(new NamedReference[0]);
-  }
-
-  public List<NamedReference<?>> refs() {
-    return Arrays.asList(refs);
+    super(refs);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/expressions/MultiColumnTerm.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/MultiColumnTerm.java
@@ -19,9 +19,22 @@
 package org.apache.iceberg.expressions;
 
 import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
-public class Zorder extends MultiColumnTerm {
-  public Zorder(List<NamedReference<?>> refs) {
-    super(refs);
+/**
+ * A {@link Term} over an ordered list of column references.
+ *
+ * <p>Shared base of multi-column expressions such as {@link Zorder} and {@link Hilbert}, which
+ * differ only in how an engine combines the referenced columns.
+ */
+public abstract class MultiColumnTerm implements Term {
+  private final List<NamedReference<?>> refs;
+
+  protected MultiColumnTerm(List<NamedReference<?>> refs) {
+    this.refs = ImmutableList.copyOf(refs);
+  }
+
+  public List<NamedReference<?>> refs() {
+    return refs;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestMultiColumnTerm.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestMultiColumnTerm.java
@@ -18,10 +18,26 @@
  */
 package org.apache.iceberg.expressions;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class Zorder extends MultiColumnTerm {
-  public Zorder(List<NamedReference<?>> refs) {
-    super(refs);
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class TestMultiColumnTerm {
+  @Test
+  public void zorderIsMultiColumnTerm() {
+    List<NamedReference<?>> refs = ImmutableList.of(Expressions.ref("a"), Expressions.ref("b"));
+    Zorder zorder = new Zorder(refs);
+    assertThat(zorder).isInstanceOf(MultiColumnTerm.class);
+    assertThat(zorder.refs()).containsExactlyElementsOf(refs);
+  }
+
+  @Test
+  public void hilbertIsMultiColumnTerm() {
+    List<NamedReference<?>> refs = ImmutableList.of(Expressions.ref("a"), Expressions.ref("b"));
+    Hilbert hilbert = new Hilbert(refs);
+    assertThat(hilbert).isInstanceOf(MultiColumnTerm.class);
+    assertThat(hilbert.refs()).containsExactlyElementsOf(refs);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -415,17 +415,9 @@ public class Spark3Util {
         case "truncate":
           return org.apache.iceberg.expressions.Expressions.truncate(colName, findWidth(transform));
         case "zorder":
-          return new Zorder(
-              Stream.of(transform.references())
-                  .map(ref -> DOT.join(ref.fieldNames()))
-                  .map(org.apache.iceberg.expressions.Expressions::ref)
-                  .collect(Collectors.toList()));
+          return new Zorder(references(transform));
         case "hilbert":
-          return new Hilbert(
-              Stream.of(transform.references())
-                  .map(ref -> DOT.join(ref.fieldNames()))
-                  .map(org.apache.iceberg.expressions.Expressions::ref)
-                  .collect(Collectors.toList()));
+          return new Hilbert(references(transform));
         default:
           throw new UnsupportedOperationException("Transform is not supported: " + transform);
       }
@@ -437,6 +429,15 @@ public class Spark3Util {
     } else {
       throw new UnsupportedOperationException("Cannot convert unknown expression: " + expr);
     }
+  }
+
+  private static List<org.apache.iceberg.expressions.NamedReference<?>> references(
+      Transform transform) {
+    return Stream.of(transform.references())
+        .map(ref -> DOT.join(ref.fieldNames()))
+        .<org.apache.iceberg.expressions.NamedReference<?>>map(
+            org.apache.iceberg.expressions.Expressions::ref)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkCurveFileRewriteRunner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkCurveFileRewriteRunner.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base for rewrite runners that sort rows by a space-filling-curve value computed from a list of
+ * columns.
+ *
+ * <p>Subclasses parameterise the internal value column name, the exact user-facing error messages
+ * (kept per-curve for compatibility), and the combine step that turns per-column ordered bytes into
+ * a single curve value.
+ */
+abstract class SparkCurveFileRewriteRunner extends SparkShufflingFileRewriteRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(SparkCurveFileRewriteRunner.class);
+
+  private final String curveColumnName;
+  private final Schema curveSchema;
+  private final SortOrder curveSortOrder;
+  private final List<String> curveColNames;
+
+  SparkCurveFileRewriteRunner(
+      SparkSession spark,
+      Table table,
+      List<String> colNames,
+      String curveColumnName,
+      String noColumnsError,
+      String columnConflictError,
+      String allIdentityColumnsError) {
+    super(spark, table);
+    this.curveColumnName = curveColumnName;
+    this.curveSchema =
+        new Schema(Types.NestedField.required(0, curveColumnName, Types.BinaryType.get()));
+    this.curveSortOrder =
+        SortOrder.builderFor(curveSchema)
+            .sortBy(curveColumnName, SortDirection.ASC, NullOrder.NULLS_LAST)
+            .build();
+    this.curveColNames =
+        validCurveColNames(
+            spark, table, colNames, noColumnsError, columnConflictError, allIdentityColumnsError);
+  }
+
+  @Override
+  protected SortOrder sortOrder() {
+    return curveSortOrder;
+  }
+
+  /**
+   * Returns the schema used while sorting: the table's columns plus the internal curve value
+   * column.
+   */
+  @Override
+  protected Schema sortSchema() {
+    return new Schema(
+        new ImmutableList.Builder<Types.NestedField>()
+            .addAll(table().schema().columns())
+            .addAll(curveSchema.columns())
+            .build());
+  }
+
+  @Override
+  protected Dataset<Row> sortedDF(Dataset<Row> df, Function<Dataset<Row>, Dataset<Row>> sortFunc) {
+    Dataset<Row> valueDF = df.withColumn(curveColumnName, curveValue(df));
+    Dataset<Row> sortedDF = sortFunc.apply(valueDF);
+    return sortedDF.drop(curveColumnName);
+  }
+
+  /** Combines the curve input columns of {@code df} into a single binary curve value. */
+  protected abstract Column curveValue(Dataset<Row> df);
+
+  protected List<String> curveColNames() {
+    return curveColNames;
+  }
+
+  /** Converts the curve input columns to their ordered-bytes representation. */
+  protected Column[] orderedColumns(Dataset<Row> df, SparkZOrderUDF byteUDF) {
+    return curveColNames.stream()
+        .map(df.schema()::apply)
+        .map(col -> byteUDF.sortedLexicographically(df.col(col.name()), col.dataType()))
+        .toArray(Column[]::new);
+  }
+
+  private List<String> validCurveColNames(
+      SparkSession spark,
+      Table table,
+      List<String> inputColNames,
+      String noColumnsError,
+      String columnConflictError,
+      String allIdentityColumnsError) {
+
+    Preconditions.checkArgument(inputColNames != null && !inputColNames.isEmpty(), noColumnsError);
+
+    Schema schema = table.schema();
+    Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
+    boolean caseSensitive = SparkUtil.caseSensitive(spark);
+
+    Preconditions.checkArgument(
+        caseSensitive
+            ? schema.findField(curveColumnName) == null
+            : schema.caseInsensitiveFindField(curveColumnName) == null,
+        columnConflictError,
+        curveColumnName);
+
+    List<String> validColNames = Lists.newArrayList();
+
+    for (String colName : inputColNames) {
+      Types.NestedField field =
+          caseSensitive ? schema.findField(colName) : schema.caseInsensitiveFindField(colName);
+      Preconditions.checkArgument(
+          field != null,
+          "Cannot find column '%s' in table schema (case sensitive = %s): %s",
+          colName,
+          caseSensitive,
+          schema.asStruct());
+
+      if (identityPartitionFieldIds.contains(field.fieldId())) {
+        LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
+      } else {
+        // use the resolved name so a case-insensitive match is not carried through as-is
+        validColNames.add(schema.findColumnName(field.fieldId()));
+      }
+    }
+
+    Preconditions.checkArgument(!validColNames.isEmpty(), allIdentityColumnsError);
+
+    return validColNames;
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkHilbertFileRewriteRunner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkHilbertFileRewriteRunner.java
@@ -21,36 +21,16 @@ package org.apache.iceberg.spark.actions;
 import static org.apache.spark.sql.functions.array;
 
 import java.util.List;
-import java.util.Set;
-import java.util.function.Function;
-import org.apache.iceberg.NullOrder;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortDirection;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkUtil;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class SparkHilbertFileRewriteRunner extends SparkShufflingFileRewriteRunner {
-  private static final Logger LOG = LoggerFactory.getLogger(SparkHilbertFileRewriteRunner.class);
+class SparkHilbertFileRewriteRunner extends SparkCurveFileRewriteRunner {
 
   private static final String H_COLUMN = "ICEHVALUE";
-  private static final Schema H_SCHEMA =
-      new Schema(Types.NestedField.required(0, H_COLUMN, Types.BinaryType.get()));
-  private static final SortOrder H_SORT_ORDER =
-      SortOrder.builderFor(H_SCHEMA)
-          .sortBy(H_COLUMN, SortDirection.ASC, NullOrder.NULLS_LAST)
-          .build();
 
   /**
    * The number of bits contributed by each column to the Hilbert index.
@@ -64,11 +44,15 @@ class SparkHilbertFileRewriteRunner extends SparkShufflingFileRewriteRunner {
    */
   private static final int BITS_PER_COLUMN = ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE * Byte.SIZE;
 
-  private final List<String> hilbertColNames;
-
   SparkHilbertFileRewriteRunner(SparkSession spark, Table table, List<String> hilbertColNames) {
-    super(spark, table);
-    this.hilbertColNames = validHilbertColNames(spark, table, hilbertColNames);
+    super(
+        spark,
+        table,
+        hilbertColNames,
+        H_COLUMN,
+        "Cannot HILBERT when no columns are specified",
+        "Cannot HILBERT because the table has a column named '%s', which conflicts with Iceberg's internal Hilbert column name",
+        "Cannot HILBERT, all columns provided were identity partition columns and cannot be used");
   }
 
   @Override
@@ -77,90 +61,13 @@ class SparkHilbertFileRewriteRunner extends SparkShufflingFileRewriteRunner {
   }
 
   @Override
-  protected SortOrder sortOrder() {
-    return H_SORT_ORDER;
-  }
-
-  /**
-   * Overrides the sortSchema method to include columns from H_SCHEMA.
-   *
-   * <p>This method generates a new Schema object which consists of columns from the original table
-   * schema and H_SCHEMA.
-   */
-  @Override
-  protected Schema sortSchema() {
-    return new Schema(
-        new ImmutableList.Builder<Types.NestedField>()
-            .addAll(table().schema().columns())
-            .addAll(H_SCHEMA.columns())
-            .build());
-  }
-
-  @Override
-  protected Dataset<Row> sortedDF(Dataset<Row> df, Function<Dataset<Row>, Dataset<Row>> sortFunc) {
-    Dataset<Row> hValueDF = df.withColumn(H_COLUMN, hilbertValue(df));
-    Dataset<Row> sortedDF = sortFunc.apply(hValueDF);
-    return sortedDF.drop(H_COLUMN);
-  }
-
-  private Column hilbertValue(Dataset<Row> df) {
+  protected Column curveValue(Dataset<Row> df) {
     // Reuse the Z-order byte conversions. Every column contributes the full primitive width so the
     // Hilbert transform sees a uniform per-dimension width with no magnitude loss.
     SparkZOrderUDF byteUDF =
         new SparkZOrderUDF(
-            hilbertColNames.size(), ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE, Integer.MAX_VALUE);
-
-    Column[] orderedCols =
-        hilbertColNames.stream()
-            .map(df.schema()::apply)
-            .map(col -> byteUDF.sortedLexicographically(df.col(col.name()), col.dataType()))
-            .toArray(Column[]::new);
-
-    SparkHilbertUDF hilbertUDF = new SparkHilbertUDF(hilbertColNames.size(), BITS_PER_COLUMN);
-    return hilbertUDF.hilbertValue(array(orderedCols));
-  }
-
-  private List<String> validHilbertColNames(
-      SparkSession spark, Table table, List<String> inputHilbertColNames) {
-
-    Preconditions.checkArgument(
-        inputHilbertColNames != null && !inputHilbertColNames.isEmpty(),
-        "Cannot HILBERT when no columns are specified");
-
-    Schema schema = table.schema();
-    Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
-    boolean caseSensitive = SparkUtil.caseSensitive(spark);
-
-    Preconditions.checkArgument(
-        caseSensitive
-            ? schema.findField(H_COLUMN) == null
-            : schema.caseInsensitiveFindField(H_COLUMN) == null,
-        "Cannot HILBERT because the table has a column named '%s', which conflicts with Iceberg's internal Hilbert column name",
-        H_COLUMN);
-
-    List<String> validHilbertColNames = Lists.newArrayList();
-
-    for (String colName : inputHilbertColNames) {
-      Types.NestedField field =
-          caseSensitive ? schema.findField(colName) : schema.caseInsensitiveFindField(colName);
-      Preconditions.checkArgument(
-          field != null,
-          "Cannot find column '%s' in table schema (case sensitive = %s): %s",
-          colName,
-          caseSensitive,
-          schema.asStruct());
-
-      if (identityPartitionFieldIds.contains(field.fieldId())) {
-        LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
-      } else {
-        validHilbertColNames.add(colName);
-      }
-    }
-
-    Preconditions.checkArgument(
-        !validHilbertColNames.isEmpty(),
-        "Cannot HILBERT, all columns provided were identity partition columns and cannot be used");
-
-    return validHilbertColNames;
+            curveColNames().size(), ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE, Integer.MAX_VALUE);
+    SparkHilbertUDF hilbertUDF = new SparkHilbertUDF(curveColNames().size(), BITS_PER_COLUMN);
+    return hilbertUDF.hilbertValue(array(orderedColumns(df, byteUDF)));
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -23,37 +23,19 @@ import static org.apache.spark.sql.functions.array;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import org.apache.iceberg.NullOrder;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortDirection;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkUtil;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
-  private static final Logger LOG = LoggerFactory.getLogger(SparkZOrderFileRewriteRunner.class);
+class SparkZOrderFileRewriteRunner extends SparkCurveFileRewriteRunner {
 
   private static final String Z_COLUMN = "ICEZVALUE";
-  private static final Schema Z_SCHEMA =
-      new Schema(Types.NestedField.required(0, Z_COLUMN, Types.BinaryType.get()));
-  private static final SortOrder Z_SORT_ORDER =
-      SortOrder.builderFor(Z_SCHEMA)
-          .sortBy(Z_COLUMN, SortDirection.ASC, NullOrder.NULLS_LAST)
-          .build();
 
   /**
    * Controls the amount of bytes interleaved in the ZOrder algorithm. Default is all bytes being
@@ -73,13 +55,18 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
 
   public static final int VAR_LENGTH_CONTRIBUTION_DEFAULT = ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE;
 
-  private final List<String> zOrderColNames;
   private int maxOutputSize;
   private int varLengthContribution;
 
   SparkZOrderFileRewriteRunner(SparkSession spark, Table table, List<String> zOrderColNames) {
-    super(spark, table);
-    this.zOrderColNames = validZOrderColNames(spark, table, zOrderColNames);
+    super(
+        spark,
+        table,
+        zOrderColNames,
+        Z_COLUMN,
+        "Cannot ZOrder when no columns are specified",
+        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
+        "Cannot ZOrder, all columns provided were identity partition columns and cannot be used");
   }
 
   @Override
@@ -104,43 +91,10 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
   }
 
   @Override
-  protected SortOrder sortOrder() {
-    return Z_SORT_ORDER;
-  }
-
-  /**
-   * Overrides the sortSchema method to include columns from Z_SCHEMA.
-   *
-   * <p>This method generates a new Schema object which consists of columns from the original table
-   * schema and Z_SCHEMA.
-   */
-  @Override
-  protected Schema sortSchema() {
-    return new Schema(
-        new ImmutableList.Builder<Types.NestedField>()
-            .addAll(table().schema().columns())
-            .addAll(Z_SCHEMA.columns())
-            .build());
-  }
-
-  @Override
-  protected Dataset<Row> sortedDF(Dataset<Row> df, Function<Dataset<Row>, Dataset<Row>> sortFunc) {
-    Dataset<Row> zValueDF = df.withColumn(Z_COLUMN, zValue(df));
-    Dataset<Row> sortedDF = sortFunc.apply(zValueDF);
-    return sortedDF.drop(Z_COLUMN);
-  }
-
-  private Column zValue(Dataset<Row> df) {
+  protected Column curveValue(Dataset<Row> df) {
     SparkZOrderUDF zOrderUDF =
-        new SparkZOrderUDF(zOrderColNames.size(), varLengthContribution, maxOutputSize);
-
-    Column[] zOrderCols =
-        zOrderColNames.stream()
-            .map(df.schema()::apply)
-            .map(col -> zOrderUDF.sortedLexicographically(df.col(col.name()), col.dataType()))
-            .toArray(Column[]::new);
-
-    return zOrderUDF.interleaveBytes(array(zOrderCols));
+        new SparkZOrderUDF(curveColNames().size(), varLengthContribution, maxOutputSize);
+    return zOrderUDF.interleaveBytes(array(orderedColumns(df, zOrderUDF)));
   }
 
   private int varLengthContribution(Map<String, String> options) {
@@ -163,50 +117,5 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
         MAX_OUTPUT_SIZE,
         value);
     return value;
-  }
-
-  private List<String> validZOrderColNames(
-      SparkSession spark, Table table, List<String> inputZOrderColNames) {
-
-    Preconditions.checkArgument(
-        inputZOrderColNames != null && !inputZOrderColNames.isEmpty(),
-        "Cannot ZOrder when no columns are specified");
-
-    Schema schema = table.schema();
-    Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
-    boolean caseSensitive = SparkUtil.caseSensitive(spark);
-
-    Preconditions.checkArgument(
-        caseSensitive
-            ? schema.findField(Z_COLUMN) == null
-            : schema.caseInsensitiveFindField(Z_COLUMN) == null,
-        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
-        Z_COLUMN);
-
-    List<String> validZOrderColNames = Lists.newArrayList();
-
-    for (String colName : inputZOrderColNames) {
-      Types.NestedField field =
-          caseSensitive ? schema.findField(colName) : schema.caseInsensitiveFindField(colName);
-      Preconditions.checkArgument(
-          field != null,
-          "Cannot find column '%s' in table schema (case sensitive = %s): %s",
-          colName,
-          caseSensitive,
-          schema.asStruct());
-
-      if (identityPartitionFieldIds.contains(field.fieldId())) {
-        LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
-      } else {
-        // use the resolved name so a case-insensitive match is not carried through as-is
-        validZOrderColNames.add(schema.findColumnName(field.fieldId()));
-      }
-    }
-
-    Preconditions.checkArgument(
-        !validZOrderColNames.isEmpty(),
-        "Cannot ZOrder, all columns provided were identity partition columns and cannot be used");
-
-    return validZOrderColNames;
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.procedures;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SortOrder;
@@ -28,6 +29,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Hilbert;
+import org.apache.iceberg.expressions.MultiColumnTerm;
 import org.apache.iceberg.expressions.NamedReference;
 import org.apache.iceberg.expressions.Zorder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -158,17 +160,16 @@ class RewriteDataFilesProcedure extends BaseProcedure {
 
   private RewriteDataFilesSparkAction checkAndApplyStrategy(
       RewriteDataFilesSparkAction action, String strategy, String sortOrderString, Schema schema) {
-    List<Zorder> zOrderTerms = Lists.newArrayList();
-    List<Hilbert> hilbertTerms = Lists.newArrayList();
+    List<MultiColumnTerm> curveTerms = Lists.newArrayList();
     List<ExtendedParser.RawOrderField> sortOrderFields = Lists.newArrayList();
     if (sortOrderString != null) {
-      parseSortOrder(sortOrderString, zOrderTerms, hilbertTerms, sortOrderFields);
+      parseSortOrder(sortOrderString, curveTerms, sortOrderFields);
     }
 
     // caller of this function ensures that between strategy and sortOrder, at least one of them is
     // not null.
     if (strategy == null || strategy.equalsIgnoreCase("sort")) {
-      return applySortStrategy(action, zOrderTerms, hilbertTerms, sortOrderFields, schema);
+      return applySortStrategy(action, curveTerms, sortOrderFields, schema);
     }
     if (strategy.equalsIgnoreCase("binpack")) {
       RewriteDataFilesSparkAction binPackAction = action.binPack();
@@ -186,27 +187,32 @@ class RewriteDataFilesProcedure extends BaseProcedure {
 
   private void parseSortOrder(
       String sortOrderString,
-      List<Zorder> zOrderTerms,
-      List<Hilbert> hilbertTerms,
+      List<MultiColumnTerm> curveTerms,
       List<ExtendedParser.RawOrderField> sortOrderFields) {
     ExtendedParser.parseSortOrder(spark(), sortOrderString)
         .forEach(
             field -> {
-              if (field.term() instanceof Zorder) {
-                zOrderTerms.add((Zorder) field.term());
-              } else if (field.term() instanceof Hilbert) {
-                hilbertTerms.add((Hilbert) field.term());
+              if (field.term() instanceof MultiColumnTerm) {
+                curveTerms.add((MultiColumnTerm) field.term());
               } else {
                 sortOrderFields.add(field);
               }
             });
 
-    if (!zOrderTerms.isEmpty() && !hilbertTerms.isEmpty()) {
+    List<String> curveTypes =
+        curveTerms.stream()
+            .map(term -> term.getClass().getSimpleName())
+            .distinct()
+            .collect(Collectors.toList());
+    if (curveTypes.size() > 1) {
       throw new IllegalArgumentException(
-          "Cannot mix Zorder and Hilbert sort expressions: " + sortOrderString);
+          "Cannot mix "
+              + String.join(" and ", curveTypes)
+              + " sort expressions: "
+              + sortOrderString);
     }
 
-    if ((!zOrderTerms.isEmpty() || !hilbertTerms.isEmpty()) && !sortOrderFields.isEmpty()) {
+    if (!curveTerms.isEmpty() && !sortOrderFields.isEmpty()) {
       throw new IllegalArgumentException(
           "Cannot mix identity sort columns and a Zorder or Hilbert sort expression: "
               + sortOrderString);
@@ -215,22 +221,23 @@ class RewriteDataFilesProcedure extends BaseProcedure {
 
   private RewriteDataFilesSparkAction applySortStrategy(
       RewriteDataFilesSparkAction action,
-      List<Zorder> zOrderTerms,
-      List<Hilbert> hilbertTerms,
+      List<MultiColumnTerm> curveTerms,
       List<ExtendedParser.RawOrderField> sortOrderFields,
       Schema schema) {
-    if (!zOrderTerms.isEmpty()) {
+    if (!curveTerms.isEmpty()) {
       String[] columnNames =
-          zOrderTerms.stream()
-              .flatMap(zOrder -> zOrder.refs().stream().map(NamedReference::name))
+          curveTerms.stream()
+              .flatMap(term -> term.refs().stream().map(NamedReference::name))
               .toArray(String[]::new);
-      return action.zOrder(columnNames);
-    } else if (!hilbertTerms.isEmpty()) {
-      String[] columnNames =
-          hilbertTerms.stream()
-              .flatMap(hilbert -> hilbert.refs().stream().map(NamedReference::name))
-              .toArray(String[]::new);
-      return action.hilbert(columnNames);
+      MultiColumnTerm curveTerm = curveTerms.get(0);
+      if (curveTerm instanceof Zorder) {
+        return action.zOrder(columnNames);
+      } else if (curveTerm instanceof Hilbert) {
+        return action.hilbert(columnNames);
+      } else {
+        throw new UnsupportedOperationException(
+            "Unsupported sort expression: " + curveTerm.getClass().getSimpleName());
+      }
     } else if (!sortOrderFields.isEmpty()) {
       return action.sort(buildSortOrder(sortOrderFields, schema));
     } else {


### PR DESCRIPTION
Closes #17657.

Follow-up to #16827, which deliberately mirrored the Z-order surface to keep that diff reviewable. This PR is the deferred de-duplication, along the lines @RussellSpitzer suggested in review ("we'll probably want a `MultiColumnTerm` or something like that in the future").

### What changed

**Core** — new `org.apache.iceberg.expressions.MultiColumnTerm`, an immutable `Term` over an ordered list of column references. `Zorder` and `Hilbert` (previously identical apart from the class name) become two-line subclasses. Public constructors and the `refs()` signature are unchanged; the parsed SQL grammar is untouched. One behavioural note on `refs()`: it previously returned `Arrays.asList` over the internal array (element-mutable via `set`), it now returns an `ImmutableList`. Callers that mutated the returned list in place would now get an `UnsupportedOperationException`.

**Spark 4.1** — `SparkZOrderFileRewriteRunner` and `SparkHilbertFileRewriteRunner` move onto a new abstract `SparkCurveFileRewriteRunner`, parameterised by the internal value column name, the exact per-curve error messages, and the combine step. The shared pieces — internal column schema/sort order, column validation (`validZOrderColNames` / `validHilbertColNames` were byte-for-byte the same logic), `sortSchema`, `sortedDF`, and the per-column ordered-bytes conversion — now live in one place. Each runner keeps only what is genuinely curve-specific: Z-order its two options and the interleave combine (~120 lines), Hilbert its fixed per-column bit width and the Hilbert-index combine (~75 lines). Adding a further curve is now a small, local change.

**Dispatch** — the duplicated `zorder`/`hilbert` branches in `Spark3Util.toIcebergTerm` share one reference-extraction helper, and `RewriteDataFilesProcedure` collapses its two per-curve term lists into a single `List<MultiColumnTerm>`. Dispatch stays closed: `applySortStrategy` branches explicitly on `Zorder` and `Hilbert` and throws for any other `MultiColumnTerm`, and the mixed-curves error names the term types actually found, so the existing message ("Cannot mix Zorder and Hilbert sort expressions") is preserved.

### What did not change

Engine-side behaviour is bit-for-bit identical, which the existing tests enforce: **every pre-existing Z-order and Hilbert test passes unmodified** (`TestSparkFileRewriteRunners`, the Z-order/Hilbert cases of `TestRewriteDataFilesAction`, `TestRewriteDataFilesProcedure`). The only test change is the new `TestMultiColumnTerm` in core. All user-facing error messages are preserved exactly. Spark 3.5/4.0/4.2 are untouched.

### Out of scope

The wider "arbitrary function via `Expressions`" refactor discussed in #16827 review builds naturally on this abstraction but is split out per the issue, to keep this diff mechanical and easy to verify.
