### PR TITLE
Hive: add HiveCatalog(Configuration, Map) convenience constructor

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -104,6 +104,19 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   public HiveCatalog() {}
 
+  /**
+   * Convenience constructor that uses the passed configuration and properties to initialize the
+   * catalog under the name {@code "hive"}, equivalent to calling {@link #setConf(Configuration)}
+   * followed by {@link #initialize(String, Map)}.
+   *
+   * @param conf The Hadoop configuration
+   * @param properties The catalog properties
+   */
+  public HiveCatalog(Configuration conf, Map<String, String> properties) {
+    setConf(conf);
+    initialize("hive", properties);
+  }
+
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -117,6 +117,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
     initialize("hive", properties);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines {@code setConf(...)} and this call.
+   */
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);
@@ -871,6 +877,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
         .toString();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines this call and {@code initialize(...)}.
+   */
   @Override
   public void setConf(Configuration conf) {
     this.conf = new Configuration(conf);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -306,6 +306,23 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
+  public void testConstructorWithConfAndProperties() {
+    Configuration conf = new Configuration();
+    conf.set("custom.caller.key", "custom-value");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("uri", "thrift://examplehost:9083");
+    properties.put("warehouse", "/user/hive/testwarehouse");
+
+    HiveCatalog hiveCatalog = new HiveCatalog(conf, properties);
+
+    assertThat(hiveCatalog.getConf().get("hive.metastore.uris"))
+        .isEqualTo("thrift://examplehost:9083");
+    assertThat(hiveCatalog.getConf().get("hive.metastore.warehouse.dir"))
+        .isEqualTo("/user/hive/testwarehouse");
+    assertThat(hiveCatalog.getConf().get("custom.caller.key")).isEqualTo("custom-value");
+  }
+
+  @Test
   public void testCreateTableTxnBuilder() throws Exception {
     Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -306,7 +306,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
-  public void testConstructorWithConfAndProperties() {
+  void constructorWithConfAndProperties() {
     Configuration conf = new Configuration();
     conf.set("custom.caller.key", "custom-value");
     Map<String, String> properties = Maps.newHashMap();


### PR DESCRIPTION
A caller that constructs `HiveCatalog` directly has to call `setConf` before `initialize`. Nothing enforces that order, and skipping it does not fail:

```java
HiveCatalog catalog = new HiveCatalog();
catalog.initialize("hive", properties);
```

`initialize` finds no configuration, logs `No Hadoop Configuration was set, using the default environment Configuration`, and carries on against the ambient environment. Whatever the caller had prepared, the HMS thrift URIs, kerberos and SSL settings, is quietly gone, and the problem only shows up later when the catalog talks to the metastore.

Getting it right today takes three lines in a fixed order:

```java
HiveCatalog catalog = new HiveCatalog();
catalog.setConf(configuration);
catalog.initialize("hive", properties);
```

`HadoopCatalog` already avoids this with [a convenience constructor](https://github.com/apache/iceberg/blob/1051b432aae7b27c5dd18a2b7b9a395b6694d84a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java#L138-L141). After this change `HiveCatalog` matches it, and the order can no longer be got wrong:

```java
HiveCatalog catalog = new HiveCatalog(configuration, properties);
```

## What changes

The new constructor takes a property map rather than a single warehouse string, because `HiveCatalog` reads more than one key:

```java
public HiveCatalog(Configuration conf, Map<String, String> properties) {
  setConf(conf);
  initialize("hive", properties);
}
```

The Javadoc on `setConf` and `initialize` now points at it, so the one-step form is discoverable from either.

## Testing

`testConstructorWithConfAndProperties` in `TestHiveCatalog` constructs a catalog through the new constructor, then asserts that `uri` and `warehouse` reach the Hadoop `Configuration` and that a caller-supplied entry set beforehand survives.

With that test applied on top of `main` and `HiveCatalog.java` left unchanged:

```
./gradlew :iceberg-hive-metastore:compileTestJava

TestHiveCatalog.java:316: error: constructor HiveCatalog in class HiveCatalog cannot be applied to given types;
BUILD FAILED in 6s
```

On this branch:

```
./gradlew :iceberg-hive-metastore:test --tests "org.apache.iceberg.hive.TestHiveCatalog.testConstructorWithConfAndProperties"

BUILD SUCCESSFUL in 3m 1s
tests=1 failures=0 errors=0 skipped=0
PASS  testConstructorWithConfAndProperties()  time=0.433s
```

Closes #16134.
