### PR TITLE
Flink: Validate concurrent commits in IcebergSink to prevent commit duplication

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -32,8 +32,11 @@ import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotAncestryValidator;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -309,8 +312,30 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     operation.set(SinkUtil.OPERATOR_ID, operatorId);
     operation.toBranch(branch);
 
+    // Prevent duplicate commits: if a previous attempt for this checkpoint already reached the
+    // table (e.g. the commit succeeded on the catalog after the committer gave up and the request
+    // was redelivered on recovery), the base ancestry will already contain a snapshot with a
+    // max-committed-checkpoint-id >= this checkpoint. Validating inside the commit transaction
+    // closes the race window between the up-front getMaxCommittedCheckpointId() read and the
+    // commit itself. Mirrors DynamicCommitter's MaxCommittedCheckpointIdValidator (#14517).
+    operation.validateWith(
+        new MaxCommittedCheckpointIdValidator(checkpointId, newFlinkJobId, operatorId));
+
     long startNano = System.nanoTime();
-    operation.commit(); // abort is automatically called if this fails.
+    try {
+      operation.commit(); // abort is automatically called if this fails.
+    } catch (MaxCommittedCheckpointMismatchException e) {
+      LOG.info(
+          "Skipping commit operation {} because the {} branch of the {} table already contains changes for checkpoint {}."
+              + " This can occur when a failure prevents the committer from receiving confirmation of a"
+              + " successful commit, causing the Flink job to retry committing the same set of changes.",
+          description,
+          branch,
+          table.name(),
+          checkpointId,
+          e);
+      return;
+    }
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
         "Committed {} to table: {}, branch: {}, checkpointId {} in {} ms",
@@ -321,6 +346,49 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
         durationMs);
     if (committerMetrics != null) {
       committerMetrics.commitDuration(durationMs);
+    }
+  }
+
+  private static class MaxCommittedCheckpointMismatchException extends ValidationException {
+    private MaxCommittedCheckpointMismatchException() {
+      super("Table already contains staged changes.");
+    }
+  }
+
+  private static class MaxCommittedCheckpointIdValidator implements SnapshotAncestryValidator {
+    private final long stagedCheckpointId;
+    private final String flinkJobId;
+    private final String flinkOperatorId;
+
+    private MaxCommittedCheckpointIdValidator(
+        long stagedCheckpointId, String flinkJobId, String flinkOperatorId) {
+      this.stagedCheckpointId = stagedCheckpointId;
+      this.flinkJobId = flinkJobId;
+      this.flinkOperatorId = flinkOperatorId;
+    }
+
+    @Override
+    public boolean validate(Iterable<Snapshot> baseSnapshots) {
+      long maxCommittedCheckpointId = SinkUtil.INITIAL_CHECKPOINT_ID;
+      for (Snapshot ancestor : baseSnapshots) {
+        Map<String, String> summary = ancestor.summary();
+        String snapshotFlinkJobId = summary.get(SinkUtil.FLINK_JOB_ID);
+        String snapshotOperatorId = summary.get(SinkUtil.OPERATOR_ID);
+        if (flinkJobId.equals(snapshotFlinkJobId)
+            && (snapshotOperatorId == null || snapshotOperatorId.equals(flinkOperatorId))) {
+          String value = summary.get(SinkUtil.MAX_COMMITTED_CHECKPOINT_ID);
+          if (value != null) {
+            maxCommittedCheckpointId = Long.parseLong(value);
+            break;
+          }
+        }
+      }
+
+      if (maxCommittedCheckpointId >= stagedCheckpointId) {
+        throw new MaxCommittedCheckpointMismatchException();
+      }
+
+      return true;
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/SinkUtil.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/SinkUtil.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 @Internal
 public class SinkUtil {
 
-  private static final long INITIAL_CHECKPOINT_ID = -1L;
+  static final long INITIAL_CHECKPOINT_ID = -1L;
 
   public static final String FLINK_JOB_ID = "flink.job-id";
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitterDuplicateCommit.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitterDuplicateCommit.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.TaskInfo;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reproducer for the non-dynamic {@link IcebergCommitter} exposure to the duplicate-commit race
+ * described in apache/iceberg issue #14425.
+ *
+ * <p>Interleaving reproduced (deterministically, via an intercepted {@link AppendFiles#commit()}):
+ *
+ * <ol>
+ *   <li>Committer A receives the commit request for checkpoint 1, reads
+ *       getMaxCommittedCheckpointId() == -1 (nothing committed yet), decides to commit.
+ *   <li>Before A's table commit lands, the SAME committable is committed by another committer
+ *       instance B (in production: the first commit request was in flight on the REST catalog when
+ *       the job restarted; the restarted job re-delivers the committable and commits it while the
+ *       original request also lands).
+ *   <li>A's commit then proceeds: SnapshotProducer.refresh() picks up B's snapshot as the new
+ *       parent, so A's append applies cleanly on top -- no conflict, no retry.
+ * </ol>
+ *
+ * <p>Expected (fixed) behavior -- what DynamicCommitter does since PR #14517: detect that the
+ * branch already contains a commit for this checkpointId (MaxCommittedCheckpointIdValidator) and
+ * skip the second commit, leaving ONE snapshot. The assertion below asserts that correct behavior,
+ * so this test FAILS on the unpatched IcebergCommitter, demonstrating duplicate data.
+ */
+class TestIcebergCommitterDuplicateCommit {
+
+  private static final String OPERATOR_ID = "flink-sink";
+  private static final String JOB_ID = "jobId";
+  private static final long CHECKPOINT_ID = 1L;
+  private static final long ROW_COUNT = 5L;
+
+  @TempDir private File temporaryFolder;
+  @TempDir private File flinkManifestFolder;
+
+  private Table table;
+  private TableLoader tableLoader;
+
+  private final DataFile dataFile =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(0)
+          .withMetrics(
+              new Metrics(
+                  ROW_COUNT,
+                  null,
+                  ImmutableMap.of(1, 5L),
+                  ImmutableMap.of(1, 0L),
+                  null,
+                  ImmutableMap.of(
+                      1,
+                      org.apache.iceberg.types.Conversions.toByteBuffer(
+                          org.apache.iceberg.types.Types.LongType.get(), 0L)),
+                  ImmutableMap.of(
+                      1,
+                      org.apache.iceberg.types.Conversions.toByteBuffer(
+                          org.apache.iceberg.types.Types.LongType.get(), 4L))))
+          .build();
+
+  @BeforeEach
+  public void before() throws Exception {
+    String warehouse = temporaryFolder.getAbsolutePath();
+    String tablePath = warehouse.concat("/test");
+    assertThat(new File(tablePath).mkdir()).isTrue();
+    String tableLocation = "file:" + tablePath;
+    Map<String, String> props =
+        ImmutableMap.of(
+            org.apache.iceberg.TableProperties.FORMAT_VERSION, "2",
+            ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION,
+                flinkManifestFolder.getAbsolutePath(),
+            IcebergCommitter.MAX_CONTINUOUS_EMPTY_COMMITS, "1");
+    table = SimpleDataUtil.createTable(tableLocation, props, false);
+    tableLoader = TableLoader.fromHadoopTable(tableLocation);
+  }
+
+  @Test
+  public void testConcurrentCommitOfSameCheckpointCausesDuplicate() throws Exception {
+    Committer.CommitRequest<IcebergCommittable> requestForA =
+        buildCommitRequestFor(JOB_ID, CHECKPOINT_ID);
+    Committer.CommitRequest<IcebergCommittable> requestForB =
+        buildCommitRequestFor(JOB_ID, CHECKPOINT_ID);
+
+    IcebergCommitter committerB = committer(tableLoader);
+
+    AtomicBoolean fired = new AtomicBoolean(false);
+    Runnable concurrentCommit =
+        () -> {
+          if (fired.compareAndSet(false, true)) {
+            try {
+              committerB.commit(Collections.singletonList(requestForB));
+            } catch (Exception e) {
+              throw new RuntimeException("Concurrent commit by committer B failed", e);
+            }
+          }
+        };
+
+    IcebergCommitter committerA = committer(interceptingLoader(tableLoader, concurrentCommit));
+    committerA.commit(Collections.singletonList(requestForA));
+
+    table.refresh();
+    long snapshots = Lists.newArrayList(table.snapshots()).size();
+    long totalRecords =
+        Long.parseLong(table.currentSnapshot().summary().getOrDefault("total-records", "0"));
+
+    System.out.println(
+        "REPRO RESULT: snapshots="
+            + snapshots
+            + " total-records="
+            + totalRecords
+            + " (expected on FIXED committer: snapshots=1 total-records="
+            + ROW_COUNT
+            + ")");
+
+    // Correct (fixed) behavior: exactly one commit for checkpoint 1 lands.
+    // On the unpatched IcebergCommitter this fails with snapshots=2 / total-records=10:
+    // the same checkpoint's data files are committed twice (duplicate data).
+    assertThat(snapshots)
+        .as("Only one commit should land for a single checkpoint's committable")
+        .isEqualTo(1L);
+    assertThat(totalRecords).isEqualTo(ROW_COUNT);
+  }
+
+  // ---------------- helpers ----------------
+
+  private IcebergCommitter committer(TableLoader loader) {
+    IcebergFilesCommitterMetrics metrics = mock(IcebergFilesCommitterMetrics.class);
+    return new IcebergCommitter(
+        loader,
+        SnapshotRef.MAIN_BRANCH,
+        Collections.singletonMap("flink.test", getClass().getName()),
+        false,
+        10,
+        "sinkId",
+        metrics,
+        false,
+        0);
+  }
+
+  /** TableLoader whose loaded Table intercepts AppendFiles.commit() to run {@code hook} first. */
+  private TableLoader interceptingLoader(TableLoader delegate, Runnable hook) {
+    return new TableLoader() {
+      @Override
+      public void open() {
+        delegate.open();
+      }
+
+      @Override
+      public boolean isOpen() {
+        return delegate.isOpen();
+      }
+
+      @Override
+      public Table loadTable() {
+        return interceptTable(delegate.loadTable(), hook);
+      }
+
+      @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
+      @Override
+      public TableLoader clone() {
+        return interceptingLoader(delegate.clone(), hook);
+      }
+
+      @Override
+      public void close() throws IOException {
+        delegate.close();
+      }
+    };
+  }
+
+  private static Table interceptTable(Table delegate, Runnable hook) {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          Object result = invoke(delegate, method, args);
+          if ("newAppend".equals(method.getName())) {
+            return interceptAppend((AppendFiles) result, hook);
+          }
+          return result;
+        };
+    return (Table)
+        Proxy.newProxyInstance(Table.class.getClassLoader(), new Class<?>[] {Table.class}, handler);
+  }
+
+  private static AppendFiles interceptAppend(AppendFiles delegate, Runnable hook) {
+    InvocationHandler handler =
+        (proxy, method, args) -> {
+          if ("commit".equals(method.getName())) {
+            hook.run();
+          }
+          Object result = invoke(delegate, method, args);
+          // fluent API returns the delegate; keep returning the proxy instead
+          return result == delegate ? proxy : result;
+        };
+    return (AppendFiles)
+        Proxy.newProxyInstance(
+            AppendFiles.class.getClassLoader(), new Class<?>[] {AppendFiles.class}, handler);
+  }
+
+  private static Object invoke(Object target, Method method, Object[] args) throws Exception {
+    try {
+      return method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw e;
+    }
+  }
+
+  private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(
+      String myJobID, long checkpoint) throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(dataFile).build();
+    IcebergCommittable committable =
+        new IcebergCommittable(
+            buildIcebergWriteAggregator(myJobID, OPERATOR_ID)
+                .writeToManifest(Lists.newArrayList(writeResult), checkpoint),
+            myJobID,
+            OPERATOR_ID,
+            checkpoint);
+    CommittableWithLineage<IcebergCommittable> committableWithLineage =
+        new CommittableWithLineage<>(committable, checkpoint, 1);
+    @SuppressWarnings("unchecked")
+    Committer.CommitRequest<IcebergCommittable> commitRequest = mock(Committer.CommitRequest.class);
+    doReturn(committableWithLineage.getCommittable()).when(commitRequest).getCommittable();
+    return commitRequest;
+  }
+
+  private IcebergWriteAggregator buildIcebergWriteAggregator(String myJobId, String operatorId) {
+    IcebergWriteAggregator icebergWriteAggregator = spy(new IcebergWriteAggregator(tableLoader));
+    StreamTask ctx = mock(StreamTask.class);
+    Environment env = mock(Environment.class);
+    StreamingRuntimeContext streamingRuntimeContext = mock(StreamingRuntimeContext.class);
+    TaskInfo taskInfo = mock(TaskInfo.class);
+    JobID myJobID = mock(JobID.class);
+    OperatorID operatorID = mock(OperatorID.class);
+    doReturn(myJobId).when(myJobID).toString();
+    doReturn(myJobID).when(env).getJobID();
+    doReturn(env).when(ctx).getEnvironment();
+    doReturn(ctx).when(icebergWriteAggregator).getContainingTask();
+    doReturn(operatorId).when(operatorID).toString();
+    doReturn(operatorID).when(icebergWriteAggregator).getOperatorID();
+    doReturn(0).when(taskInfo).getAttemptNumber();
+    doReturn(taskInfo).when(streamingRuntimeContext).getTaskInfo();
+    doReturn(streamingRuntimeContext).when(icebergWriteAggregator).getRuntimeContext();
+    try {
+      icebergWriteAggregator.open();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return icebergWriteAggregator;
+  }
+}


### PR DESCRIPTION
## Problem

The non-dynamic `IcebergSink` committer (`IcebergCommitter`) is exposed to the duplicate-commit race described in #14425, which was fixed for the `DynamicIcebergSink` in #14517 (+ Flink 2.0/2.1 port in #14637) but never ported to the non-dynamic path.

`IcebergCommitter.commit()` reads `getMaxCommittedCheckpointId()` once, up front, and then commits without re-validation:

1. The committer sends a commit for checkpoint N to the catalog; the request is slow (e.g. the catalog commits asynchronously after the client gives up) and the committer fails/restarts before receiving confirmation.
2. On recovery, Flink redelivers the committable. The restarted committer reads `getMaxCommittedCheckpointId()` — the original commit has not landed yet, so it decides checkpoint N is uncommitted.
3. The original commit now lands. When the redelivered commit reaches `SnapshotProducer.apply()`, the refresh picks up the just-landed snapshot as the new parent, so the second commit applies **cleanly — no conflict, no retry exhaustion** — and the same checkpoint's data files are committed twice.

We reproduced this deterministically (test included) and verified the resulting table has 2 snapshots carrying the same `flink.max-committed-checkpoint-id` for the same job/operator id, with doubled record counts. The behavior is identical on HadoopTables, AWS Glue, and Amazon S3 Tables catalogs — once the interleaving occurs, the second commit is structurally valid from the catalog's perspective, so only the committer can prevent it.

## Solution

Port the `MaxCommittedCheckpointIdValidator` introduced in #14517 to `IcebergCommitter`: register a `SnapshotAncestryValidator` on the commit operation that re-checks `max-committed-checkpoint-id` against the base snapshot ancestry **inside the commit transaction**, and skip the commit (log + return) when the branch already contains changes for the staged checkpoint — mirroring `DynamicCommitter`'s behavior.

`SinkUtil.INITIAL_CHECKPOINT_ID` is widened from `private` to package-private so the validator can reuse it.

The validator is currently duplicated as a private inner class (same shape as in `DynamicCommitter`). Happy to extract a shared class for both committers if preferred — kept the diff minimal for review.

## Testing

- New `TestIcebergCommitterDuplicateCommit` reproduces the race deterministically (a delegating `TableLoader`/`Table` intercepts `AppendFiles.commit()` to land a concurrent commit of the same committable between the committer's dedup read and its commit). Fails on the unpatched committer with `snapshots=2 / doubled records`; passes with this change (`snapshots=1`, duplicate skipped).
- `TestIcebergCommitter`: 288 tests, 0 failures (no regressions).
- `TestDynamicCommitter`: 12/12 (unchanged).
- `spotlessApply` clean.

If the approach is accepted I'll follow up with the ports to the other Flink versions (v1.20, v2.0, v2.2, v2.3), mirroring how #14517 → #14637 was staged.

Relates to #14425 (fixes the non-dynamic `IcebergSink` exposure it describes).
