### PR TITLE
Core, API, Parquet: Collapse redundant nested if statements

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -73,10 +73,8 @@ public class Files {
 
     @Override
     public PositionOutputStream createOrOverwrite() {
-      if (file.exists()) {
-        if (!file.delete()) {
-          throw new RuntimeIOException("Failed to delete: %s", file);
-        }
+      if (file.exists() && !file.delete()) {
+        throw new RuntimeIOException("Failed to delete: %s", file);
       }
       return create();
     }

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -224,10 +224,9 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
 
       @Override
       public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
-        if (fileContent(ref)) {
-          if (literalSet.stream().noneMatch(lit -> mayContainFileContent((Integer) lit))) {
-            return ROWS_CANNOT_MATCH;
-          }
+        if (fileContent(ref)
+            && literalSet.stream().noneMatch(lit -> mayContainFileContent((Integer) lit))) {
+          return ROWS_CANNOT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -95,10 +95,9 @@ public class CachingCatalog implements Catalog {
     @Override
     public void onRemoval(TableIdentifier tableIdentifier, Table table, RemovalCause cause) {
       LOG.debug("Evicted {} from the table cache ({})", tableIdentifier, cause);
-      if (RemovalCause.EXPIRED.equals(cause)) {
-        if (!MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
-          tableCache.invalidateAll(metadataTableIdentifiers(tableIdentifier));
-        }
+      if (RemovalCause.EXPIRED.equals(cause)
+          && !MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
+        tableCache.invalidateAll(metadataTableIdentifiers(tableIdentifier));
       }
     }
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
@@ -447,11 +447,9 @@ public abstract class VariantShreddingAnalyzer<T, S> {
       typeCounts[type.ordinal()]++;
 
       // Track max precision and scale for decimal types
-      if (DECIMAL_TYPES.contains(type)) {
-        if (value.asPrimitive().get() instanceof BigDecimal bd) {
-          maxDecimalIntegerDigits = Math.max(maxDecimalIntegerDigits, bd.precision() - bd.scale());
-          maxDecimalScale = Math.max(maxDecimalScale, bd.scale());
-        }
+      if (DECIMAL_TYPES.contains(type) && value.asPrimitive().get() instanceof BigDecimal bd) {
+        maxDecimalIntegerDigits = Math.max(maxDecimalIntegerDigits, bd.precision() - bd.scale());
+        maxDecimalScale = Math.max(maxDecimalScale, bd.scale());
       }
     }
 


### PR DESCRIPTION
Several places nest an `if` whose entire body is another `if` (no else on either), which is equivalent to a single `if` combined with `&&`:

  - BaseEntriesTable.in(): matches the sibling notIn() which already uses &&
  - CachingCatalog metadata-table invalidation on cache eviction
  - Files.LocalOutputFile.createOrOverwrite() delete-on-overwrite check
  - VariantShreddingAnalyzer.observe() decimal precision/scale tracking

No behavior change.