### PR TITLE
Docs, Core, AWS, BigQuery, Flink: Fix miscellaneous typos in comments and docs

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -330,7 +330,7 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
   }
 
   /**
-   * The lock table column definition, for users who whould like to create the table separately
+   * The lock table column definition, for users who would like to create the table separately
    *
    * @return lock table column definition
    */

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -429,7 +429,7 @@ public class S3FileIO
 
           this.clientByPrefix = localClientByPrefix;
           // Note: the s3 clients separately refresh via the VendedCredentialsProvider but are
-          // not directly referencable from the FileIO
+          // not directly referenceable from the FileIO
           scheduleCredentialRefresh();
         }
       }

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
@@ -182,7 +182,7 @@ class BigQueryProperties implements Serializable {
           ImpersonatedCredentials.create(
               sourceCredentials, impersonateServiceAccount, delegates, scopes, lifetimeSeconds);
 
-      // refresh to validate credentials and get intial token
+      // refresh to validate credentials and get initial token
       impersonatedCredentials.refresh();
 
       LOG.debug(

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -162,7 +162,7 @@ public class PuffinReader implements Closeable {
     if (knownFooterSize == null) {
       Preconditions.checkState(
           fileSize >= PuffinFormat.FOOTER_STRUCT_LENGTH,
-          "Invalid file: file length %s is less tha minimal length of the footer tail %s",
+          "Invalid file: file length %s is less than minimal length of the footer tail %s",
           fileSize,
           PuffinFormat.FOOTER_STRUCT_LENGTH);
       byte[] footerStruct =

--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -275,7 +275,7 @@ PARTITIONED BY (hours(ts))
 
 #### Connector config
 
-This example config connects to a Iceberg REST catalog.
+This example config connects to an Iceberg REST catalog.
 ```json
 {
   "name": "events-sink",

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -87,7 +87,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // A sorted map to maintain the completed data files for each pending checkpointId (which have not
   // been committed to iceberg table). We need a sorted map here because there's possible that few
   // checkpoints snapshot failed, for example: the 1st checkpoint have 2 data files <1, <file0,
-  // file1>>, the 2st checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
+  // file1>>, the 2nd checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
   // interrupted because of network/disk failure etc, while we don't expect any data loss in iceberg
   // table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit iceberg
   // table when the next checkpoint happen.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Adding new columns
- *   <li>Widening the type of existing columsn
+ *   <li>Widening the type of existing columns
  *   <li>Reordering columns
  *   <li>Dropping columns (when dropUnusedColumns is enabled)
  * </ul>

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
@@ -84,7 +84,7 @@ public class RangePartitioner implements Partitioner<StatisticsOrRecord> {
   /**
    * Util method that handles rescale (write parallelism / numPartitions change).
    *
-   * @param partition partition caculated based on the existing statistics
+   * @param partition partition calculated based on the existing statistics
    * @param numPartitionsStatsCalculation number of partitions when the assignment was calculated
    *     based on
    * @param numPartitions current number of partitions

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -58,7 +58,7 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   /** Track enumeration result history for split discovery throttling. */
   private final EnumerationHistory enumerationHistory;
 
-  /** Count the consecutive failures and throw exception if the max allowed failres are reached */
+  /** Count the consecutive failures and throw exception if the max allowed failures are reached */
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -88,7 +88,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // A sorted map to maintain the completed data files for each pending checkpointId (which have not
   // been committed to iceberg table). We need a sorted map here because there's possible that few
   // checkpoints snapshot failed, for example: the 1st checkpoint have 2 data files <1, <file0,
-  // file1>>, the 2st checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
+  // file1>>, the 2nd checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
   // interrupted because of network/disk failure etc, while we don't expect any data loss in iceberg
   // table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit iceberg
   // table when the next checkpoint happen.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Adding new columns
- *   <li>Widening the type of existing columsn
+ *   <li>Widening the type of existing columns
  *   <li>Reordering columns
  *   <li>Dropping columns (when dropUnusedColumns is enabled)
  * </ul>

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
@@ -84,7 +84,7 @@ public class RangePartitioner implements Partitioner<StatisticsOrRecord> {
   /**
    * Util method that handles rescale (write parallelism / numPartitions change).
    *
-   * @param partition partition caculated based on the existing statistics
+   * @param partition partition calculated based on the existing statistics
    * @param numPartitionsStatsCalculation number of partitions when the assignment was calculated
    *     based on
    * @param numPartitions current number of partitions

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -58,7 +58,7 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   /** Track enumeration result history for split discovery throttling. */
   private final EnumerationHistory enumerationHistory;
 
-  /** Count the consecutive failures and throw exception if the max allowed failres are reached */
+  /** Count the consecutive failures and throw exception if the max allowed failures are reached */
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -88,7 +88,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // A sorted map to maintain the completed data files for each pending checkpointId (which have not
   // been committed to iceberg table). We need a sorted map here because there's possible that few
   // checkpoints snapshot failed, for example: the 1st checkpoint have 2 data files <1, <file0,
-  // file1>>, the 2st checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
+  // file1>>, the 2nd checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
   // interrupted because of network/disk failure etc, while we don't expect any data loss in iceberg
   // table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit iceberg
   // table when the next checkpoint happen.

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Adding new columns
- *   <li>Widening the type of existing columsn
+ *   <li>Widening the type of existing columns
  *   <li>Reordering columns
  *   <li>Dropping columns (when dropUnusedColumns is enabled)
  * </ul>

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
@@ -84,7 +84,7 @@ public class RangePartitioner implements Partitioner<StatisticsOrRecord> {
   /**
    * Util method that handles rescale (write parallelism / numPartitions change).
    *
-   * @param partition partition caculated based on the existing statistics
+   * @param partition partition calculated based on the existing statistics
    * @param numPartitionsStatsCalculation number of partitions when the assignment was calculated
    *     based on
    * @param numPartitions current number of partitions

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -58,7 +58,7 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   /** Track enumeration result history for split discovery throttling. */
   private final EnumerationHistory enumerationHistory;
 
-  /** Count the consecutive failures and throw exception if the max allowed failres are reached */
+  /** Count the consecutive failures and throw exception if the max allowed failures are reached */
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -88,7 +88,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // A sorted map to maintain the completed data files for each pending checkpointId (which have not
   // been committed to iceberg table). We need a sorted map here because there's possible that few
   // checkpoints snapshot failed, for example: the 1st checkpoint have 2 data files <1, <file0,
-  // file1>>, the 2st checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
+  // file1>>, the 2nd checkpoint have 1 data files <2, <file3>>. Snapshot for checkpoint#1
   // interrupted because of network/disk failure etc, while we don't expect any data loss in iceberg
   // table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit iceberg
   // table when the next checkpoint happen.

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Adding new columns
- *   <li>Widening the type of existing columsn
+ *   <li>Widening the type of existing columns
  *   <li>Reordering columns
  *   <li>Dropping columns (when dropUnusedColumns is enabled)
  * </ul>

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/RangePartitioner.java
@@ -84,7 +84,7 @@ public class RangePartitioner implements Partitioner<StatisticsOrRecord> {
   /**
    * Util method that handles rescale (write parallelism / numPartitions change).
    *
-   * @param partition partition caculated based on the existing statistics
+   * @param partition partition calculated based on the existing statistics
    * @param numPartitionsStatsCalculation number of partitions when the assignment was calculated
    *     based on
    * @param numPartitions current number of partitions

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -58,7 +58,7 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   /** Track enumeration result history for split discovery throttling. */
   private final EnumerationHistory enumerationHistory;
 
-  /** Count the consecutive failures and throw exception if the max allowed failres are reached */
+  /** Count the consecutive failures and throw exception if the max allowed failures are reached */
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;

--- a/site/docs/blog/posts/2026-07-21-iceberg-rust-0.10.0-release.md
+++ b/site/docs/blog/posts/2026-07-21-iceberg-rust-0.10.0-release.md
@@ -51,7 +51,7 @@ A new `ExpireSnapshotsAction` ([#2591](https://github.com/apache/iceberg-rust/pu
 
 A [custom tokio `Runtime`](https://github.com/apache/iceberg-rust/pull/2308) can now be provided when initializing catalogs.
 This allows for injecting a customized Tokio runtime into the session.
-For example, it is now possible to configure the thread stack size or maximum number of threads programatically.
+For example, it is now possible to configure the thread stack size or maximum number of threads programmatically.
 
 ### Writer Improvements
 

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -402,7 +402,7 @@ The 1.10.0 release contains bug fixes and new features. For full release notes v
     - 4.0: Add row lineage support using conditional nullification mechanism introduced in Spark 4.0 ([\#13310](https://github.com/apache/iceberg/pull/13310))
     - Use bulk deletion operation for deleting manifests when importing files from partitions ([\#13620](https://github.com/apache/iceberg/pull/13620))
     - Preserve row lineage on compaction ([\#13555](https://github.com/apache/iceberg/pull/13555))
-    - Refactor DeleteOrphanFilesSparkAction to to use common code from core ([\#13429](https://github.com/apache/iceberg/pull/13429))
+    - Refactor DeleteOrphanFilesSparkAction to use common code from core ([\#13429](https://github.com/apache/iceberg/pull/13429))
     - Add variant read support ([\#13219](https://github.com/apache/iceberg/pull/13219))
     - Add config to disable executor cache for deleting files  ([\#12893](https://github.com/apache/iceberg/pull/12893))
     - Accept custom partition order in RewriteManifest  ([\#12840](https://github.com/apache/iceberg/pull/12840))
@@ -542,7 +542,7 @@ the API. This is fixed in 1.9.1.
     - Netty to 4.2.0.Final
     - Nessie to 0.103.3
     - Parquet to 1.15.1 (Fixes CVE-2025-30065)
-    - Sqllite JDBC to 3.49.1.0
+    - SQLite JDBC to 3.49.1.0
     - Jackson to 2.18.3
     - downgraded AWS SDK to 2.29.52 ([\#12649](https://github.com/apache/iceberg/pull/12649))
 
@@ -630,7 +630,7 @@ The 1.8.0 release contains bug fixes and new features. For full release notes vi
     - Kafka to 3.9.0
     - Nessie to 0.102.2
     - ORC to 1.9.5
-    - Sqllite JDBC to 3.48.0.0
+    - SQLite JDBC to 3.48.0.0
     - Jackson to 2.18.2
 
 ### 1.7.2 release
@@ -706,7 +706,7 @@ The 1.7.0 release contains fixes, dependency updates, and new features. For full
     - ORC to 1.9.4
     - Roaring Bitmap to 1.3.0
     - Spring to 5.3.39
-    - Sqllite JDBC to 3.46.0.0
+    - SQLite JDBC to 3.46.0.0
     - Hadoop to 3.4.1
 * Core
     - Remove dangling deletes as part of RewriteDataFilesAction ([\#9724](https://github.com/apache/iceberg/pull/9724))
@@ -1165,7 +1165,7 @@ The 1.2.0 release adds a variety of new features and bug fixes.
 Here is an overview:
 
 * Core
-    - Added AES GCM encrpytion stream spec ([\#5432](https://github.com/apache/iceberg/pull/5432))
+    - Added AES GCM encryption stream spec ([\#5432](https://github.com/apache/iceberg/pull/5432))
     - Added support for Delta Lake to Iceberg table conversion ([\#6449](https://github.com/apache/iceberg/pull/6449), [\#6880](https://github.com/apache/iceberg/pull/6880))
     - Added support for `position_deletes` metadata table ([\#6365](https://github.com/apache/iceberg/pull/6365), [\#6716](https://github.com/apache/iceberg/pull/6716))
     - Added support for scan and commit metrics reporter that is pluggable through catalog ([\#6404](https://github.com/apache/iceberg/pull/6404), [\#6246](https://github.com/apache/iceberg/pull/6246), [\#6410](https://github.com/apache/iceberg/pull/6410))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes several unrelated small misspellings/grammar errors found while reviewing docs and comments:

- `PuffinReader`: "tha" -> "than" in an exception message
- `site/docs/releases.md`: doubled word "to to"; "Sqllite" -> "SQLite" (3 occurrences); "encrpytion" -> "encryption"
- `docs/docs/kafka-connect.md`: "a Iceberg" -> "an Iceberg"
- `DynamoDbLockManager`: "whould" -> "would"
- `S3FileIO`: "referencable" -> "referenceable"
- `BigQueryProperties`: "intial" -> "initial"
- Flink (duplicated across v1.20/v2.1/v2.2/v2.3): "2st" -> "2nd", "columsn" -> "columns", "caculated" -> "calculated", "failres" -> "failures"
- Rust 0.10.0 blog post: "programatically" -> "programmatically"

### Why are the changes needed?
Spelling/grammar correctness in Javadoc, an exception message, and documentation. No behavior change.

### Does this PR introduce any user-facing change?
No functional change. The exception message text in `PuffinReader` changes (fixes a typo), which is the only user-visible string affected.

### How was this patch tested?
Comment/doc/string-only changes; existing test suite covers `PuffinReader` behavior (message content is not asserted in tests).