### PR TITLE
BigQuery: Deduplicate retry handling in BigQueryMetastoreClientImpl

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -55,6 +55,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.BaseMetastoreTableOperations;
@@ -148,21 +149,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
 
   @Override
   public Dataset create(Dataset dataset) {
-    Dataset response = null;
-    try {
-      response =
-          BigQueryRetryHelper.runWithRetries(
-              () -> internalCreate(dataset),
-              bigqueryOptions.getRetrySettings(),
-              BIGQUERY_EXCEPTION_HANDLER,
-              bigqueryOptions.getClock(),
-              DEFAULT_RETRY_CONFIG,
-              bigqueryOptions.isOpenTelemetryTracingEnabled(),
-              bigqueryOptions.getOpenTelemetryTracer());
-    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-    }
-    return response;
+    return runWithRetries(() -> internalCreate(dataset));
   }
 
   private Dataset internalCreate(Dataset dataset) {
@@ -245,18 +232,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
 
     dataset.setExternalCatalogDatasetOptions(optionsToUpdate.setParameters(newParameters));
 
-    try {
-      BigQueryRetryHelper.runWithRetries(
-          () -> internalUpdate(dataset),
-          bigqueryOptions.getRetrySettings(),
-          BIGQUERY_EXCEPTION_HANDLER,
-          bigqueryOptions.getClock(),
-          DEFAULT_RETRY_CONFIG,
-          bigqueryOptions.isOpenTelemetryTracingEnabled(),
-          bigqueryOptions.getOpenTelemetryTracer());
-    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-    }
+    runWithRetries(() -> internalUpdate(dataset));
 
     return true;
   }
@@ -286,18 +262,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
 
     dataset.setExternalCatalogDatasetOptions(existingOptions.setParameters(newParameters));
 
-    try {
-      BigQueryRetryHelper.runWithRetries(
-          () -> internalUpdate(dataset),
-          bigqueryOptions.getRetrySettings(),
-          BIGQUERY_EXCEPTION_HANDLER,
-          bigqueryOptions.getClock(),
-          DEFAULT_RETRY_CONFIG,
-          bigqueryOptions.isOpenTelemetryTracingEnabled(),
-          bigqueryOptions.getOpenTelemetryTracer());
-    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-    }
+    runWithRetries(() -> internalUpdate(dataset));
     return true;
   }
 
@@ -328,22 +293,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
     // Ensure it is an Iceberg table supported by the BigQuery metastore catalog.
     validateTable(table);
     // TODO: Ensure table creation is idempotent when handling retries.
-    Table response = null;
-    try {
-      response =
-          BigQueryRetryHelper.runWithRetries(
-              () -> internalCreate(table),
-              bigqueryOptions.getRetrySettings(),
-              BIGQUERY_EXCEPTION_HANDLER,
-              bigqueryOptions.getClock(),
-              DEFAULT_RETRY_CONFIG,
-              bigqueryOptions.isOpenTelemetryTracingEnabled(),
-              bigqueryOptions.getOpenTelemetryTracer());
-    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-    }
-
-    return response;
+    return runWithRetries(() -> internalCreate(table));
   }
 
   private Table internalCreate(Table table) {
@@ -401,22 +351,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
             // Must set the schema as null for using schema auto-detect.
             .setSchema(Data.nullOf(TableSchema.class));
 
-    Table response = null;
-    try {
-      response =
-          BigQueryRetryHelper.runWithRetries(
-              () -> internalUpdate(tableReference, updatedTable, table.getEtag()),
-              bigqueryOptions.getRetrySettings(),
-              BIGQUERY_EXCEPTION_HANDLER,
-              bigqueryOptions.getClock(),
-              DEFAULT_RETRY_CONFIG,
-              bigqueryOptions.isOpenTelemetryTracingEnabled(),
-              bigqueryOptions.getOpenTelemetryTracer());
-    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-    }
-
-    return response;
+    return runWithRetries(() -> internalUpdate(tableReference, updatedTable, table.getEtag()));
   }
 
   private Table internalUpdate(TableReference tableReference, Table table, String etag) {
@@ -634,6 +569,28 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
       case HttpStatusCodes.STATUS_CODE_CONFLICT ->
           throw new AlreadyExistsException("%s", errorMessage);
       default -> throw new HttpResponseException(response);
+    }
+  }
+
+  /**
+   * Executes the given callable through {@link BigQueryRetryHelper} with this client's configured
+   * retry settings, translating a {@link BigQueryRetryHelper.BigQueryRetryHelperException} into the
+   * underlying runtime exception.
+   */
+  private <T> T runWithRetries(Callable<T> callable) {
+    try {
+      return BigQueryRetryHelper.runWithRetries(
+          callable,
+          bigqueryOptions.getRetrySettings(),
+          BIGQUERY_EXCEPTION_HANDLER,
+          bigqueryOptions.getClock(),
+          DEFAULT_RETRY_CONFIG,
+          bigqueryOptions.isOpenTelemetryTracingEnabled(),
+          bigqueryOptions.getOpenTelemetryTracer());
+    } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
+      handleBigQueryRetryException(e);
+      throw new IllegalStateException(
+          "handleBigQueryRetryException must throw for BigQueryRetryHelperException", e);
     }
   }
 

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -588,24 +588,21 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
           bigqueryOptions.isOpenTelemetryTracingEnabled(),
           bigqueryOptions.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
-      handleBigQueryRetryException(e);
-      throw new IllegalStateException(
-          "handleBigQueryRetryException must throw for BigQueryRetryHelperException", e);
+      throw asRuntimeException(e);
     }
   }
 
   /**
-   * Translates BigQueryRetryHelperException to the RuntimeException that caused the error. This
-   * method will always throw an exception.
+   * Unwraps a {@link BigQueryRetryHelper.BigQueryRetryHelperException} to the {@link
+   * RuntimeException} that caused it, wrapping a non-runtime cause in a new {@link RuntimeException}.
    */
-  private static void handleBigQueryRetryException(
+  private static RuntimeException asRuntimeException(
       BigQueryRetryHelper.BigQueryRetryHelperException retryException) {
     Throwable cause = retryException.getCause();
-    String message = retryException.getMessage();
     if (cause instanceof RuntimeException runtimeException) {
-      throw runtimeException;
-    } else {
-      throw new RuntimeException(message, cause);
+      return runtimeException;
     }
+
+    return new RuntimeException(retryException.getMessage(), cause);
   }
 }

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -593,8 +593,8 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
   }
 
   /**
-   * Unwraps a {@link BigQueryRetryHelper.BigQueryRetryHelperException} to the {@link
-   * RuntimeException} that caused it, wrapping a non-runtime cause in a new {@link RuntimeException}.
+   * Returns the {@link RuntimeException} that caused the given retry exception, wrapping a
+   * non-runtime cause in a new {@link RuntimeException}.
    */
   private static RuntimeException asRuntimeException(
       BigQueryRetryHelper.BigQueryRetryHelperException retryException) {


### PR DESCRIPTION
Five methods (create(Dataset), setParameters, removeParameters, create(Table), update) each repeated the same block: a call to BigQueryRetryHelper.runWithRetries(...) passing the same six retry/telemetry settings, followed by an identical catch that forwards the BigQueryRetryHelperException to a shared handler.

Extract that block into a private generic runWithRetries(Callable<T>) helper and call it from all five sites. The shared handler, renamed asRuntimeException, now returns the underlying RuntimeException (the unwrapped runtime cause, or a wrapper around a non-runtime cause) so the catch block can throw asRuntimeException(e) directly, which keeps the compiler satisfied without the null response local each site previously used. Behaviour is unchanged.

**How was this tested?**
This is a behavior-preserving refactor (extracting five identical copies of the retry-wrapper block into one private helper), so it's covered by the existing iceberg-bigquery test suite — no new tests added.

Ran locally against the branch:

- ./gradlew :iceberg-bigquery:test — passes
- ./gradlew :iceberg-bigquery:compileJava — clean (no new error-prone warnings)
- ./gradlew :iceberg-bigquery:spotlessCheck — passes

The only intentional difference in behavior: the path after handleBigQueryRetryException(...) (which always throws) was previously an unreachable return null and is now an unreachable throw new IllegalStateException(...).