### PR TITLE
Flink: Support Variant type in DynamicIcebergSink

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,20 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.VariantType;
 import org.junit.jupiter.api.Test;
 
 class TestCompareSchemasVisitor {
@@ -54,6 +55,50 @@ class TestCompareSchemasVisitor {
                 CASE_SENSITIVE,
                 PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testSchemaWithVariantSame() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testVariantAgainstNonVariantTableField() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()), optional(2, "payload", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testVariantFieldMissingFromTable() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(optional(1, "id", IntegerType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -104,6 +104,30 @@ public class TestEvolveSchemaVisitor {
   }
 
   @Test
+  public void testAddTopLevelVariant() {
+    Schema targetSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(new Schema());
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(targetSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
+  public void testExistingVariantFieldIsUnchanged() {
+    Schema existingSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, existingSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(existingSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
   public void testMakeTopLevelPrimitivesOptional() {
     Schema existingSchema = new Schema(primitiveFields(0, primitiveTypes(), false));
     assertThat(existingSchema.columns().stream().allMatch(Types.NestedField::isRequired)).isTrue();

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
@@ -74,6 +75,19 @@ class TestRowDataConverter {
   void testAddColumn() {
     assertThat(convert(SimpleDataUtil.createRowData(1, "a"), SCHEMA, SCHEMA2))
         .isEqualTo(GenericRowData.of(1, StringData.fromString("a"), null));
+  }
+
+  @Test
+  void testVariantIdentity() {
+    Schema schemaWithVariant =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "payload", Types.VariantType.get()));
+
+    Variant variant = Variant.newBuilder().object().add("k", Variant.newBuilder().of(1L)).build();
+    RowData row = GenericRowData.of(42, variant);
+
+    assertThat(convert(row, schemaWithVariant, schemaWithVariant)).isEqualTo(row);
   }
 
   @Test

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,20 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.VariantType;
 import org.junit.jupiter.api.Test;
 
 class TestCompareSchemasVisitor {
@@ -54,6 +55,50 @@ class TestCompareSchemasVisitor {
                 CASE_SENSITIVE,
                 PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testSchemaWithVariantSame() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testVariantAgainstNonVariantTableField() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()), optional(2, "payload", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testVariantFieldMissingFromTable() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(optional(1, "id", IntegerType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
   @Test

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -104,6 +104,30 @@ public class TestEvolveSchemaVisitor {
   }
 
   @Test
+  public void testAddTopLevelVariant() {
+    Schema targetSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(new Schema());
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(targetSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
+  public void testExistingVariantFieldIsUnchanged() {
+    Schema existingSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, existingSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(existingSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
   public void testMakeTopLevelPrimitivesOptional() {
     Schema existingSchema = new Schema(primitiveFields(0, primitiveTypes(), false));
     assertThat(existingSchema.columns().stream().allMatch(Types.NestedField::isRequired)).isTrue();

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
@@ -74,6 +75,19 @@ class TestRowDataConverter {
   void testAddColumn() {
     assertThat(convert(SimpleDataUtil.createRowData(1, "a"), SCHEMA, SCHEMA2))
         .isEqualTo(GenericRowData.of(1, StringData.fromString("a"), null));
+  }
+
+  @Test
+  void testVariantIdentity() {
+    Schema schemaWithVariant =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "payload", Types.VariantType.get()));
+
+    Variant variant = Variant.newBuilder().object().add("k", Variant.newBuilder().of(1L)).build();
+    RowData row = GenericRowData.of(42, variant);
+
+    assertThat(convert(row, schemaWithVariant, schemaWithVariant)).isEqualTo(row);
   }
 
   @Test

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,20 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.VariantType;
 import org.junit.jupiter.api.Test;
 
 class TestCompareSchemasVisitor {
@@ -54,6 +55,50 @@ class TestCompareSchemasVisitor {
                 CASE_SENSITIVE,
                 PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testSchemaWithVariantSame() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "payload", VariantType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testVariantAgainstNonVariantTableField() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()), optional(2, "payload", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testVariantFieldMissingFromTable() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "payload", VariantType.get())),
+                new Schema(optional(1, "id", IntegerType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
   @Test

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -104,6 +104,30 @@ public class TestEvolveSchemaVisitor {
   }
 
   @Test
+  public void testAddTopLevelVariant() {
+    Schema targetSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(new Schema());
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(targetSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
+  public void testExistingVariantFieldIsUnchanged() {
+    Schema existingSchema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, existingSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    assertThat(existingSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
+  }
+
+  @Test
   public void testMakeTopLevelPrimitivesOptional() {
     Schema existingSchema = new Schema(primitiveFields(0, primitiveTypes(), false));
     assertThat(existingSchema.columns().stream().allMatch(Types.NestedField::isRequired)).isTrue();

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
@@ -74,6 +75,19 @@ class TestRowDataConverter {
   void testAddColumn() {
     assertThat(convert(SimpleDataUtil.createRowData(1, "a"), SCHEMA, SCHEMA2))
         .isEqualTo(GenericRowData.of(1, StringData.fromString("a"), null));
+  }
+
+  @Test
+  void testVariantIdentity() {
+    Schema schemaWithVariant =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "payload", Types.VariantType.get()));
+
+    Variant variant = Variant.newBuilder().object().add("k", Variant.newBuilder().of(1L)).build();
+    RowData row = GenericRowData.of(42, variant);
+
+    assertThat(convert(row, schemaWithVariant, schemaWithVariant)).isEqualTo(row);
   }
 
   @Test


### PR DESCRIPTION
Fixes #17615

## Problem

`DynamicIcebergSink` fails on any `DynamicRecord` whose schema contains a `variant` field:

```
java.lang.UnsupportedOperationException: Unsupported type: variant
	at org.apache.iceberg.schema.SchemaWithPartnerVisitor.variant(SchemaWithPartnerVisitor.java:167)
	at org.apache.iceberg.schema.SchemaWithPartnerVisitor.visit(SchemaWithPartnerVisitor.java:111)
	at org.apache.iceberg.schema.SchemaWithPartnerVisitor.visit(SchemaWithPartnerVisitor.java:62)
	at org.apache.iceberg.schema.SchemaWithPartnerVisitor.visit(SchemaWithPartnerVisitor.java:45)
	at org.apache.iceberg.flink.sink.dynamic.CompareSchemasVisitor.visit(CompareSchemasVisitor.java:60)
	at org.apache.iceberg.flink.sink.dynamic.TableMetadataCache.schema(TableMetadataCache.java:161)
	at org.apache.iceberg.flink.sink.dynamic.TableMetadataCache.schema(TableMetadataCache.java:112)
	at org.apache.iceberg.flink.sink.dynamic.DynamicRecordProcessor.collect(DynamicRecordProcessor.java:138)
```

`CompareSchemasVisitor` and `EvolveSchemaVisitor` extend `SchemaWithPartnerVisitor` but do not override `variant()`, so they inherit the base implementation which throws unconditionally. Since `TableMetadataCache.schema()` runs `CompareSchemasVisitor` on every incoming record's schema, the failure occurs during schema resolution — before any writer is created, and **even when the target table already exists with an exactly matching schema**. `DataConverter.get()` also lacks a `VARIANT` case on the conversion path.

The rest of the stack already supports variant: `FlinkSchemaUtil` maps `VariantType` in both directions, `FlinkParquetWriters`/`FlinkParquetReaders` read and write it, and the static `IcebergSink` writes variant fields end-to-end (verified: identical schema + row data succeeds through `IcebergSink.forRowData` against the same table where the dynamic sink throws). Notably, `VariantAvroDynamicTableRecordGenerator` (#16450) already produces variant-bearing `DynamicRecord`s that the pipeline is currently unable to process.

## Changes

- `CompareSchemasVisitor`: add `variant()` override — `SAME` when the table field is also variant, `SCHEMA_UPDATE_NEEDED` otherwise (variant has no widening/conversion semantics).
- `EvolveSchemaVisitor`: add `variant()` override, consistent with `primitive()`.
- `DataConverter`: add identity `case VARIANT`.
- Applied to the `v2.1`, `v2.2`, and `v2.3` modules. `v1.20` is intentionally excluded: Flink 1.20 has no `VariantType` / `LogicalTypeRoot.VARIANT`, so the dynamic sink cannot receive variant data there and a `case VARIANT:` in `DataConverter` would not compile against Flink 1.20.

## Tests

Per module (v2.1/v2.2/v2.3):

- `TestCompareSchemasVisitor`: same variant schema → `SAME`; variant vs non-variant table field → `SCHEMA_UPDATE_NEEDED`; variant field missing from table → `SCHEMA_UPDATE_NEEDED`.
- `TestEvolveSchemaVisitor`: adding a top-level variant field via schema evolution; identical variant schema is a no-op.
- `TestRowDataConverter`: variant value passes through `DataConverter` unchanged.

`:iceberg-flink:iceberg-flink-{2.1,2.2,2.3}:test` for the three test classes: 79 tests per module, 0 failures. Spotless clean.

## Relationship to #17631

This supersedes #17631 (thank you @waterWang for the original fix — credited via `Co-authored-by` on the commit). That PR targets the `flink/v2.0` module which no longer exists on `main`, and its `v1.20` `DataConverter` change cannot compile against Flink 1.20; this PR retargets the same fix to the current module layout (v2.1/v2.2/v2.3) and adds test coverage.
