### PR TITLE
AWS/GCP: Resolve relative storage credential refresh endpoints

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -461,7 +462,12 @@ public class S3FileIO
       return;
     }
 
-    try (VendedCredentialsProvider provider = VendedCredentialsProvider.create(properties)) {
+    Map<String, String> refreshProperties = Maps.newHashMap(properties);
+    refreshProperties.putIfAbsent(
+        VendedCredentialsProvider.URI,
+        properties.get(AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT));
+
+    try (VendedCredentialsProvider provider = VendedCredentialsProvider.create(refreshProperties)) {
       List<StorageCredential> refreshed =
           provider.fetchCredentials().credentials().stream()
               .filter(c -> c.prefix().startsWith(ROOT_PREFIX))

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
@@ -67,7 +67,8 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
             .cachedValueName(VendedCredentialsProvider.class.getName())
             .build();
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
-    this.credentialsEndpoint = properties.get(URI);
+    this.credentialsEndpoint =
+        RESTUtil.resolveEndpoint(properties.get(CatalogProperties.URI), properties.get(URI));
     this.planId = properties.getOrDefault(RESTCatalogProperties.REST_SCAN_PLAN_ID, null);
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -145,8 +146,8 @@ public class TestS3FileIOCredentialRefresh {
         ImmutableMap.of(
             AwsProperties.CLIENT_FACTORY,
             StaticClientFactory.class.getName(),
-            VendedCredentialsProvider.URI,
-            CREDENTIALS_URI,
+            AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT,
+            "/credentials",
             CatalogProperties.URI,
             CATALOG_URI,
             "init-creation-stacktrace",

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestVendedCredentialsProvider.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestVendedCredentialsProvider.java
@@ -121,6 +121,29 @@ public class TestVendedCredentialsProvider {
   }
 
   @Test
+  public void resolvesRelativeCredentialsUri() {
+    HttpRequest mockRequest = request("/v1/credentials").withMethod(HttpMethod.GET.name());
+    HttpResponse mockResponse =
+        response(
+                LoadCredentialsResponseParser.toJson(
+                    ImmutableLoadCredentialsResponse.builder().build()))
+            .withStatusCode(200);
+    mockServer.when(mockRequest).respond(mockResponse);
+
+    try (VendedCredentialsProvider provider =
+        VendedCredentialsProvider.create(
+            ImmutableMap.of(
+                VendedCredentialsProvider.URI,
+                "/credentials",
+                CatalogProperties.URI,
+                CATALOG_URI))) {
+      assertThat(provider.fetchCredentials().credentials()).isEmpty();
+    }
+
+    mockServer.verify(mockRequest, VerificationTimes.once());
+  }
+
+  @Test
   public void accessKeyIdAndSecretAccessKeyWithoutToken() {
     HttpRequest mockRequest = request("/v1/credentials").withMethod(HttpMethod.GET.name());
     LoadCredentialsResponse response =

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
@@ -59,7 +59,9 @@ public class OAuth2RefreshCredentialsHandler
     Preconditions.checkArgument(
         null != properties.get(CatalogProperties.URI), "Invalid catalog endpoint: null");
     this.credentialsEndpoint =
-        properties.get(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT);
+        RESTUtil.resolveEndpoint(
+            properties.get(CatalogProperties.URI),
+            properties.get(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT));
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
     this.properties = properties;
     this.planId = properties.getOrDefault(RESTCatalogProperties.REST_SCAN_PLAN_ID, null);

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestOAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestOAuth2RefreshCredentialsHandler.java
@@ -121,6 +121,30 @@ public class TestOAuth2RefreshCredentialsHandler {
   }
 
   @Test
+  public void resolvesRelativeCredentialsUri() {
+    HttpRequest mockRequest =
+        HttpRequest.request("/v1/credentials").withMethod(HttpMethod.GET.name());
+    HttpResponse mockResponse =
+        HttpResponse.response(
+                LoadCredentialsResponseParser.toJson(
+                    ImmutableLoadCredentialsResponse.builder().build()))
+            .withStatusCode(200);
+    mockServer.when(mockRequest).respond(mockResponse);
+
+    try (OAuth2RefreshCredentialsHandler handler =
+        OAuth2RefreshCredentialsHandler.create(
+            ImmutableMap.of(
+                GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT,
+                "/credentials",
+                CatalogProperties.URI,
+                CATALOG_URI))) {
+      assertThat(handler.fetchCredentials().credentials()).isEmpty();
+    }
+
+    mockServer.verify(mockRequest, VerificationTimes.once());
+  }
+
+  @Test
   public void noGcsCredentialInResponse() {
     HttpRequest mockRequest =
         HttpRequest.request("/v1/credentials").withMethod(HttpMethod.GET.name());


### PR DESCRIPTION
Fixes #17810.

Resolve relative storage credential refresh endpoints in the credential handlers. Both the initial client setup and scheduled refresh paths now use the same endpoint resolution.

Add regression coverage for relative endpoints in the AWS and GCP handlers.

### Testing

- `./gradlew spotlessCheck :iceberg-aws:test --tests org.apache.iceberg.aws.s3.TestVendedCredentialsProvider --tests org.apache.iceberg.aws.s3.TestS3FileIOCredentialRefresh :iceberg-gcp:test --tests org.apache.iceberg.gcp.gcs.TestOAuth2RefreshCredentialsHandler`

---
**AI Disclosure**
- Model: GPT-5.6
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Investigated review feedback on #17810 and updated the AWS and GCP credential refresh handlers to resolve relative endpoints consistently.