### PR TITLE
Docs: Note that REST catalog credentials should be redacted by engines

### DIFF
--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -94,6 +94,13 @@ Required and optional properties to include while using `oauth2` authentication
 | `audience`              | null              | Optional param to specify token `audience`                                                                                                                            |
 | `resource`              | null              | Optional param to specify `resource`                                                                                                                                  |
 
+!!! warning
+    `credential` and `token` are secrets. Engines that surface their configuration can expose them: Spark
+    lists catalog options in the Environment tab of its UI and persists them to event logs. Spark's default
+    `spark.redaction.regex` matches `token` and `password`, but not `credential`, so on versions where
+    `credential` is not part of the default pattern, set it explicitly:
+    `spark.redaction.regex=(?i)secret|password|token|access[.]?key|credential`
+
 #### SigV4 auth properties
 Required and optional properties to include while using `sigv4` authentication
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -96,7 +96,7 @@ Required and optional properties to include while using `oauth2` authentication
 
 !!! warning
     `credential` and `token` are secrets. Engines may expose catalog configuration in their UIs and logs —
-    Spark, for example, lists it in the Environment tab and writes it to event logs. Confirm that your engine
+    Apache Spark, for example, lists it in the Environment tab and writes it to event logs. Confirm that your engine
     redacts these values; for Spark, check that they are covered by `spark.redaction.regex` and add them to
     the pattern if they are not.
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -95,11 +95,10 @@ Required and optional properties to include while using `oauth2` authentication
 | `resource`              | null              | Optional param to specify `resource`                                                                                                                                  |
 
 !!! warning
-    `credential` and `token` are secrets. Engines that surface their configuration can expose them: Spark
-    lists catalog options in the Environment tab of its UI and persists them to event logs. Spark's default
-    `spark.redaction.regex` matches `token` and `password`, but not `credential`, so on versions where
-    `credential` is not part of the default pattern, set it explicitly:
-    `spark.redaction.regex=(?i)secret|password|token|access[.]?key|credential`
+    `credential` and `token` are secrets. Engines may expose catalog configuration in their UIs and logs —
+    Spark, for example, lists it in the Environment tab and writes it to event logs. Confirm that your engine
+    redacts these values; for Spark, check that they are covered by `spark.redaction.regex` and add them to
+    the pattern if they are not.
 
 #### SigV4 auth properties
 Required and optional properties to include while using `sigv4` authentication


### PR DESCRIPTION
`credential` and `token` are secrets, but the REST catalog property reference
doesn't say so. Iceberg already redacts both in its own output — `AuthConfig`
marks them `@Value.Redacted` — so this extends the same stance to the engine
boundary, where engines such as Spark surface catalog configuration in their
UIs and logs.
