### PR TITLE
Common, Data, Flink, Spark: Fix miscellaneous typos in test comments and assertions

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -319,7 +319,7 @@ public class DynFields {
     }
 
     /**
-     * Returns the first valid implementation as a UnboundField or throws a NoSuchFieldException if
+     * Returns the first valid implementation as an UnboundField or throws a NoSuchFieldException if
      * there is none.
      *
      * @param <T> Java class stored in the field
@@ -354,7 +354,7 @@ public class DynFields {
     }
 
     /**
-     * Returns the first valid implementation as a UnboundField or throws a NoSuchFieldException if
+     * Returns the first valid implementation as an UnboundField or throws a NoSuchFieldException if
      * there is none.
      *
      * @param <T> Java class stored in the field

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -399,7 +399,7 @@ public class DynMethods {
     }
 
     /**
-     * Returns the first valid implementation as a UnboundMethod or throws a RuntimeError if there
+     * Returns the first valid implementation as an UnboundMethod or throws a RuntimeError if there
      * is none.
      *
      * @return a {@link UnboundMethod} with a valid implementation
@@ -428,7 +428,7 @@ public class DynMethods {
     }
 
     /**
-     * Returns the first valid implementation as a UnboundMethod or throws a NoSuchMethodException
+     * Returns the first valid implementation as an UnboundMethod or throws a NoSuchMethodException
      * if there is none.
      *
      * @return a {@link UnboundMethod} with a valid implementation

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -138,7 +138,7 @@ public class RandomGenericData {
       // with
       // limited values("0","1","2"). It's impossible for us to request the generator to generate
       // more than 3 keys,
-      // otherwise we will get in a infinite loop in RandomDataGenerator#map.
+      // otherwise we will get in an infinite loop in RandomDataGenerator#map.
       return 3;
     }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -388,7 +388,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -478,7 +478,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -572,7 +572,7 @@ class TestIcebergCommitter extends TestBase {
     CommittableSummary<IcebergCommittable> committableSummary;
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -651,7 +651,7 @@ class TestIcebergCommitter extends TestBase {
     // We've two steps in checkpoint: 1. snapshotState(ckp); 2. notifyCheckpointComplete(ckp).
     // The Flink job should be able to restore from a checkpoint with only step#1 finished.
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -875,7 +875,7 @@ class TestIcebergCommitter extends TestBase {
   @TestTemplate
   public void testMultipleSinksRecoveryFromValidSnapshot() throws Exception {
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
@@ -49,7 +49,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "data", Types.StringType.get()));
 
     PartitionSpec spec1 = PartitionSpec.builderFor(schema).bucket("id", 10).build();
-    // Same spec als spec1 but different number of buckets
+    // Same spec as spec1 but different number of buckets
     PartitionSpec spec2 = PartitionSpec.builderFor(schema).bucket("id", 23).build();
 
     assertThat(PartitionSpecEvolution.checkCompatibility(spec1, spec2)).isFalse();
@@ -85,7 +85,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
             Types.NestedField.required(2, "data", Types.StringType.get()));
 
-    // Same spec als spec1 but bound to a different schema
+    // Same spec as spec1 but bound to a different schema
     PartitionSpec spec2 = PartitionSpec.builderFor(schema2).bucket("id", 10).build();
 
     // Compatible because the source names match

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -329,7 +329,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<GenericData.Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    assertThat(expectedFiles).as("Should have 3 files manifest entriess").hasSize(3);
+    assertThat(expectedFiles).as("Should have 3 files manifest entries").hasSize(3);
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(1), actualFiles.get(1));
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
@@ -318,7 +318,7 @@ public class TestIcebergSourceWithWatermarkExtractor implements Serializable {
    * continue reading the files, but the watermark alignment will still prevent the paused reader to
    * continue.
    *
-   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both ot
+   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both of
    * the readers continue reading.
    */
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -387,7 +387,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -475,7 +475,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -567,7 +567,7 @@ class TestIcebergCommitter extends TestBase {
     CommittableSummary<IcebergCommittable> committableSummary;
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -644,7 +644,7 @@ class TestIcebergCommitter extends TestBase {
     // We've two steps in checkpoint: 1. snapshotState(ckp); 2. notifyCheckpointComplete(ckp).
     // The Flink job should be able to restore from a checkpoint with only step#1 finished.
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -869,7 +869,7 @@ class TestIcebergCommitter extends TestBase {
   @TestTemplate
   public void testMultipleSinksRecoveryFromValidSnapshot() throws Exception {
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
@@ -49,7 +49,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "data", Types.StringType.get()));
 
     PartitionSpec spec1 = PartitionSpec.builderFor(schema).bucket("id", 10).build();
-    // Same spec als spec1 but different number of buckets
+    // Same spec as spec1 but different number of buckets
     PartitionSpec spec2 = PartitionSpec.builderFor(schema).bucket("id", 23).build();
 
     assertThat(PartitionSpecEvolution.checkCompatibility(spec1, spec2)).isFalse();
@@ -85,7 +85,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
             Types.NestedField.required(2, "data", Types.StringType.get()));
 
-    // Same spec als spec1 but bound to a different schema
+    // Same spec as spec1 but bound to a different schema
     PartitionSpec spec2 = PartitionSpec.builderFor(schema2).bucket("id", 10).build();
 
     // Compatible because the source names match

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -329,7 +329,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<GenericData.Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    assertThat(expectedFiles).as("Should have 3 files manifest entriess").hasSize(3);
+    assertThat(expectedFiles).as("Should have 3 files manifest entries").hasSize(3);
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(1), actualFiles.get(1));
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
@@ -318,7 +318,7 @@ public class TestIcebergSourceWithWatermarkExtractor implements Serializable {
    * continue reading the files, but the watermark alignment will still prevent the paused reader to
    * continue.
    *
-   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both ot
+   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both of
    * the readers continue reading.
    */
   @Test

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -387,7 +387,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -475,7 +475,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -567,7 +567,7 @@ class TestIcebergCommitter extends TestBase {
     CommittableSummary<IcebergCommittable> committableSummary;
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -644,7 +644,7 @@ class TestIcebergCommitter extends TestBase {
     // We've two steps in checkpoint: 1. snapshotState(ckp); 2. notifyCheckpointComplete(ckp).
     // The Flink job should be able to restore from a checkpoint with only step#1 finished.
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -869,7 +869,7 @@ class TestIcebergCommitter extends TestBase {
   @TestTemplate
   public void testMultipleSinksRecoveryFromValidSnapshot() throws Exception {
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
@@ -49,7 +49,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "data", Types.StringType.get()));
 
     PartitionSpec spec1 = PartitionSpec.builderFor(schema).bucket("id", 10).build();
-    // Same spec als spec1 but different number of buckets
+    // Same spec as spec1 but different number of buckets
     PartitionSpec spec2 = PartitionSpec.builderFor(schema).bucket("id", 23).build();
 
     assertThat(PartitionSpecEvolution.checkCompatibility(spec1, spec2)).isFalse();
@@ -85,7 +85,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
             Types.NestedField.required(2, "data", Types.StringType.get()));
 
-    // Same spec als spec1 but bound to a different schema
+    // Same spec as spec1 but bound to a different schema
     PartitionSpec spec2 = PartitionSpec.builderFor(schema2).bucket("id", 10).build();
 
     // Compatible because the source names match

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -329,7 +329,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<GenericData.Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    assertThat(expectedFiles).as("Should have 3 files manifest entriess").hasSize(3);
+    assertThat(expectedFiles).as("Should have 3 files manifest entries").hasSize(3);
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(1), actualFiles.get(1));
   }

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
@@ -318,7 +318,7 @@ public class TestIcebergSourceWithWatermarkExtractor implements Serializable {
    * continue reading the files, but the watermark alignment will still prevent the paused reader to
    * continue.
    *
-   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both ot
+   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both of
    * the readers continue reading.
    */
   @Test

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -387,7 +387,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -475,7 +475,7 @@ class TestIcebergCommitter extends TestBase {
     String jobId1 = "jobId1";
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -567,7 +567,7 @@ class TestIcebergCommitter extends TestBase {
     CommittableSummary<IcebergCommittable> committableSummary;
     OperatorSubtaskState snapshot;
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -644,7 +644,7 @@ class TestIcebergCommitter extends TestBase {
     // We've two steps in checkpoint: 1. snapshotState(ckp); 2. notifyCheckpointComplete(ckp).
     // The Flink job should be able to restore from a checkpoint with only step#1 finished.
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;
@@ -869,7 +869,7 @@ class TestIcebergCommitter extends TestBase {
   @TestTemplate
   public void testMultipleSinksRecoveryFromValidSnapshot() throws Exception {
 
-    // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+    // We cannot test a different checkpoint than 0 because when using the OperatorTestHarness
     // for recovery the lastCompleted checkpoint is always reset to 0.
     // see: https://github.com/apache/iceberg/issues/10942
     long checkpointId = 0;

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestPartitionSpecEvolution.java
@@ -49,7 +49,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "data", Types.StringType.get()));
 
     PartitionSpec spec1 = PartitionSpec.builderFor(schema).bucket("id", 10).build();
-    // Same spec als spec1 but different number of buckets
+    // Same spec as spec1 but different number of buckets
     PartitionSpec spec2 = PartitionSpec.builderFor(schema).bucket("id", 23).build();
 
     assertThat(PartitionSpecEvolution.checkCompatibility(spec1, spec2)).isFalse();
@@ -85,7 +85,7 @@ public class TestPartitionSpecEvolution {
             Types.NestedField.required(1, "id", Types.IntegerType.get()),
             Types.NestedField.required(2, "data", Types.StringType.get()));
 
-    // Same spec als spec1 but bound to a different schema
+    // Same spec as spec1 but bound to a different schema
     PartitionSpec spec2 = PartitionSpec.builderFor(schema2).bucket("id", 10).build();
 
     // Compatible because the source names match

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -329,7 +329,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<GenericData.Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    assertThat(expectedFiles).as("Should have 3 files manifest entriess").hasSize(3);
+    assertThat(expectedFiles).as("Should have 3 files manifest entries").hasSize(3);
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEquals(filesTableSchema, expectedFiles.get(1), actualFiles.get(1));
   }

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceWithWatermarkExtractor.java
@@ -318,7 +318,7 @@ public class TestIcebergSourceWithWatermarkExtractor implements Serializable {
    * continue reading the files, but the watermark alignment will still prevent the paused reader to
    * continue.
    *
-   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both ot
+   * <p>After adding some records with new timestamps the blocked reader is un-paused, and both of
    * the readers continue reading.
    */
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -387,7 +387,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
         sql(
             "CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)",
             catalogName, tableIdent);
-    assertEquals("There should be 2 manifests rewriten", ImmutableList.of(row(2, 1)), output);
+    assertEquals("There should be 2 manifests rewritten", ImmutableList.of(row(2, 1)), output);
     assertEquals(
         "Should have 2 manifests and their partition spec id should be 0 and 1",
         ImmutableList.of(row(0), row(1)),

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -120,7 +120,7 @@ public class TestSnapshotTableProcedure extends ExtensionsTestBase {
   @TestTemplate
   public void testSnapshotWithAlternateLocation() throws IOException {
     assumeThat(catalogName)
-        .as("No Snapshoting with Alternate locations with Hadoop Catalogs")
+        .as("No Snapshotting with Alternate locations with Hadoop Catalogs")
         .doesNotContain("hadoop");
     String location = Files.createTempDirectory(temp, "junit").toFile().toString();
     String snapshotLocation = Files.createTempDirectory(temp, "junit").toFile().toString();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -138,7 +138,7 @@ public class TestBaseReader {
     tasks.forEach(
         t ->
             assertThat(reader.isIteratorClosed(t))
-                .as("All iterators should be closed after read exhausion")
+                .as("All iterators should be closed after read exhaustion")
                 .isTrue());
   }
 
@@ -211,7 +211,7 @@ public class TestBaseReader {
         t -> {
           if (reader.hasIterator(t)) {
             assertThat(reader.isIteratorClosed(t))
-                .as("Iterator should be closed after read exhausion")
+                .as("Iterator should be closed after read exhaustion")
                 .isTrue();
           }
         });
@@ -235,7 +235,7 @@ public class TestBaseReader {
       reader.close();
       for (int i = 0; i < 5; i++) {
         assertThat(reader.isIteratorClosed(tasks.get(i)))
-            .as("Iterator should be closed after read exhausion")
+            .as("Iterator should be closed after read exhaustion")
             .isTrue();
       }
       for (int i = 5; i < 10; i++) {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -387,7 +387,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
         sql(
             "CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)",
             catalogName, tableIdent);
-    assertEquals("There should be 2 manifests rewriten", ImmutableList.of(row(2, 1)), output);
+    assertEquals("There should be 2 manifests rewritten", ImmutableList.of(row(2, 1)), output);
     assertEquals(
         "Should have 2 manifests and their partition spec id should be 0 and 1",
         ImmutableList.of(row(0), row(1)),

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -119,7 +119,7 @@ public class TestSnapshotTableProcedure extends ExtensionsTestBase {
   @TestTemplate
   public void testSnapshotWithAlternateLocation() throws IOException {
     assumeThat(catalogName)
-        .as("No Snapshoting with Alternate locations with Hadoop Catalogs")
+        .as("No Snapshotting with Alternate locations with Hadoop Catalogs")
         .doesNotContain("hadoop");
     String location = Files.createTempDirectory(temp, "junit").toFile().toString();
     String snapshotLocation = Files.createTempDirectory(temp, "junit").toFile().toString();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -138,7 +138,7 @@ public class TestBaseReader {
     tasks.forEach(
         t ->
             assertThat(reader.isIteratorClosed(t))
-                .as("All iterators should be closed after read exhausion")
+                .as("All iterators should be closed after read exhaustion")
                 .isTrue());
   }
 
@@ -211,7 +211,7 @@ public class TestBaseReader {
         t -> {
           if (reader.hasIterator(t)) {
             assertThat(reader.isIteratorClosed(t))
-                .as("Iterator should be closed after read exhausion")
+                .as("Iterator should be closed after read exhaustion")
                 .isTrue();
           }
         });
@@ -235,7 +235,7 @@ public class TestBaseReader {
       reader.close();
       for (int i = 0; i < 5; i++) {
         assertThat(reader.isIteratorClosed(tasks.get(i)))
-            .as("Iterator should be closed after read exhausion")
+            .as("Iterator should be closed after read exhaustion")
             .isTrue();
       }
       for (int i = 5; i < 10; i++) {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -387,7 +387,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
         sql(
             "CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)",
             catalogName, tableIdent);
-    assertEquals("There should be 2 manifests rewriten", ImmutableList.of(row(2, 1)), output);
+    assertEquals("There should be 2 manifests rewritten", ImmutableList.of(row(2, 1)), output);
     assertEquals(
         "Should have 2 manifests and their partition spec id should be 0 and 1",
         ImmutableList.of(row(0), row(1)),

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -119,7 +119,7 @@ public class TestSnapshotTableProcedure extends ExtensionsTestBase {
   @TestTemplate
   public void testSnapshotWithAlternateLocation() throws IOException {
     assumeThat(catalogName)
-        .as("No Snapshoting with Alternate locations with Hadoop Catalogs")
+        .as("No Snapshotting with Alternate locations with Hadoop Catalogs")
         .doesNotContain("hadoop");
     String location = Files.createTempDirectory(temp, "junit").toFile().toString();
     String snapshotLocation = Files.createTempDirectory(temp, "junit").toFile().toString();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -138,7 +138,7 @@ public class TestBaseReader {
     tasks.forEach(
         t ->
             assertThat(reader.isIteratorClosed(t))
-                .as("All iterators should be closed after read exhausion")
+                .as("All iterators should be closed after read exhaustion")
                 .isTrue());
   }
 
@@ -211,7 +211,7 @@ public class TestBaseReader {
         t -> {
           if (reader.hasIterator(t)) {
             assertThat(reader.isIteratorClosed(t))
-                .as("Iterator should be closed after read exhausion")
+                .as("Iterator should be closed after read exhaustion")
                 .isTrue();
           }
         });
@@ -235,7 +235,7 @@ public class TestBaseReader {
       reader.close();
       for (int i = 0; i < 5; i++) {
         assertThat(reader.isIteratorClosed(tasks.get(i)))
-            .as("Iterator should be closed after read exhausion")
+            .as("Iterator should be closed after read exhaustion")
             .isTrue();
       }
       for (int i = 5; i < 10; i++) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow-up to #17898, fixing more unrelated small misspellings found while continuing to review comments/test code:

- `DynFields.java`, `DynMethods.java`: "a UnboundField/UnboundMethod" -> "an Unbound..." (article agreement)
- `RandomGenericData.java`: "a infinite loop" -> "an infinite loop"
- Flink (v1.20/v2.1/v2.2/v2.3): `TestIcebergCommitter.java` "thant 0" -> "than 0"; `TestPartitionSpecEvolution.java` "als spec1" -> "as spec1"; `TestFlinkMetaDataTable.java` "entriess" -> "entries"; `TestIcebergSourceWithWatermarkExtractor.java` "both ot the" -> "both of the"
- Spark (v3.5/v4.0/v4.1): `TestBaseReader.java` "exhausion" -> "exhaustion"; `TestSnapshotTableProcedure.java` "Snapshoting" -> "Snapshotting"; `TestRewriteManifestsProcedure.java` "rewriten" -> "rewritten"

### Why are the changes needed?
Spelling/grammar correctness in test comments and assertion messages. No behavior change.

### Does this PR introduce any user-facing change?
No. All changes are in test source (comments and assertion description strings).

### How was this patch tested?
Comment/string-only changes; no test behavior is affected.