### PR TITLE
Kafka Connect: add upsert, source-timezone shift, and naive-storage options

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -79,6 +79,13 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String TABLES_UPSERT_MODE_ENABLED_PROP =
+      "iceberg.tables.upsert-mode-enabled";
+  private static final String TABLES_CDC_FIELD_PROP = "iceberg.tables.cdc-field";
+  private static final String DEFAULT_CDC_FIELD = "_cdc.op";
+  private static final String TABLES_SOURCE_TIMEZONE_PROP = "iceberg.tables.source-timezone";
+  private static final String TABLES_STORE_NAIVE_TIMESTAMPS_PROP =
+      "iceberg.tables.store-naive-timestamps";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -175,6 +182,37 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to add any missing record fields to the table schema, false otherwise");
+    configDef.define(
+        TABLES_UPSERT_MODE_ENABLED_PROP,
+        ConfigDef.Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "Set to true to enable upsert mode, requires id-columns to be set");
+    configDef.define(
+        TABLES_CDC_FIELD_PROP,
+        ConfigDef.Type.STRING,
+        DEFAULT_CDC_FIELD,
+        Importance.MEDIUM,
+        "Dot-separated path to the CDC op field (I/U/D) in the record value, default _cdc.op");
+    configDef.define(
+        TABLES_SOURCE_TIMEZONE_PROP,
+        ConfigDef.Type.STRING,
+        null,
+        Importance.MEDIUM,
+        "IANA zone id (e.g. Africa/Cairo) that the source database uses for naive timestamp "
+            + "columns. When set, epoch-millis timestamps received from Debezium are "
+            + "reinterpreted: their wall-clock digits are relabeled as this zone and converted "
+            + "to the correct UTC instant before storing in Iceberg. Leave unset (default) to "
+            + "keep the raw value as received.");
+    configDef.define(
+        TABLES_STORE_NAIVE_TIMESTAMPS_PROP,
+        ConfigDef.Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        "When true, all timestamp-like columns are stored as Iceberg 'timestamp' (naive) rather "
+            + "than 'timestamptz'. Combined with iceberg.tables.source-timezone, the stored "
+            + "wall-clock digits are the source zone's local time (matches what the source "
+            + "database displays). Default false preserves 'timestamptz' storage.");
     configDef.define(
         CATALOG_NAME_PROP,
         ConfigDef.Type.STRING,
@@ -442,6 +480,23 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean schemaForceOptional() {
     return getBoolean(TABLES_SCHEMA_FORCE_OPTIONAL_PROP);
+  }
+
+  public boolean upsertModeEnabled() {
+    return getBoolean(TABLES_UPSERT_MODE_ENABLED_PROP);
+  }
+
+  public String tablesCdcField() {
+    return getString(TABLES_CDC_FIELD_PROP);
+  }
+
+  public java.time.ZoneId sourceTimezone() {
+    String zone = getString(TABLES_SOURCE_TIMEZONE_PROP);
+    return zone == null || zone.isEmpty() ? null : java.time.ZoneId.of(zone);
+  }
+
+  public boolean storeNaiveTimestamps() {
+    return getBoolean(TABLES_STORE_NAIVE_TIMESTAMPS_PROP);
   }
 
   public boolean schemaCaseInsensitive() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
@@ -61,7 +61,11 @@ class IcebergWriter implements RecordWriter {
       // ignore tombstones...
       if (record.value() != null) {
         Record row = convertToRow(record);
-        writer.write(row);
+        if (config.upsertModeEnabled() && writer instanceof RecordDeltaWriter) {
+          routeDelta((RecordDeltaWriter) writer, row, record.value());
+        } else {
+          writer.write(row);
+        }
       }
     } catch (Exception e) {
       throw new DataException(
@@ -72,6 +76,30 @@ class IcebergWriter implements RecordWriter {
               record.kafkaPartition(),
               record.kafkaOffset()),
           e);
+    }
+  }
+
+  private void routeDelta(RecordDeltaWriter deltaWriter, Record row, Object recordValue)
+      throws java.io.IOException {
+    String opField = config.tablesCdcField();
+    Object opValue = opField == null ? null : RecordUtils.extractFromRecordValue(recordValue, opField);
+    String op = opValue == null ? "I" : opValue.toString().toUpperCase(Locale.ROOT);
+    switch (op) {
+      case "D":
+      case "DELETE":
+        deltaWriter.deleteRow(row);
+        break;
+      case "U":
+      case "UPDATE":
+        deltaWriter.updateRow(row);
+        break;
+      case "I":
+      case "INSERT":
+      case "C":
+      case "R":
+      default:
+        deltaWriter.insertRow(row);
+        break;
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -712,7 +712,8 @@ class RecordConverter {
   private OffsetDateTime convertOffsetDateTime(Object value) {
     if (value instanceof Number) {
       long millis = ((Number) value).longValue();
-      return DateTimeUtil.timestamptzFromMicros(millis * 1000);
+      long correctedMicros = correctForSourceTimezone(millis) * 1000;
+      return DateTimeUtil.timestamptzFromMicros(correctedMicros);
     } else if (value instanceof String) {
       return parseOffsetDateTime((String) value);
     } else if (value instanceof OffsetDateTime) {
@@ -720,10 +721,32 @@ class RecordConverter {
     } else if (value instanceof LocalDateTime) {
       return ((LocalDateTime) value).atOffset(ZoneOffset.UTC);
     } else if (value instanceof Date) {
-      return DateTimeUtil.timestamptzFromMicros(((Date) value).getTime() * 1000);
+      long correctedMicros = correctForSourceTimezone(((Date) value).getTime()) * 1000;
+      return DateTimeUtil.timestamptzFromMicros(correctedMicros);
     }
     throw new ConnectException(
         "Cannot convert timestamptz: " + value + ", type: " + value.getClass());
+  }
+
+  /**
+   * If {@code iceberg.tables.source-timezone} is set, treat the incoming epoch millis as if their
+   * wall-clock digits were originally in the configured zone (mislabeled as UTC by Debezium for
+   * naive DB types like SQL Server DATETIME2) and return the corrected UTC epoch millis.
+   *
+   * <p>Algorithm: recover the wall-clock digits by rendering the instant in UTC, relabel those
+   * digits as being in the source zone, then convert back to a true instant.
+   */
+  private long correctForSourceTimezone(long millis) {
+    java.time.ZoneId sourceZone = config.sourceTimezone();
+    if (sourceZone == null) {
+      return millis;
+    }
+    return Instant.ofEpochMilli(millis)
+        .atZone(ZoneOffset.UTC)
+        .toLocalDateTime()
+        .atZone(sourceZone)
+        .toInstant()
+        .toEpochMilli();
   }
 
   private OffsetDateTime parseOffsetDateTime(String str) {
@@ -740,7 +763,7 @@ class RecordConverter {
   private LocalDateTime convertLocalDateTime(Object value) {
     if (value instanceof Number) {
       long millis = ((Number) value).longValue();
-      return DateTimeUtil.timestampFromMicros(millis * 1000);
+      return millisToNaive(millis);
     } else if (value instanceof String) {
       return parseLocalDateTime((String) value);
     } else if (value instanceof LocalDateTime) {
@@ -748,10 +771,25 @@ class RecordConverter {
     } else if (value instanceof OffsetDateTime) {
       return ((OffsetDateTime) value).toLocalDateTime();
     } else if (value instanceof Date) {
-      return DateTimeUtil.timestampFromMicros(((Date) value).getTime() * 1000);
+      return millisToNaive(((Date) value).getTime());
     }
     throw new ConnectException(
         "Cannot convert timestamp: " + value + ", type: " + value.getClass());
+  }
+
+  /**
+   * Convert incoming epoch millis to a naive LocalDateTime. When {@code
+   * iceberg.tables.source-timezone} is set, the value is the source-zone wall-clock digits
+   * (matches the source database's display). Otherwise it is the UTC wall-clock (existing
+   * behavior).
+   */
+  private LocalDateTime millisToNaive(long millis) {
+    java.time.ZoneId sourceZone = config.sourceTimezone();
+    if (sourceZone == null) {
+      return DateTimeUtil.timestampFromMicros(millis * 1000);
+    }
+    long correctedMillis = correctForSourceTimezone(millis);
+    return Instant.ofEpochMilli(correctedMillis).atZone(sourceZone).toLocalDateTime();
   }
 
   private LocalDateTime parseLocalDateTime(String str) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordDeltaWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordDeltaWriter.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.BaseTaskWriter;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileWriterFactory;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.StructProjection;
+
+/**
+ * A delta task writer that supports insert / update / delete on Iceberg V2 tables via equality
+ * deletes. Backs the sink's upsert mode.
+ */
+class RecordDeltaWriter extends BaseTaskWriter<Record> {
+
+  private final Schema schema;
+  private final Schema deleteSchema;
+  private final PartitionKey partitionKey;
+  private final InternalRecordWrapper partitionWrapper;
+  private final Map<PartitionKey, RecordEqualityDeltaWriter> writers = Maps.newHashMap();
+  private final boolean unpartitioned;
+  private RecordEqualityDeltaWriter singleWriter;
+
+  RecordDeltaWriter(
+      PartitionSpec spec,
+      FileFormat format,
+      FileWriterFactory<Record> writerFactory,
+      OutputFileFactory fileFactory,
+      FileIO io,
+      long targetFileSize,
+      Schema schema,
+      Set<Integer> equalityFieldIds) {
+    super(spec, format, writerFactory, fileFactory, io, targetFileSize);
+    this.schema = schema;
+    this.deleteSchema = TypeUtil.select(schema, equalityFieldIds);
+    this.partitionKey = new PartitionKey(spec, schema);
+    this.partitionWrapper = new InternalRecordWrapper(schema.asStruct());
+    this.unpartitioned = spec.isUnpartitioned();
+  }
+
+  /** Insert a new row: equality-delete the key first (idempotent on replay) then append. */
+  void insertRow(Record row) throws IOException {
+    RecordEqualityDeltaWriter writer = writerFor(row);
+    writer.deleteKey(row);
+    writer.write(row);
+  }
+
+  /** Update an existing row: equality-delete the key then append the new version. */
+  void updateRow(Record row) throws IOException {
+    RecordEqualityDeltaWriter writer = writerFor(row);
+    writer.deleteKey(row);
+    writer.write(row);
+  }
+
+  /** Delete a row by its equality key. */
+  void deleteRow(Record row) throws IOException {
+    RecordEqualityDeltaWriter writer = writerFor(row);
+    writer.deleteKey(row);
+  }
+
+  /** TaskWriter contract; defaults to insert semantics. */
+  @Override
+  public void write(Record row) throws IOException {
+    insertRow(row);
+  }
+
+  private RecordEqualityDeltaWriter writerFor(Record row) {
+    if (unpartitioned) {
+      if (singleWriter == null) {
+        singleWriter = new RecordEqualityDeltaWriter(null);
+      }
+      return singleWriter;
+    }
+
+    partitionKey.partition(partitionWrapper.wrap(row));
+    RecordEqualityDeltaWriter writer = writers.get(partitionKey);
+    if (writer == null) {
+      PartitionKey copiedKey = partitionKey.copy();
+      writer = new RecordEqualityDeltaWriter(copiedKey);
+      writers.put(copiedKey, writer);
+    }
+    return writer;
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+      if (singleWriter != null) {
+        singleWriter.close();
+        singleWriter = null;
+      }
+      for (RecordEqualityDeltaWriter w : writers.values()) {
+        w.close();
+      }
+      writers.clear();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close record delta writer", e);
+    }
+  }
+
+  private class RecordEqualityDeltaWriter extends BaseEqualityDeltaWriter {
+    private final InternalRecordWrapper rowWrapper;
+    private final InternalRecordWrapper keyWrapper;
+    private final StructProjection keyProjection;
+
+    RecordEqualityDeltaWriter(StructLike partition) {
+      super(partition, schema, deleteSchema);
+      this.rowWrapper = new InternalRecordWrapper(schema.asStruct());
+      this.keyWrapper = new InternalRecordWrapper(schema.asStruct());
+      this.keyProjection = StructProjection.create(schema, deleteSchema);
+    }
+
+    @Override
+    protected StructLike asStructLike(Record data) {
+      return rowWrapper.wrap(data);
+    }
+
+    @Override
+    protected StructLike asStructLikeKey(Record data) {
+      return keyProjection.wrap(keyWrapper.wrap(data));
+    }
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
@@ -159,7 +159,20 @@ class RecordUtils {
             .build();
 
     TaskWriter<Record> writer;
-    if (table.spec().isUnpartitioned()) {
+    if (config.upsertModeEnabled()
+        && identifierFieldIds != null
+        && !identifierFieldIds.isEmpty()) {
+      writer =
+          new RecordDeltaWriter(
+              table.spec(),
+              format,
+              writerFactory,
+              fileFactory,
+              table.io(),
+              targetFileSize,
+              table.schema(),
+              identifierFieldIds);
+    } else if (table.spec().isUnpartitioned()) {
       writer =
           new UnpartitionedWriter<>(
               table.spec(), format, writerFactory, fileFactory, table.io(), targetFileSize);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -249,7 +249,9 @@ class SchemaUtils {
           return IntegerType.get();
         case INT64:
           if (Timestamp.LOGICAL_NAME.equals(valueSchema.name())) {
-            return TimestampType.withZone();
+            return config.storeNaiveTimestamps()
+                ? TimestampType.withoutZone()
+                : TimestampType.withZone();
           }
           return LongType.get();
         case FLOAT32:
@@ -311,7 +313,9 @@ class SchemaUtils {
       } else if (value instanceof LocalTime) {
         return TimeType.get();
       } else if (value instanceof java.util.Date || value instanceof OffsetDateTime) {
-        return TimestampType.withZone();
+        return config.storeNaiveTimestamps()
+            ? TimestampType.withoutZone()
+            : TimestampType.withZone();
       } else if (value instanceof LocalDateTime) {
         return TimestampType.withoutZone();
       } else if (value instanceof List) {

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+1.11.0-upsert-tz-naive


### PR DESCRIPTION
Adds experimental modes to the kafka-connect sink for CDC pipelines fed by Debezium. All controlled by connector config; defaults preserve upstream behavior.

Upsert (equality-delete backed) — enabled by
`iceberg.tables.upsert-mode-enabled=true` plus per-table `iceberg.tables.<name>.id-columns` (or global `default-id-columns`). New `RecordDeltaWriter` extends Iceberg core's `BaseTaskWriter` with per-partition `BaseEqualityDeltaWriter` instances. `IcebergWriter.write` reads `iceberg.tables.cdc-field` (default `_cdc.op`) and routes I/C/R to insertRow, U to updateRow, D to deleteRow. `RecordUtils.createTableWriter` selects the delta writer when both the flag and id-columns are set.

Source-timezone shift — `iceberg.tables.source-timezone=<zone>` treats Debezium's naive DATETIME/DATETIME2 columns (mislabeled as UTC by the JDBC driver) as the given IANA zone and rewrites incoming epoch millis to the corrected UTC instant via
recover-digits → relabel-as-source-zone → back-to-instant. `RecordConverter.correctForSourceTimezone` is invoked from both the timestamptz and naive Number/Date branches.

Naive storage — `iceberg.tables.store-naive-timestamps=true` forces `SchemaUtils.toIcebergType` to emit `TimestampType.withoutZone()` for Debezium Connect.Timestamp columns. Combined with `source-timezone`, the new `RecordConverter.millisToNaive` stores the source-zone wall-clock digits as a naive `timestamp` (matches SQL Server display; ClickHouse IcebergS3 auto-discovers `DateTime64(6)` without a zone attribute).

Files touched:
- IcebergSinkConfig: new configs and getters
- SchemaUtils: naive vs zoned type inference
- RecordConverter: shift and naive value conversion
- IcebergWriter, RecordUtils: upsert delta-writer routing
- RecordDeltaWriter: new equality-delete writer