### PR TITLE
kafka-connect: Prevent hanging coordinator in consumer group

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -53,6 +53,7 @@ abstract class Channel {
   private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
   private final String producerId;
+  private final Duration commitTimeout;
 
   Channel(
       String name,
@@ -70,6 +71,7 @@ abstract class Channel {
     this.admin = clientFactory.createAdmin();
 
     this.producerId = UUID.randomUUID().toString();
+    this.commitTimeout = Duration.ofMillis(config.commitTimeoutMs());
   }
 
   protected void send(Event event) {
@@ -161,9 +163,9 @@ abstract class Channel {
   void stop() {
     LOG.info("Channel stopping");
     // Close the consumer first to prevent stale consumer in the consumer group if producer close
-    // hangs
-    consumer.close();
-    producer.close();
-    admin.close();
+    // hangs + add timeouts
+    consumer.close(commitTimeout);
+    producer.close(commitTimeout);
+    admin.close(commitTimeout);
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -160,8 +160,10 @@ abstract class Channel {
 
   void stop() {
     LOG.info("Channel stopping");
-    producer.close();
+    // Close the consumer first to prevent stale consumer in the consumer group if producer close
+    // hangs
     consumer.close();
+    producer.close();
     admin.close();
   }
 }


### PR DESCRIPTION
**Context**
If producer is unable to close it might lead to a situation where consumer stays hanging  in the consumer group which increases a delay before new coordinator can join or it might  prevent stopping the task which leads into a zombie coordinator situation. 

https://github.com/apache/iceberg/issues/15452

**Solution**
- No major change in the logic 
- Close the consumer first and then take care of the rest (admin, producer). 
- Add sane timeouts to prevent stop hanging forever (use commit timeout)