### PR TITLE
API, Core, Spark: Add CONTAINS and NOT_CONTAINS expressions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -88,6 +88,10 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return String.valueOf(value).startsWith((String) literal.value());
       case NOT_STARTS_WITH:
         return !String.valueOf(value).startsWith((String) literal.value());
+      case CONTAINS:
+        return String.valueOf(value).contains((String) literal.value());
+      case NOT_CONTAINS:
+        return !String.valueOf(value).contains((String) literal.value());
       default:
         throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -157,5 +157,16 @@ public class Evaluator implements Serializable {
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
     }
+
+    @Override
+    public <T> Boolean contains(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).contains((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notContains(Bound<T> valueExpr, Literal<T> lit) {
+      return !contains(valueExpr, lit);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,8 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    CONTAINS,
+    NOT_CONTAINS,
     COUNT,
     COUNT_NULL,
     COUNT_STAR,
@@ -91,6 +93,10 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case CONTAINS:
+          return Operation.NOT_CONTAINS;
+        case NOT_CONTAINS:
+          return Operation.CONTAINS;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -403,6 +403,8 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
+        case CONTAINS:
+        case NOT_CONTAINS:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
@@ -503,6 +505,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case CONTAINS:
+          return term + " CONTAINS " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + value((BoundLiteralPredicate<?>) pred);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -555,6 +561,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case CONTAINS:
+          return term + " CONTAINS " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -126,6 +126,16 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R contains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "contains expression is not supported by the visitor");
+    }
+
+    public <T> R notContains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notContains expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -166,6 +176,10 @@ public class ExpressionVisitors {
             return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains((BoundReference<T>) pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -266,6 +280,14 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R contains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notContains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -287,6 +309,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -465,6 +491,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -553,6 +583,14 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R contains(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notContains(BoundTerm<T> term, Literal<T> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -198,6 +198,14 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, ref(name), value);
   }
 
+  public static UnboundPredicate<String> contains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notContains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
+  }
+
   public static UnboundPredicate<String> notStartsWith(UnboundTerm<String> expr, String value) {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveEvalVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveEvalVisitor.java
@@ -345,6 +345,16 @@ abstract class InclusiveEvalVisitor extends ExpressionVisitors.BoundVisitor<Bool
   }
 
   @Override
+  public <T> Boolean contains(Bound<T> term, Literal<T> lit) {
+    return ROWS_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T> Boolean notContains(Bound<T> term, Literal<T> lit) {
+    return ROWS_MIGHT_MATCH;
+  }
+
+  @Override
   public <T> Boolean startsWith(Bound<T> term, Literal<T> lit) {
     if (term instanceof BoundTransform && !((BoundTransform<?, ?>) term).transform().isIdentity()) {
       // truncate must be rewritten in binding. the result is either always or never compatible

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -324,6 +324,16 @@ public class ManifestEvaluator {
     }
 
     @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
       int pos = Accessors.toPosition(ref.accessor());
       PartitionFieldSummary fieldStats = stats.get(pos);

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -225,6 +225,20 @@ public class ResidualEvaluator implements Serializable {
     }
 
     @Override
+    public <T> Expression contains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(BoundPredicate<T> pred) {
       // Get the strict projection and inclusive projection of this predicate in partition data,

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
@@ -383,6 +383,16 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
   }
 
   @Override
+  public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+    return ROWS_MIGHT_NOT_MATCH;
+  }
+
+  @Override
+  public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+    return ROWS_MIGHT_NOT_MATCH;
+  }
+
+  @Override
   public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
     int id = ref.fieldId();
     if (isNestedColumn(id)) {

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -168,10 +168,14 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
   }
 
   private Expression bindLiteralOperation(BoundTerm<T> boundTerm) {
-    if (op() == Operation.STARTS_WITH || op() == Operation.NOT_STARTS_WITH) {
+    if (op() == Operation.STARTS_WITH
+        || op() == Operation.NOT_STARTS_WITH
+        || op() == Operation.CONTAINS
+        || op() == Operation.NOT_CONTAINS) {
       ValidationException.check(
           boundTerm.type().equals(Types.StringType.get()),
-          "Term for STARTS_WITH or NOT_STARTS_WITH must produce a string: %s: %s",
+          "Term for %s must produce a string: %s: %s",
+          op(),
           boundTerm,
           boundTerm.type());
     }
@@ -284,6 +288,10 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         return term() + " startsWith \"" + literal() + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal() + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal() + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal() + "\"";
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -33,6 +34,7 @@ import static org.apache.iceberg.expressions.Expressions.not;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.notStartsWith;
 import static org.apache.iceberg.expressions.Expressions.or;
@@ -345,6 +347,60 @@ public class TestEvaluator {
         .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("Abcde")))
         .as("Abcde notStartsWith abc should be true")
+        .isTrue();
+  }
+
+  @Test
+  public void testContains() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, contains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("xabc")))
+        .as("xabc contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("Abc")))
+        .as("Abc contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("a contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcd")))
+        .as("abcd contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("xabcd")))
+        .as("xabcd contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null contains abc should be false")
+        .isFalse();
+  }
+
+  @Test
+  public void testNotContains() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, notContains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc notContains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("xabc")))
+        .as("xabc notContains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("Abc")))
+        .as("Abc notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("a notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("abcde notContains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("Abcde")))
+        .as("Abcde notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null notContains abc should be true")
         .isTrue();
   }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -22,12 +22,14 @@ import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.extract;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.notStartsWith;
 import static org.apache.iceberg.expressions.Expressions.or;
@@ -180,6 +182,48 @@ public class TestExpressionBinding {
     assertThat(pred.term().ref().fieldId())
         .as("Should bind term to correct field id")
         .isEqualTo(21);
+  }
+
+  @Test
+  public void testContains() {
+    StructType struct = StructType.of(required(0, "s", Types.StringType.get()));
+    Expression expr = contains("s", "abc");
+    Expression boundExpr = Binder.bind(struct, expr);
+    TestHelpers.assertAllReferencesBound("Contains", boundExpr);
+    // make sure the expression is a Contains
+    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(boundExpr, BoundPredicate.class);
+    assertThat(pred.op()).as("Should be right operation").isEqualTo(Expression.Operation.CONTAINS);
+    assertThat(pred.term().ref().fieldId()).as("Should bind s correctly").isZero();
+  }
+
+  @Test
+  public void testNotContains() {
+    StructType struct = StructType.of(required(21, "s", Types.StringType.get()));
+    Expression expr = notContains("s", "abc");
+    Expression boundExpr = Binder.bind(struct, expr);
+    TestHelpers.assertAllReferencesBound("NotContains", boundExpr);
+    // Make sure the expression is a NotContains
+    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(boundExpr, BoundPredicate.class);
+    assertThat(pred.op())
+        .as("Should be right operation")
+        .isEqualTo(Expression.Operation.NOT_CONTAINS);
+    assertThat(pred.term().ref().fieldId())
+        .as("Should bind term to correct field id")
+        .isEqualTo(21);
+  }
+
+  @Test
+  public void testContainsNonStringColumn() {
+    assertThatThrownBy(() -> Binder.bind(STRUCT, contains("x", "abc")))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Term for CONTAINS must produce a string");
+  }
+
+  @Test
+  public void testNotContainsNonStringColumn() {
+    assertThatThrownBy(() -> Binder.bind(STRUCT, notContains("x", "abc")))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Term for NOT_CONTAINS must produce a string");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.day;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
@@ -33,6 +34,7 @@ import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.month;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
@@ -178,7 +180,9 @@ public class TestExpressionHelpers {
           {or(equal("a", 5), isNull("a")), not(and(notEqual("a", 5), notNull("a")))},
           {or(equal("a", 5), notNull("a")), or(equal("a", 5), not(isNull("a")))},
           {startsWith("s", "hello"), not(notStartsWith("s", "hello"))},
-          {notStartsWith("s", "world"), not(startsWith("s", "world"))}
+          {notStartsWith("s", "world"), not(startsWith("s", "world"))},
+          {contains("s", "hello"), not(notContains("s", "hello"))},
+          {notContains("s", "world"), not(contains("s", "world"))}
         };
 
     for (Expression[] pair : expressions) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
@@ -53,6 +53,8 @@ public class TestExpressionSerialization {
           Expressions.notNaN("maybeNaN2"),
           Expressions.startsWith("col", "abc"),
           Expressions.notStartsWith("col", "abc"),
+          Expressions.contains("col", "abc"),
+          Expressions.notContains("col", "abc"),
           Expressions.not(Expressions.greaterThan("a", 10)),
           Expressions.and(Expressions.greaterThanOrEqual("a", 0), Expressions.lessThan("a", 3)),
           Expressions.or(Expressions.lessThan("a", 0), Expressions.greaterThan("a", 10)),
@@ -61,7 +63,9 @@ public class TestExpressionSerialization {
           Expressions.notIn("s", "abc", "xyz").bind(schema.asStruct()),
           Expressions.isNull("a").bind(schema.asStruct()),
           Expressions.startsWith("s", "abc").bind(schema.asStruct()),
-          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct())
+          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct()),
+          Expressions.contains("s", "abc").bind(schema.asStruct()),
+          Expressions.notContains("s", "xyz").bind(schema.asStruct())
         };
 
     for (Expression expression : expressions) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -374,6 +374,45 @@ public class TestExpressionUtil {
   }
 
   @Test
+  public void testSanitizeContains() {
+    assertEquals(
+        Expressions.contains("test", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(Expressions.contains("test", "aaa")));
+
+    assertEquals(
+        Expressions.contains("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.contains("data", "aaa"), true));
+
+    assertThat(ExpressionUtil.toSanitizedString(Expressions.contains("test", "aaa")))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test CONTAINS (hash-34d05fb7)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.contains("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data CONTAINS (hash-34d05fb7)");
+  }
+
+  @Test
+  public void testSanitizeNotContains() {
+    assertEquals(
+        Expressions.notContains("test", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(Expressions.notContains("test", "aaa")));
+
+    assertEquals(
+        Expressions.notContains("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.notContains("data", "aaa"), true));
+
+    assertThat(ExpressionUtil.toSanitizedString(Expressions.notContains("test", "aaa")))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test NOT CONTAINS (hash-34d05fb7)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.notContains("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data NOT CONTAINS (hash-34d05fb7)");
+  }
+
+  @Test
   public void testSanitizeTransformedTerm() {
     assertEquals(
         Expressions.equal(Expressions.truncate("test", 2), "(2-digit-int)"),
@@ -1001,6 +1040,8 @@ public class TestExpressionUtil {
           Expressions.notIn("id", 5, 6),
           Expressions.startsWith("data", "aaa"),
           Expressions.notStartsWith("data", "aaa"),
+          Expressions.contains("data", "aaa"),
+          Expressions.notContains("data", "aaa"),
           Expressions.alwaysTrue(),
           Expressions.alwaysFalse(),
           Expressions.and(Expressions.lessThan("id", 5), Expressions.notNull("data")),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveManifestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveManifestEvaluator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -28,6 +29,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -661,6 +663,49 @@ public class TestInclusiveManifestEvaluator {
         ManifestEvaluator.forRowFilter(notStartsWith("no_nulls_same_value_a", "a"), SPEC, false)
             .eval(FILE);
     assertThat(shouldRead).as("Should not read: all values start with the prefix").isFalse();
+  }
+
+  @Test
+  public void testStringContains() {
+    boolean shouldRead =
+        ManifestEvaluator.forRowFilter(contains("some_nulls", "a"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(contains("some_nulls", "dddd"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = ManifestEvaluator.forRowFilter(contains("no_nulls", "a"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(contains("some_nulls", "zzzz"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(contains("some_nulls", "1"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+  }
+
+  @Test
+  public void testStringNotContains() {
+    boolean shouldRead =
+        ManifestEvaluator.forRowFilter(notContains("some_nulls", "a"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(notContains("some_nulls", "zzzz"), SPEC, false).eval(FILE);
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(notContains("all_nulls_missing_nan", "A"), SPEC, false)
+            .eval(FILE);
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead =
+        ManifestEvaluator.forRowFilter(notContains("no_nulls_same_value_a", "a"), SPEC, false)
+            .eval(FILE);
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -28,6 +29,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -861,6 +863,59 @@ public class TestInclusiveMetricsEvaluator<F> {
 
     shouldRead = shouldRead(SCHEMA, notStartsWith("required", "abcd"), true, file5());
     assertThat(shouldRead).as("Should not read: lower shorter than prefix, cannot match").isTrue();
+  }
+
+  @Test
+  public void testStringContains() {
+    boolean shouldRead = shouldRead(SCHEMA, contains("required", "a"), true, file());
+    assertThat(shouldRead).as("Should read: no stats").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("required", "a"), true, file2());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("required", "aB"), true, file2());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("required", "dWX"), true, file2());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("required", "5"), true, file3());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("required", "3str3x"), true, file3());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, contains("all_nulls", ""), true, file());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+
+    String aboveMax = UnicodeUtil.truncateStringMax(Literal.of("イロハニホヘト"), 4).value().toString();
+    shouldRead = shouldRead(SCHEMA, contains("required", aboveMax), true, file4());
+    assertThat(shouldRead).as("Should read: contains never skips").isTrue();
+  }
+
+  @Test
+  public void testStringNotContains() {
+    boolean shouldRead = shouldRead(SCHEMA, notContains("required", "a"), true, file());
+    assertThat(shouldRead).as("Should read: no stats").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, notContains("required", "a"), true, file2());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, notContains("required", "aB"), true, file2());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, notContains("required", "5"), true, file3());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    String aboveMax = UnicodeUtil.truncateStringMax(Literal.of("イロハニホヘト"), 4).value().toString();
+    shouldRead = shouldRead(SCHEMA, notContains("required", aboveMax), true, file4());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, notContains("required", "abc"), true, file5());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
+
+    shouldRead = shouldRead(SCHEMA, notContains("required", "abcd"), true, file5());
+    assertThat(shouldRead).as("Should read: notContains never skips").isTrue();
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -28,6 +29,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -823,6 +825,45 @@ public class TestStrictMetricsEvaluator {
   @Test
   void testStartsWithNoStats() {
     boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
+  }
+
+  @Test
+  void testContains() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, contains("required", "ab")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: contains cannot be evaluated strictly").isFalse();
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, contains("required", "a")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: contains cannot be evaluated strictly").isFalse();
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, contains("required", "zzz")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: contains cannot be evaluated strictly").isFalse();
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, contains("required", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
+  }
+
+  @Test
+  void testNotContains() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notContains("required", "aaa")).eval(STRING_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: notContains cannot be evaluated strictly")
+        .isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notContains("required", "zzz")).eval(STRING_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: notContains cannot be evaluated strictly")
+        .isFalse();
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notContains("all_nulls", "a")).eval(FILE);
+    assertThat(shouldRead)
+        .as("Should not match: notContains cannot be evaluated strictly")
+        .isFalse();
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, notContains("required", "a")).eval(FILE);
     assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
   }
 

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -427,6 +427,16 @@ public class AllManifestsTable extends BaseMetadataTable {
       }
 
       @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
       public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
         return ROWS_MIGHT_MATCH;
       }

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -247,6 +247,16 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       }
 
       @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
       public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
         return ROWS_MIGHT_MATCH;
       }

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -347,6 +347,8 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+      case CONTAINS:
+      case NOT_CONTAINS:
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -84,6 +84,8 @@ public class TestExpressionParser {
           Expressions.notNaN("f"),
           Expressions.startsWith("s", "crackle"),
           Expressions.notStartsWith("s", "tackle"),
+          Expressions.contains("s", "crackle"),
+          Expressions.notContains("s", "tackle"),
           Expressions.equal(Expressions.day("date"), "2022-08-14"),
           Expressions.equal(Expressions.bucket("id", 100), 0),
           Expressions.and(

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -254,6 +254,16 @@ class ExpressionToSearchArgument
   }
 
   @Override
+  public <T> Action contains(Bound<T> expr, Literal<T> lit) {
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action notContains(Bound<T> expr, Literal<T> lit) {
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
   public <T> Action startsWith(Bound<T> expr, Literal<T> lit) {
     // Cannot push down STARTS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which
     // signifies

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -249,6 +249,16 @@ public class ParquetBloomRowGroupFilter {
     }
 
     @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on startsWith
       return ROWS_MIGHT_MATCH;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -371,6 +371,16 @@ public class ParquetDictionaryRowGroupFilter {
     }
 
     @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -466,6 +466,16 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -674,6 +674,10 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case CONTAINS:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "%'";
+        case NOT_CONTAINS:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "%'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -88,6 +88,7 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String CONTAINS_OP = "CONTAINS";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +108,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(CONTAINS_OP, Operation.CONTAINS)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -303,6 +305,10 @@ public class SparkV2Filters {
         case STARTS_WITH:
           String colName = SparkUtil.toColumnName(leftChild(predicate));
           return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+        case CONTAINS:
+          String containsColName = SparkUtil.toColumnName(leftChild(predicate));
+          return Expressions.contains(
+              containsColName, convertLiteral(rightChild(predicate)).toString());
       }
     }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -226,6 +226,22 @@ public class TestSparkV2Filters {
               .as("StartsWith must match")
               .isEqualTo(expectedStartsWith.toString());
 
+          Predicate contains = new Predicate("CONTAINS", attrAndStr);
+          Expression expectedContains = Expressions.contains(unquoted, "iceberg");
+          Expression actualContains = SparkV2Filters.convert(contains);
+          assertThat(actualContains)
+              .asString()
+              .as("Contains must match")
+              .isEqualTo(expectedContains.toString());
+
+          Predicate notContains = new Not(contains);
+          Expression expectedNotContains = Expressions.not(expectedContains);
+          Expression actualNotContains = SparkV2Filters.convert(notContains);
+          assertThat(actualNotContains)
+              .asString()
+              .as("NotContains must match")
+              .isEqualTo(expectedNotContains.toString());
+
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -678,6 +678,10 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case CONTAINS:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "%'";
+        case NOT_CONTAINS:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "%'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -88,6 +88,7 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String CONTAINS_OP = "CONTAINS";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +108,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(CONTAINS_OP, Operation.CONTAINS)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -303,6 +305,10 @@ public class SparkV2Filters {
         case STARTS_WITH:
           String colName = SparkUtil.toColumnName(leftChild(predicate));
           return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+        case CONTAINS:
+          String containsColName = SparkUtil.toColumnName(leftChild(predicate));
+          return Expressions.contains(
+              containsColName, convertLiteral(rightChild(predicate)).toString());
       }
     }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -226,6 +226,22 @@ public class TestSparkV2Filters {
               .as("StartsWith must match")
               .isEqualTo(expectedStartsWith.toString());
 
+          Predicate contains = new Predicate("CONTAINS", attrAndStr);
+          Expression expectedContains = Expressions.contains(unquoted, "iceberg");
+          Expression actualContains = SparkV2Filters.convert(contains);
+          assertThat(actualContains)
+              .asString()
+              .as("Contains must match")
+              .isEqualTo(expectedContains.toString());
+
+          Predicate notContains = new Not(contains);
+          Expression expectedNotContains = Expressions.not(expectedContains);
+          Expression actualNotContains = SparkV2Filters.convert(notContains);
+          assertThat(actualNotContains)
+              .asString()
+              .as("NotContains must match")
+              .isEqualTo(expectedNotContains.toString());
+
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -708,6 +708,10 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case CONTAINS:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "%'";
+        case NOT_CONTAINS:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "%'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -88,6 +88,7 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String CONTAINS_OP = "CONTAINS";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +108,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(CONTAINS_OP, Operation.CONTAINS)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -303,6 +305,10 @@ public class SparkV2Filters {
         case STARTS_WITH:
           String colName = SparkUtil.toColumnName(leftChild(predicate));
           return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+        case CONTAINS:
+          String containsColName = SparkUtil.toColumnName(leftChild(predicate));
+          return Expressions.contains(
+              containsColName, convertLiteral(rightChild(predicate)).toString());
       }
     }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -226,6 +226,22 @@ public class TestSparkV2Filters {
               .as("StartsWith must match")
               .isEqualTo(expectedStartsWith.toString());
 
+          Predicate contains = new Predicate("CONTAINS", attrAndStr);
+          Expression expectedContains = Expressions.contains(unquoted, "iceberg");
+          Expression actualContains = SparkV2Filters.convert(contains);
+          assertThat(actualContains)
+              .asString()
+              .as("Contains must match")
+              .isEqualTo(expectedContains.toString());
+
+          Predicate notContains = new Not(contains);
+          Expression expectedNotContains = Expressions.not(expectedContains);
+          Expression actualNotContains = SparkV2Filters.convert(notContains);
+          assertThat(actualNotContains)
+              .asString()
+              .as("NotContains must match")
+              .isEqualTo(expectedNotContains.toString());
+
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);


### PR DESCRIPTION
Add `CONTAINS` / `NOT_CONTAINS` (substring match on string terms) to the expression API, alongside the existing `STARTS_WITH` / `NOT_STARTS_WITH`.

Spark emits a DSv2 `CONTAINS` predicate for the `contains()` function, but Iceberg has no matching operation, so the predicate is dropped at `SparkV2Filters` and any operation that could otherwise be answered from metadata falls back to row-level scans. The motivating case: `DELETE FROM t WHERE contains(part_col, 'x')` on an identity-partitioned column is decidable exactly from partition values, but today plans as a full copy-on-write scan-and-rewrite. With this change it plans as a metadata-only delete.