### PR TITLE
Common: Add missing Javadoc for Dyn* utility classes

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynClasses.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynClasses.java
@@ -22,14 +22,21 @@ import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
+/** Utility for dynamically loading a class by trying candidate implementations by name. */
 public class DynClasses {
 
   private DynClasses() {}
 
+  /**
+   * Constructs a new builder for loading a class dynamically.
+   *
+   * @return a Builder for finding a class
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** Builder for resolving a class from a set of candidate names. */
   public static class Builder {
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();
     private Class<?> foundClass = null;

--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -33,6 +33,7 @@ public class DynConstructors {
 
   private DynConstructors() {}
 
+  /** A wrapper around a {@link Constructor} that can be invoked to create new instances. */
   public static class Ctor<C> extends DynMethods.UnboundMethod {
     private final Constructor<C> ctor;
     private final Class<? extends C> constructed;
@@ -43,6 +44,13 @@ public class DynConstructors {
       this.constructed = constructed;
     }
 
+    /**
+     * Invokes the constructor with the given arguments.
+     *
+     * @param args the arguments to pass to the constructor
+     * @return a new instance
+     * @throws Exception if the constructor throws a checked exception
+     */
     public C newInstanceChecked(Object... args) throws Exception {
       try {
         if (args.length > ctor.getParameterCount()) {
@@ -59,6 +67,13 @@ public class DynConstructors {
       }
     }
 
+    /**
+     * Invokes the constructor with the given arguments, wrapping checked exceptions in a
+     * RuntimeException.
+     *
+     * @param args the arguments to pass to the constructor
+     * @return a new instance
+     */
     public C newInstance(Object... args) {
       try {
         return newInstanceChecked(args);
@@ -100,24 +115,42 @@ public class DynConstructors {
     }
   }
 
+  /**
+   * Constructs a new builder for finding a constructor dynamically.
+   *
+   * @return a Builder for finding a constructor
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /**
+   * Constructs a new builder for finding a constructor dynamically.
+   *
+   * @param baseClass the base class used in error messages when no constructor is found
+   * @return a Builder for finding a constructor
+   */
   public static Builder builder(Class<?> baseClass) {
     return new Builder(baseClass);
   }
 
+  /** Builder for resolving a constructor from candidate implementations. */
   public static class Builder {
     private final Class<?> baseClass;
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();
     private Ctor<?> ctor = null;
     private final Map<String, Throwable> problems = Maps.newHashMap();
 
+    /**
+     * Constructs a builder for the given base class.
+     *
+     * @param baseClass the base class used in error messages when no constructor is found
+     */
     public Builder(Class<?> baseClass) {
       this.baseClass = baseClass;
     }
 
+    /** Constructs a builder with no base class. */
     public Builder() {
       this.baseClass = null;
     }
@@ -135,6 +168,13 @@ public class DynConstructors {
       return this;
     }
 
+    /**
+     * Checks for an implementation, first finding the class by name.
+     *
+     * @param className name of a class
+     * @param types the constructor argument types
+     * @return this Builder for method chaining
+     */
     public Builder impl(String className, Class<?>... types) {
       // don't do any work if an implementation has been found
       if (ctor != null) {
@@ -151,6 +191,14 @@ public class DynConstructors {
       return this;
     }
 
+    /**
+     * Checks for an implementation.
+     *
+     * @param <T> the type of the target class
+     * @param targetClass a class instance
+     * @param types the constructor argument types
+     * @return this Builder for method chaining
+     */
     public <T> Builder impl(Class<T> targetClass, Class<?>... types) {
       // don't do any work if an implementation has been found
       if (ctor != null) {
@@ -166,6 +214,13 @@ public class DynConstructors {
       return this;
     }
 
+    /**
+     * Checks for a hidden implementation, first finding the class by name.
+     *
+     * @param className name of a class
+     * @param types the constructor argument types
+     * @return this Builder for method chaining
+     */
     public Builder hiddenImpl(String className, Class<?>... types) {
       // don't do any work if an implementation has been found
       if (ctor != null) {
@@ -182,6 +237,14 @@ public class DynConstructors {
       return this;
     }
 
+    /**
+     * Checks for a hidden implementation.
+     *
+     * @param <T> the type of the target class
+     * @param targetClass a class instance
+     * @param types the constructor argument types
+     * @return this Builder for method chaining
+     */
     @SuppressWarnings("removal")
     public <T> Builder hiddenImpl(Class<T> targetClass, Class<?>... types) {
       // don't do any work if an implementation has been found
@@ -203,6 +266,14 @@ public class DynConstructors {
       return this;
     }
 
+    /**
+     * Returns the first valid constructor as a {@link Ctor} or throws a NoSuchMethodException if
+     * there is none.
+     *
+     * @param <C> Java class constructed by the constructor
+     * @return a {@link Ctor} with a valid implementation
+     * @throws NoSuchMethodException if no implementation was found
+     */
     @SuppressWarnings("unchecked")
     public <C> Ctor<C> buildChecked() throws NoSuchMethodException {
       if (ctor != null) {
@@ -211,6 +282,14 @@ public class DynConstructors {
       throw buildCheckedException(baseClass, problems);
     }
 
+    /**
+     * Returns the first valid constructor as a {@link Ctor} or throws a RuntimeException if there
+     * is none.
+     *
+     * @param <C> Java class constructed by the constructor
+     * @return a {@link Ctor} with a valid implementation
+     * @throws RuntimeException if no implementation was found
+     */
     @SuppressWarnings("unchecked")
     public <C> Ctor<C> build() {
       if (ctor != null) {

--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Throwables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
+/** Utility for dynamically resolving a field and building accessors for it. */
 public class DynFields {
 
   private DynFields() {}
@@ -48,6 +49,12 @@ public class DynFields {
       this.name = name;
     }
 
+    /**
+     * Returns the value of this field in the given object.
+     *
+     * @param target the object to read the field from
+     * @return the value of the field in the given object
+     */
     @SuppressWarnings({"unchecked", "deprecation"})
     public T get(Object target) {
       try {
@@ -57,6 +64,12 @@ public class DynFields {
       }
     }
 
+    /**
+     * Sets the value of this field in the given object.
+     *
+     * @param target the object to set the field in
+     * @param value the value to set
+     */
     @SuppressWarnings("deprecation")
     public void set(Object target, T value) {
       try {
@@ -106,12 +119,20 @@ public class DynFields {
       return new StaticField<>(this);
     }
 
-    /** Returns whether the field is a static field. */
+    /**
+     * Returns whether the field is a static field.
+     *
+     * @return true if the field is static, false otherwise
+     */
     public boolean isStatic() {
       return Modifier.isStatic(field.getModifiers());
     }
 
-    /** Returns whether the field is always null. */
+    /**
+     * Returns whether the field is always null.
+     *
+     * @return true if the field is always null, false otherwise
+     */
     public boolean isAlwaysNull() {
       return this == AlwaysNull.INSTANCE;
     }
@@ -148,6 +169,7 @@ public class DynFields {
     }
   }
 
+  /** A handle to a static field, providing access without a target instance. */
   public static class StaticField<T> {
     private final UnboundField<T> field;
 
@@ -155,15 +177,26 @@ public class DynFields {
       this.field = field;
     }
 
+    /**
+     * Returns the value of this static field.
+     *
+     * @return the value of the field
+     */
     public T get() {
       return field.get(null);
     }
 
+    /**
+     * Sets the value of this static field.
+     *
+     * @param value the value to set
+     */
     public void set(T value) {
       field.set(null, value);
     }
   }
 
+  /** A field bound to a target object, providing access without passing the target. */
   public static class BoundField<T> {
     private final UnboundField<T> field;
     private final Object target;
@@ -173,19 +206,35 @@ public class DynFields {
       this.target = target;
     }
 
+    /**
+     * Returns the value of this field in the bound object.
+     *
+     * @return the value of the field
+     */
     public T get() {
       return field.get(target);
     }
 
+    /**
+     * Sets the value of this field in the bound object.
+     *
+     * @param value the value to set
+     */
     public void set(T value) {
       field.set(target, value);
     }
   }
 
+  /**
+   * Constructs a new builder for finding a field dynamically.
+   *
+   * @return a Builder for finding a field
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** Builder for resolving a field from candidate implementations. */
   public static class Builder {
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();
     private UnboundField<?> field = null;

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -67,6 +67,14 @@ public class DynMethods {
       }
     }
 
+    /**
+     * Invokes the method on the given target, wrapping checked exceptions in a RuntimeException.
+     *
+     * @param <R> the return type of the method
+     * @param target the object to invoke the method on
+     * @param args the arguments to pass to the method
+     * @return the result of the invocation
+     */
     @SuppressWarnings("deprecation")
     public <R> R invoke(Object target, Object... args) {
       try {
@@ -97,12 +105,20 @@ public class DynMethods {
       return new BoundMethod(this, receiver);
     }
 
-    /** Returns whether the method is a static method. */
+    /**
+     * Returns whether the method is a static method.
+     *
+     * @return true if the method is static, false otherwise
+     */
     public boolean isStatic() {
       return Modifier.isStatic(method.getModifiers());
     }
 
-    /** Returns whether the method is a noop. */
+    /**
+     * Returns whether the method is a noop.
+     *
+     * @return true if the method is a noop, false otherwise
+     */
     public boolean isNoop() {
       return this == NOOP;
     }
@@ -153,6 +169,7 @@ public class DynMethods {
         };
   }
 
+  /** A method bound to a receiver, invokable without passing the receiver. */
   public static class BoundMethod {
     private final UnboundMethod method;
     private final Object receiver;
@@ -162,15 +179,32 @@ public class DynMethods {
       this.receiver = receiver;
     }
 
+    /**
+     * Invokes the bound method with the given arguments.
+     *
+     * @param <R> the return type of the method
+     * @param args the arguments to pass to the method
+     * @return the result of the invocation
+     * @throws Exception if the method throws a checked exception
+     */
     public <R> R invokeChecked(Object... args) throws Exception {
       return method.invokeChecked(receiver, args);
     }
 
+    /**
+     * Invokes the bound method with the given arguments, wrapping checked exceptions in a
+     * RuntimeException.
+     *
+     * @param <R> the return type of the method
+     * @param args the arguments to pass to the method
+     * @return the result of the invocation
+     */
     public <R> R invoke(Object... args) {
       return method.invoke(receiver, args);
     }
   }
 
+  /** A static method, invokable without a receiver. */
   public static class StaticMethod {
     private final UnboundMethod method;
 
@@ -178,10 +212,26 @@ public class DynMethods {
       this.method = method;
     }
 
+    /**
+     * Invokes the static method with the given arguments.
+     *
+     * @param <R> the return type of the method
+     * @param args the arguments to pass to the method
+     * @return the result of the invocation
+     * @throws Exception if the method throws a checked exception
+     */
     public <R> R invokeChecked(Object... args) throws Exception {
       return method.invokeChecked(null, args);
     }
 
+    /**
+     * Invokes the static method with the given arguments, wrapping checked exceptions in a
+     * RuntimeException.
+     *
+     * @param <R> the return type of the method
+     * @param args the arguments to pass to the method
+     * @return the result of the invocation
+     */
     public <R> R invoke(Object... args) {
       return method.invoke(null, args);
     }
@@ -197,11 +247,17 @@ public class DynMethods {
     return new Builder(methodName);
   }
 
+  /** Builder for resolving a method from candidate implementations. */
   public static class Builder {
     private final String name;
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();
     private UnboundMethod method = null;
 
+    /**
+     * Constructs a builder that locates a method by the given name.
+     *
+     * @param methodName name of the method the builder will locate
+     */
     public Builder(String methodName) {
       this.name = methodName;
     }


### PR DESCRIPTION
`build-javadoc` emits 41 doclint warnings (37 × `no comment`, 4 × `no @return`) for the public API of the `Dyn*` reflection utilities in `iceberg-common`: the Gradle `javadoc` task runs default doclint (`-Xdoclint:all`) with no suppression, so every undocumented `public`/`protected` element is flagged.

This documents the flagged elements in `DynClasses`, `DynConstructors`, `DynFields` and `DynMethods` with complete Javadoc (summary + `@param`/`@return`/`@throws`, including type parameters), matching the style already used on their siblings (e.g. `DynMethods.Builder`). `@Override` methods are left as-is since they inherit their documentation. Javadoc-only — no signature or bytecode change; `./gradlew :iceberg-common:javadoc` is now warning-free.
