### PR TITLE
Kafka Connect: Require every expected partition before completing a commit

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -69,10 +69,6 @@ class CommitState {
           "Received commit ready when no commit in progress, this can happen during recovery. Commit ID: {}",
           dataComplete.commitId());
     } else if (Objects.equals(currentCommitId, dataComplete.commitId())) {
-      // Track which source partitions reported rather than how many responses arrived. The same
-      // partition can be reported more than once for one commit: a control-topic replay redelivers
-      // a DataComplete, and two workers can transiently claim a partition across a rebalance.
-      // Counting those again would satisfy the quorum before every partition has reported.
       dataComplete
           .assignments()
           .forEach(

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -31,6 +32,8 @@ import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +42,7 @@ class CommitState {
 
   private final List<Envelope> commitBuffer = Lists.newArrayList();
   private final List<DataComplete> readyBuffer = Lists.newArrayList();
-  private int receivedPartitionCount = 0;
+  private final Set<TopicPartition> reportedPartitions = Sets.newHashSet();
   private long startTime;
   private UUID currentCommitId;
   private final IcebergSinkConfig config;
@@ -66,7 +69,16 @@ class CommitState {
           "Received commit ready when no commit in progress, this can happen during recovery. Commit ID: {}",
           dataComplete.commitId());
     } else if (Objects.equals(currentCommitId, dataComplete.commitId())) {
-      receivedPartitionCount += dataComplete.assignments().size();
+      // Track which source partitions reported rather than how many responses arrived. The same
+      // partition can be reported more than once for one commit: a control-topic replay redelivers
+      // a DataComplete, and two workers can transiently claim a partition across a rebalance.
+      // Counting those again would satisfy the quorum before every partition has reported.
+      dataComplete
+          .assignments()
+          .forEach(
+              assignment ->
+                  reportedPartitions.add(
+                      new TopicPartition(assignment.topic(), assignment.partition())));
     }
   }
 
@@ -94,7 +106,7 @@ class CommitState {
 
   void endCurrentCommit() {
     readyBuffer.clear();
-    receivedPartitionCount = 0;
+    reportedPartitions.clear();
     currentCommitId = null;
   }
 
@@ -119,18 +131,18 @@ class CommitState {
       return false;
     }
 
-    if (receivedPartitionCount >= expectedPartitionCount) {
+    if (reportedPartitions.size() >= expectedPartitionCount) {
       LOG.info(
           "Commit {} ready, received responses for all {} partitions",
           currentCommitId,
-          receivedPartitionCount);
+          reportedPartitions.size());
       return true;
     }
 
     LOG.info(
         "Commit {} not ready, received responses for {} of {} partitions, waiting for more",
         currentCommitId,
-        receivedPartitionCount,
+        reportedPartitions.size(),
         expectedPartitionCount);
 
     return false;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -126,24 +126,24 @@ class CommitState {
     return false;
   }
 
-  boolean isCommitReady(int expectedPartitionCount) {
+  boolean isCommitReady(Set<TopicPartition> expectedPartitions) {
     if (!isCommitInProgress()) {
       return false;
     }
 
-    if (reportedPartitions.size() >= expectedPartitionCount) {
+    if (reportedPartitions.containsAll(expectedPartitions)) {
       LOG.info(
-          "Commit {} ready, received responses for all {} partitions",
+          "Commit {} ready, received responses for all {} expected partitions",
           currentCommitId,
-          reportedPartitions.size());
+          expectedPartitions.size());
       return true;
     }
 
     LOG.info(
-        "Commit {} not ready, received responses for {} of {} partitions, waiting for more",
+        "Commit {} not ready, received responses for {} of {} expected partitions, waiting for more",
         currentCommitId,
-        reportedPartitions.size(),
-        expectedPartitionCount);
+        Sets.intersection(reportedPartitions, expectedPartitions).size(),
+        expectedPartitions.size());
 
     return false;
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -62,6 +63,7 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFact
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
@@ -78,7 +80,7 @@ class Coordinator extends Channel {
 
   private final Catalog catalog;
   private final IcebergSinkConfig config;
-  private final int totalPartitionCount;
+  private final Set<TopicPartition> expectedPartitions;
   private final String snapshotOffsetsProp;
   private final ExecutorService exec;
   private final CommitState commitState;
@@ -98,8 +100,10 @@ class Coordinator extends Channel {
 
     this.catalog = catalog;
     this.config = config;
-    this.totalPartitionCount =
-        members.stream().mapToInt(desc -> desc.assignment().topicPartitions().size()).sum();
+    this.expectedPartitions =
+        members.stream()
+            .flatMap(member -> member.assignment().topicPartitions().stream())
+            .collect(Collectors.toUnmodifiableSet());
     this.snapshotOffsetsProp =
         String.format(
             "kafka.connect.offsets.%s.%s", config.controlTopic(), config.connectGroupId());
@@ -143,7 +147,7 @@ class Coordinator extends Channel {
         return true;
       case DATA_COMPLETE:
         commitState.addReady(envelope);
-        if (commitState.isCommitReady(totalPartitionCount)) {
+        if (commitState.isCommitReady(expectedPartitions)) {
           commit(false);
         }
         return true;

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
@@ -23,21 +23,55 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.DataComplete;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.Payload;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
 public class TestCommitState {
   private static TopicPartitionOffset partition(int partition) {
+    return partition("src-topic", partition);
+  }
+
+  private static TopicPartitionOffset partition(String topic, int partition) {
     TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
-    when(tp.topic()).thenReturn("src-topic");
+    when(tp.topic()).thenReturn(topic);
     when(tp.partition()).thenReturn(partition);
     return tp;
+  }
+
+  private static Set<TopicPartition> topicPartitions(TopicPartitionOffset... assignments) {
+    return Arrays.stream(assignments)
+        .map(assignment -> new TopicPartition(assignment.topic(), assignment.partition()))
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  void readinessRequiresActiveCommit() {
+    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+
+    assertThat(commitState.isCommitReady(topicPartitions())).isFalse();
+
+    commitState.startNewCommit();
+    commitState.endCurrentCommit();
+
+    assertThat(commitState.isCommitReady(topicPartitions())).isFalse();
+  }
+
+  @Test
+  void emptyAssignmentIsReadyDuringCommit() {
+    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    commitState.startNewCommit();
+
+    assertThat(commitState.isCommitReady(topicPartitions())).isTrue();
   }
 
   @Test
@@ -65,8 +99,8 @@ public class TestCommitState {
     commitState.addReady(wrapInEnvelope(payload2));
     commitState.addReady(wrapInEnvelope(payload3));
 
-    assertThat(commitState.isCommitReady(3)).isTrue();
-    assertThat(commitState.isCommitReady(4)).isFalse();
+    assertThat(commitState.isCommitReady(topicPartitions(tp0, tp1, tp2))).isTrue();
+    assertThat(commitState.isCommitReady(topicPartitions(tp0, tp1, tp2, tp3))).isFalse();
   }
 
   @Test
@@ -76,6 +110,8 @@ public class TestCommitState {
 
     // one worker owning source partition 0 reports; a control-topic replay redelivers it
     TopicPartitionOffset tp0 = partition(0);
+    TopicPartitionOffset tp1 = partition(1);
+    Set<TopicPartition> expectedPartitions = topicPartitions(tp0, tp1);
     DataComplete payload = mock(DataComplete.class);
     when(payload.commitId()).thenReturn(commitState.currentCommitId());
     when(payload.assignments()).thenReturn(ImmutableList.of(tp0));
@@ -83,18 +119,17 @@ public class TestCommitState {
     commitState.addReady(wrapInEnvelope(payload));
     commitState.addReady(wrapInEnvelope(payload));
 
-    assertThat(commitState.isCommitReady(2))
+    assertThat(commitState.isCommitReady(expectedPartitions))
         .as("a redelivered response must not stand in for a partition that never reported")
         .isFalse();
 
     // the partition that was actually missing reports
-    TopicPartitionOffset tp1 = partition(1);
     DataComplete second = mock(DataComplete.class);
     when(second.commitId()).thenReturn(commitState.currentCommitId());
     when(second.assignments()).thenReturn(ImmutableList.of(tp1));
     commitState.addReady(wrapInEnvelope(second));
 
-    assertThat(commitState.isCommitReady(2)).isTrue();
+    assertThat(commitState.isCommitReady(expectedPartitions)).isTrue();
   }
 
   @Test
@@ -105,6 +140,9 @@ public class TestCommitState {
     // during a rebalance two workers can transiently claim the same source partition
     TopicPartitionOffset tp0 = partition(0);
     TopicPartitionOffset alsoTp0 = partition(0);
+    TopicPartitionOffset otherTopicPartition = partition("other-topic", 0);
+    TopicPartitionOffset missing = partition(1);
+    Set<TopicPartition> expectedPartitions = topicPartitions(tp0, otherTopicPartition);
 
     DataComplete leaving = mock(DataComplete.class);
     when(leaving.commitId()).thenReturn(commitState.currentCommitId());
@@ -117,9 +155,42 @@ public class TestCommitState {
     commitState.addReady(wrapInEnvelope(leaving));
     commitState.addReady(wrapInEnvelope(arriving));
 
-    assertThat(commitState.isCommitReady(2))
+    assertThat(commitState.isCommitReady(expectedPartitions))
         .as("two claims on one partition cover one partition, not two")
         .isFalse();
+
+    DataComplete otherTopic = mock(DataComplete.class);
+    when(otherTopic.commitId()).thenReturn(commitState.currentCommitId());
+    when(otherTopic.assignments()).thenReturn(ImmutableList.of(otherTopicPartition));
+    commitState.addReady(wrapInEnvelope(otherTopic));
+
+    assertThat(commitState.isCommitReady(expectedPartitions)).isTrue();
+    assertThat(commitState.isCommitReady(topicPartitions(tp0, otherTopicPartition, missing)))
+        .isFalse();
+  }
+
+  @Test
+  void unexpectedPartitionsDoNotSatisfyReadiness() {
+    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    commitState.startNewCommit();
+
+    TopicPartitionOffset first = partition(0);
+    TopicPartitionOffset unexpected = partition("other-topic", 0);
+    TopicPartitionOffset missing = partition(1);
+    Set<TopicPartition> expectedPartitions = topicPartitions(first, missing);
+    DataComplete payload = mock(DataComplete.class);
+    when(payload.commitId()).thenReturn(commitState.currentCommitId());
+    when(payload.assignments()).thenReturn(ImmutableList.of(first, unexpected));
+    commitState.addReady(wrapInEnvelope(payload));
+
+    assertThat(commitState.isCommitReady(expectedPartitions)).isFalse();
+
+    DataComplete missingPayload = mock(DataComplete.class);
+    when(missingPayload.commitId()).thenReturn(commitState.currentCommitId());
+    when(missingPayload.assignments()).thenReturn(ImmutableList.of(missing));
+    commitState.addReady(wrapInEnvelope(missingPayload));
+
+    assertThat(commitState.isCommitReady(expectedPartitions)).isTrue();
   }
 
   @Test
@@ -134,25 +205,26 @@ public class TestCommitState {
     when(firstPayload.commitId()).thenReturn(commitState.currentCommitId());
     when(firstPayload.assignments()).thenReturn(ImmutableList.of(tp, other));
     commitState.addReady(wrapInEnvelope(firstPayload));
-    assertThat(commitState.isCommitReady(2)).isTrue();
+    assertThat(commitState.isCommitReady(topicPartitions(tp, other))).isTrue();
 
     commitState.endCurrentCommit();
     commitState.startNewCommit();
 
-    assertThat(commitState.isCommitReady(1)).isFalse();
+    assertThat(commitState.isCommitReady(topicPartitions(tp))).isFalse();
 
     DataComplete secondPayload = mock(DataComplete.class);
     when(secondPayload.commitId()).thenReturn(commitState.currentCommitId());
     when(secondPayload.assignments()).thenReturn(ImmutableList.of(tp));
     commitState.addReady(wrapInEnvelope(secondPayload));
 
-    assertThat(commitState.isCommitReady(1)).isTrue();
-    assertThat(commitState.isCommitReady(2)).isFalse();
+    assertThat(commitState.isCommitReady(topicPartitions(tp))).isTrue();
+    assertThat(commitState.isCommitReady(topicPartitions(tp, other))).isFalse();
   }
 
   @Test
   public void testIsCommitReadyIgnoresZombieCoordinatorPayloads() {
     TopicPartitionOffset tp = partition(0);
+    TopicPartitionOffset missing = partition(1);
 
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
@@ -160,18 +232,27 @@ public class TestCommitState {
     // Stale DataComplete from a zombie Coordinator that started a different commit.
     DataComplete zombiePayload = mock(DataComplete.class);
     when(zombiePayload.commitId()).thenReturn(UUID.randomUUID());
-    when(zombiePayload.assignments()).thenReturn(ImmutableList.of(tp, tp));
+    when(zombiePayload.assignments()).thenReturn(ImmutableList.of(missing));
 
     DataComplete currentPayload = mock(DataComplete.class);
     when(currentPayload.commitId()).thenReturn(commitState.currentCommitId());
     when(currentPayload.assignments()).thenReturn(ImmutableList.of(tp));
 
     commitState.addReady(wrapInEnvelope(zombiePayload));
+    assertThat(commitState.isCommitReady(topicPartitions(missing))).isFalse();
+
     commitState.addReady(wrapInEnvelope(currentPayload));
 
     // Only the current commit's payload counts toward readiness.
-    assertThat(commitState.isCommitReady(1)).isTrue();
-    assertThat(commitState.isCommitReady(2)).isFalse();
+    assertThat(commitState.isCommitReady(topicPartitions(tp))).isTrue();
+    assertThat(commitState.isCommitReady(topicPartitions(tp, missing))).isFalse();
+
+    DataComplete missingPayload = mock(DataComplete.class);
+    when(missingPayload.commitId()).thenReturn(commitState.currentCommitId());
+    when(missingPayload.assignments()).thenReturn(ImmutableList.of(missing));
+    commitState.addReady(wrapInEnvelope(missingPayload));
+
+    assertThat(commitState.isCommitReady(topicPartitions(tp, missing))).isTrue();
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
@@ -33,24 +33,33 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 public class TestCommitState {
+  private static TopicPartitionOffset partition(int partition) {
+    TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
+    when(tp.topic()).thenReturn("src-topic");
+    when(tp.partition()).thenReturn(partition);
+    return tp;
+  }
+
   @Test
   public void testIsCommitReady() {
-    TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
-
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
 
     DataComplete payload1 = mock(DataComplete.class);
     when(payload1.commitId()).thenReturn(commitState.currentCommitId());
-    when(payload1.assignments()).thenReturn(ImmutableList.of(tp, tp));
+    TopicPartitionOffset tp0 = partition(0);
+    TopicPartitionOffset tp1 = partition(1);
+    when(payload1.assignments()).thenReturn(ImmutableList.of(tp0, tp1));
 
     DataComplete payload2 = mock(DataComplete.class);
     when(payload2.commitId()).thenReturn(commitState.currentCommitId());
-    when(payload2.assignments()).thenReturn(ImmutableList.of(tp));
+    TopicPartitionOffset tp2 = partition(2);
+    when(payload2.assignments()).thenReturn(ImmutableList.of(tp2));
 
     DataComplete payload3 = mock(DataComplete.class);
     when(payload3.commitId()).thenReturn(UUID.randomUUID());
-    when(payload3.assignments()).thenReturn(ImmutableList.of(tp));
+    TopicPartitionOffset tp3 = partition(3);
+    when(payload3.assignments()).thenReturn(ImmutableList.of(tp3));
 
     commitState.addReady(wrapInEnvelope(payload1));
     commitState.addReady(wrapInEnvelope(payload2));
@@ -61,15 +70,69 @@ public class TestCommitState {
   }
 
   @Test
+  public void testReplayedReadyDoesNotSatisfyQuorumTwice() {
+    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    commitState.startNewCommit();
+
+    // one worker owning source partition 0 reports; a control-topic replay redelivers it
+    TopicPartitionOffset tp0 = partition(0);
+    DataComplete payload = mock(DataComplete.class);
+    when(payload.commitId()).thenReturn(commitState.currentCommitId());
+    when(payload.assignments()).thenReturn(ImmutableList.of(tp0));
+
+    commitState.addReady(wrapInEnvelope(payload));
+    commitState.addReady(wrapInEnvelope(payload));
+
+    assertThat(commitState.isCommitReady(2))
+        .as("a redelivered response must not stand in for a partition that never reported")
+        .isFalse();
+
+    // the partition that was actually missing reports
+    TopicPartitionOffset tp1 = partition(1);
+    DataComplete second = mock(DataComplete.class);
+    when(second.commitId()).thenReturn(commitState.currentCommitId());
+    when(second.assignments()).thenReturn(ImmutableList.of(tp1));
+    commitState.addReady(wrapInEnvelope(second));
+
+    assertThat(commitState.isCommitReady(2)).isTrue();
+  }
+
+  @Test
+  public void testOverlappingAssignmentsDoNotSatisfyQuorumTwice() {
+    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    commitState.startNewCommit();
+
+    // during a rebalance two workers can transiently claim the same source partition
+    TopicPartitionOffset tp0 = partition(0);
+    TopicPartitionOffset alsoTp0 = partition(0);
+
+    DataComplete leaving = mock(DataComplete.class);
+    when(leaving.commitId()).thenReturn(commitState.currentCommitId());
+    when(leaving.assignments()).thenReturn(ImmutableList.of(tp0));
+
+    DataComplete arriving = mock(DataComplete.class);
+    when(arriving.commitId()).thenReturn(commitState.currentCommitId());
+    when(arriving.assignments()).thenReturn(ImmutableList.of(alsoTp0));
+
+    commitState.addReady(wrapInEnvelope(leaving));
+    commitState.addReady(wrapInEnvelope(arriving));
+
+    assertThat(commitState.isCommitReady(2))
+        .as("two claims on one partition cover one partition, not two")
+        .isFalse();
+  }
+
+  @Test
   public void testIsCommitReadyResetsBetweenCommits() {
-    TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp = partition(0);
+    TopicPartitionOffset other = partition(1);
 
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
 
     DataComplete firstPayload = mock(DataComplete.class);
     when(firstPayload.commitId()).thenReturn(commitState.currentCommitId());
-    when(firstPayload.assignments()).thenReturn(ImmutableList.of(tp, tp));
+    when(firstPayload.assignments()).thenReturn(ImmutableList.of(tp, other));
     commitState.addReady(wrapInEnvelope(firstPayload));
     assertThat(commitState.isCommitReady(2)).isTrue();
 
@@ -89,7 +152,7 @@ public class TestCommitState {
 
   @Test
   public void testIsCommitReadyIgnoresZombieCoordinatorPayloads() {
-    TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp = partition(0);
 
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
@@ -114,17 +177,17 @@ public class TestCommitState {
   @Test
   public void testGetValidThroughTs() {
     DataComplete payload1 = mock(DataComplete.class);
-    TopicPartitionOffset tp1 = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp1 = partition(0);
     OffsetDateTime ts1 = EventTestUtil.now();
     when(tp1.timestamp()).thenReturn(ts1);
 
-    TopicPartitionOffset tp2 = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp2 = partition(1);
     OffsetDateTime ts2 = ts1.plusSeconds(1);
     when(tp2.timestamp()).thenReturn(ts2);
     when(payload1.assignments()).thenReturn(ImmutableList.of(tp1, tp2));
 
     DataComplete payload2 = mock(DataComplete.class);
-    TopicPartitionOffset tp3 = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp3 = partition(2);
     OffsetDateTime ts3 = ts1.plusSeconds(2);
     when(tp3.timestamp()).thenReturn(ts3);
     when(payload2.assignments()).thenReturn(ImmutableList.of(tp3));
@@ -140,7 +203,7 @@ public class TestCommitState {
 
     // null timestamp for one, so should not set a valid-through timestamp
     DataComplete payload3 = mock(DataComplete.class);
-    TopicPartitionOffset tp4 = mock(TopicPartitionOffset.class);
+    TopicPartitionOffset tp4 = partition(3);
     when(tp4.timestamp()).thenReturn(null);
     when(payload3.assignments()).thenReturn(ImmutableList.of(tp4));
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -58,6 +59,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -478,6 +481,90 @@ public class TestCoordinator extends ChannelTestBase {
     CommitComplete commitCompletePayload = (CommitComplete) commitComplete.payload();
     assertThat(commitCompletePayload.commitId()).isEqualTo(commitId);
     assertThat(commitCompletePayload.validThroughTs()).isEqualTo(ts);
+  }
+
+  @Test
+  public void testReplayedDataCompleteStillCommitsTheFileExactlyOnce() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    // two source partitions, so a commit is only ready once both have reported
+    MemberDescription member =
+        new MemberDescription(
+            "member",
+            Optional.empty(),
+            "client",
+            "host",
+            new MemberAssignment(
+                ImmutableSet.of(
+                    new TopicPartition(SRC_TOPIC_NAME, 0), new TopicPartition(SRC_TOPIC_NAME, 1))));
+    Coordinator coordinator =
+        new Coordinator(
+            catalog, config, ImmutableList.of(member), clientFactory, mock(SinkTaskContext.class));
+    coordinator.start();
+    initConsumer();
+
+    coordinator.process();
+    UUID commitId =
+        ((StartCommit) AvroUtil.decode(producer.history().get(0).value()).payload()).commitId();
+
+    DataFile dataFile = EventTestUtil.createDataFile();
+    Event written =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitId,
+                TableReference.of("catalog", TABLE_IDENTIFIER, table.uuid()),
+                ImmutableList.of(dataFile),
+                ImmutableList.of()));
+    Event firstPartitionReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                commitId, ImmutableList.of(new TopicPartitionOffset(SRC_TOPIC_NAME, 0, 1L, null))));
+
+    // partition 0 reports, then a control-topic replay redelivers both of its records
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(written)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(firstPartitionReady)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 3L, "key", AvroUtil.encode(written)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 4L, "key", AvroUtil.encode(firstPartitionReady)));
+    coordinator.process();
+
+    table.refresh();
+    assertThat(table.currentSnapshot())
+        .as("a replayed response must not stand in for the partition that has not reported")
+        .isNull();
+
+    // the partition that was actually missing reports
+    consumer.addRecord(
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME,
+            0,
+            5L,
+            "key",
+            AvroUtil.encode(
+                new Event(
+                    config.connectGroupId(),
+                    new DataComplete(
+                        commitId,
+                        ImmutableList.of(
+                            new TopicPartitionOffset(SRC_TOPIC_NAME, 1, 1L, null)))))));
+    coordinator.process();
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(
+            SnapshotChanges.builderFor(table)
+                .snapshot(table.currentSnapshot())
+                .build()
+                .addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(dataFile.location());
   }
 
   private UUID coordinatorTest(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,6 +67,8 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestCoordinator extends ChannelTestBase {
 
@@ -452,12 +455,15 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   private Coordinator startCoordinator() {
+    return startCoordinator(ImmutableList.of());
+  }
+
+  private Coordinator startCoordinator(Collection<MemberDescription> members) {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
 
     SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory, context);
     coordinator.start();
     initConsumer();
     return coordinator;
@@ -483,12 +489,9 @@ public class TestCoordinator extends ChannelTestBase {
     assertThat(commitCompletePayload.validThroughTs()).isEqualTo(ts);
   }
 
-  @Test
-  public void testReplayedDataCompleteStillCommitsTheFileExactlyOnce() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    // two source partitions, so a commit is only ready once both have reported
+  @ParameterizedTest(name = "Repeated data starts at offset {0}")
+  @ValueSource(longs = {1, 3})
+  void repeatedDataCompleteWaitsForEveryExpectedPartition(long repeatedWrittenOffset) {
     MemberDescription member =
         new MemberDescription(
             "member",
@@ -498,11 +501,10 @@ public class TestCoordinator extends ChannelTestBase {
             new MemberAssignment(
                 ImmutableSet.of(
                     new TopicPartition(SRC_TOPIC_NAME, 0), new TopicPartition(SRC_TOPIC_NAME, 1))));
-    Coordinator coordinator =
-        new Coordinator(
-            catalog, config, ImmutableList.of(member), clientFactory, mock(SinkTaskContext.class));
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator(ImmutableList.of(member));
+    TopicPartition controlPartition = new TopicPartition(CTL_TOPIC_NAME, 0);
+    long initialOffset = 1L;
+    consumer.commitSync(ImmutableMap.of(controlPartition, new OffsetAndMetadata(initialOffset)));
 
     coordinator.process();
     UUID commitId =
@@ -518,45 +520,51 @@ public class TestCoordinator extends ChannelTestBase {
                 TableReference.of("catalog", TABLE_IDENTIFIER, table.uuid()),
                 ImmutableList.of(dataFile),
                 ImmutableList.of()));
+    OffsetDateTime missingPartitionTimestamp = EventTestUtil.now();
+    OffsetDateTime firstPartitionTimestamp = missingPartitionTimestamp.plusSeconds(1);
     Event firstPartitionReady =
         new Event(
             config.connectGroupId(),
             new DataComplete(
-                commitId, ImmutableList.of(new TopicPartitionOffset(SRC_TOPIC_NAME, 0, 1L, null))));
+                commitId,
+                ImmutableList.of(
+                    new TopicPartitionOffset(SRC_TOPIC_NAME, 0, 1L, firstPartitionTimestamp))));
 
-    // partition 0 reports, then a control-topic replay redelivers both of its records
     consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(written)));
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, initialOffset, "key", AvroUtil.encode(written)));
     consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(firstPartitionReady)));
-    consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 3L, "key", AvroUtil.encode(written)));
-    consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 4L, "key", AvroUtil.encode(firstPartitionReady)));
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, initialOffset + 1, "key", AvroUtil.encode(firstPartitionReady)));
     coordinator.process();
 
-    table.refresh();
-    assertThat(table.currentSnapshot())
-        .as("a replayed response must not stand in for the partition that has not reported")
-        .isNull();
+    assertCommitPending(controlPartition, initialOffset);
 
-    // the partition that was actually missing reports
+    consumer.seek(controlPartition, repeatedWrittenOffset);
+    consumer.addRecord(
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, repeatedWrittenOffset, "key", AvroUtil.encode(written)));
     consumer.addRecord(
         new ConsumerRecord<>(
             CTL_TOPIC_NAME,
             0,
-            5L,
+            repeatedWrittenOffset + 1,
             "key",
-            AvroUtil.encode(
-                new Event(
-                    config.connectGroupId(),
-                    new DataComplete(
-                        commitId,
-                        ImmutableList.of(
-                            new TopicPartitionOffset(SRC_TOPIC_NAME, 1, 1L, null)))))));
+            AvroUtil.encode(firstPartitionReady)));
+    coordinator.process();
+
+    assertCommitPending(controlPartition, initialOffset);
+
+    long missingPartitionOffset = repeatedWrittenOffset + 2;
+    addReadyRecord(
+        missingPartitionOffset,
+        commitId,
+        new TopicPartitionOffset(SRC_TOPIC_NAME, 1, 1L, missingPartitionTimestamp));
     coordinator.process();
 
     table.refresh();
+    assertThat(producer.history()).hasSize(3);
+    assertCommitTable(1, commitId, missingPartitionTimestamp);
+    assertCommitComplete(2, commitId, missingPartitionTimestamp);
     assertThat(table.snapshots()).hasSize(1);
     assertThat(
             SnapshotChanges.builderFor(table)
@@ -565,6 +573,72 @@ public class TestCoordinator extends ChannelTestBase {
                 .addedDataFiles())
         .extracting(DataFile::location)
         .containsExactly(dataFile.location());
+
+    long committedOffset = missingPartitionOffset + 1;
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(COMMIT_ID_SNAPSHOT_PROP, commitId.toString())
+        .containsEntry(OFFSETS_SNAPSHOT_PROP, String.format("{\"0\":%d}", committedOffset))
+        .containsEntry(VALID_THROUGH_TS_SNAPSHOT_PROP, missingPartitionTimestamp.toString());
+    assertThat(consumer.committed(ImmutableSet.of(controlPartition)).get(controlPartition).offset())
+        .isEqualTo(committedOffset);
+  }
+
+  @Test
+  void unexpectedPartitionDoesNotCompleteCommit() {
+    MemberDescription member =
+        new MemberDescription(
+            "member",
+            Optional.empty(),
+            "client",
+            "host",
+            new MemberAssignment(
+                ImmutableSet.of(
+                    new TopicPartition(SRC_TOPIC_NAME, 0), new TopicPartition(SRC_TOPIC_NAME, 1))));
+    Coordinator coordinator = startCoordinator(ImmutableList.of(member));
+    TopicPartition controlPartition = new TopicPartition(CTL_TOPIC_NAME, 0);
+    long initialOffset = 1L;
+    consumer.commitSync(ImmutableMap.of(controlPartition, new OffsetAndMetadata(initialOffset)));
+
+    coordinator.process();
+    UUID commitId =
+        ((StartCommit) AvroUtil.decode(producer.history().get(0).value()).payload()).commitId();
+    OffsetDateTime timestamp = EventTestUtil.now();
+
+    addReadyRecord(
+        initialOffset, commitId, new TopicPartitionOffset(SRC_TOPIC_NAME, 0, 1L, timestamp));
+    addReadyRecord(
+        initialOffset + 1, commitId, new TopicPartitionOffset("other-topic", 0, 1L, timestamp));
+    coordinator.process();
+
+    assertCommitPending(controlPartition, initialOffset);
+
+    long missingPartitionOffset = initialOffset + 2;
+    addReadyRecord(
+        missingPartitionOffset,
+        commitId,
+        new TopicPartitionOffset(SRC_TOPIC_NAME, 1, 1L, timestamp));
+    coordinator.process();
+
+    assertThat(producer.history()).hasSize(2);
+    assertCommitComplete(1, commitId, timestamp);
+    assertThat(consumer.committed(ImmutableSet.of(controlPartition)).get(controlPartition).offset())
+        .isEqualTo(missingPartitionOffset + 1);
+  }
+
+  private void addReadyRecord(long offset, UUID commitId, TopicPartitionOffset assignment) {
+    Event event =
+        new Event(
+            config.connectGroupId(), new DataComplete(commitId, ImmutableList.of(assignment)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset, "key", AvroUtil.encode(event)));
+  }
+
+  private void assertCommitPending(TopicPartition controlPartition, long committedOffset) {
+    table.refresh();
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(producer.history()).hasSize(1);
+    assertThat(consumer.committed(ImmutableSet.of(controlPartition)).get(controlPartition).offset())
+        .isEqualTo(committedOffset);
   }
 
   private UUID coordinatorTest(


### PR DESCRIPTION
Part of the #16282 investigation. Not a complete fix for it.

## Problem

`CommitState` decided readiness by comparing a total against the number of partitions the coordinator was constructed with:

```java
receivedPartitionCount += dataComplete.assignments().size();
...
if (receivedPartitionCount >= expectedPartitionCount)
```

Cardinality does not establish coverage. Three inputs raise the total without covering the expected assignment:

- a `DataComplete` redelivered by a control-topic replay
- two workers transiently claiming the same source partition while an assignment moves
- a partition no worker owns any more, or one on a different topic

Any of them can satisfy the check while a partition that never reported is still missing. The coordinator then performs a **full** commit — a subset of the cycle's data, stamped with a `kafka.connect.valid-through-ts` the table does not satisfy. That watermark is a completeness claim consumers act on.

```mermaid
sequenceDiagram
    autonumber
    participant W0 as Worker, src-topic-0
    participant W1 as Worker, src-topic-1
    participant K as Control topic
    participant C as Coordinator
    participant T as Iceberg table

    Note over C: expects {src-topic-0, src-topic-1}
    W0->>K: DataWritten + DataComplete(src-topic-0)
    K-->>C: total = 1
    Note over K,C: replay, or a stale/foreign partition
    K-->>C: total = 2 -- but still only src-topic-0 covered
    Note over W1: src-topic-1 has never reported
    C->>T: full commit, valid-through-ts stamped
    Note over C,T: snapshot holds one partition's data,<br/>watermark asserts both
```

### After the fix

Successful full-commit path for one existing table, with an unchanged captured assignment and no timeout. All reports below use the current commit ID; all buffered assignment timestamps are non-null. Partition 0 reports the later timestamp (`t0 > t1`).

```mermaid
sequenceDiagram
    autonumber
    participant W0 as Worker, src-topic-0
    participant W1 as Worker, src-topic-1
    participant K as Control topic
    participant C as Coordinator
    participant T as Iceberg table

    Note over C: Active commit<br/>Expected = {src-topic-0, src-topic-1}
    W0->>K: DataWritten + DataComplete(src-topic-0, t0)
    K-->>C: Deliver partition 0 events
    C->>C: Record src-topic-0<br/>missingPartitionCount = 1

    K-->>C: Replay partition 0 events
    C->>C: Reported identities unchanged<br/>missingPartitionCount = 1
    Note over C,T: No snapshot, completion event,<br/>or committed-offset advance
    Note over C: An unexpected identity also<br/>cannot cover missing src-topic-1

    W1->>K: DataWritten + DataComplete(src-topic-1, t1)
    K-->>C: Deliver partition 1 events
    C->>C: Record src-topic-1<br/>missingPartitionCount = 0
    C->>C: validThroughTs = min(t0, t1) = t1
    C->>T: Commit buffered files<br/>with control offsets and valid-through-ts = t1
    T-->>C: Snapshot committed
    C->>K: CommitToTable(commitId, snapshotId, t1)
    C->>C: Checkpoint control-topic consumer offsets<br/>and clear buffered file responses
    C->>K: CommitComplete(commitId, t1)
    C->>C: End current commit<br/>and clear readiness state
```

Replayed events still reach the coordinator; this fix prevents them from substituting for the missing expected partition. Readiness covers the captured assignment only; assignment freshness, timeout-driven partial commits, and stale-ID timestamp filtering remain separate concerns.

## Change

`Coordinator` retains the expected identities instead of their count, and readiness requires coverage of that set:

```java
// Coordinator
this.expectedPartitions =
    members.stream()
        .flatMap(member -> member.assignment().topicPartitions().stream())
        .collect(Collectors.toUnmodifiableSet());

// CommitState
int missingPartitionCount = Sets.difference(expectedPartitions, reportedPartitions).size();
if (missingPartitionCount == 0)
```

Reported identities are keyed on `(topic, partition)`, so a matching partition number on a different topic does not count.

The missing-partition count is computed once from expected minus reported and reused for readiness and logging. The expected set also counts overlapping member claims once; it does not validate assignment ownership or freshness.

```mermaid
flowchart LR
    A[DataComplete arrives] --> B{commit id matches?}
    B -- no --> Z[no partition recorded]
    B -- yes --> C["record (topic, partition)"]
    C --> D{"reported ⊇ expected?"}
    D -- no --> E[keep waiting]
    D -- yes --> F[full commit]

    classDef ok fill:#dcfce7,stroke:#16a34a,color:#14532d
    class C,F ok
```

Commit-id filtering is unchanged. A `DataComplete` whose id does not match contributes no identity, but it still enters `readyBuffer`. Its timestamps can therefore **lower** `validThroughTs`, or **suppress it entirely** — `hasValidThroughTs` requires `allMatch(timestamp != null)` across the whole buffer, so one null from a stale payload yields `null`. Neither direction can raise the watermark. Excluding stale-commit entries from the `validThroughTs` calculation was proposed in #17080, which was closed unmerged; that calculation change leaves insertion into `readyBuffer` unchanged and is a separate concern from readiness, not addressed here.

## Scope

This checks coverage **against the assignment captured when the coordinator was constructed**. Establishing that the captured assignment is still current — a topic expansion while a leader is retained, for instance — is a separate concern and is not addressed here. The watermark is truthful for the captured assignment, not unconditionally.

## Relationship to the other control-topic work

**Integration dependency:** This PR will wait for #17450 to merge, then adapt expected-partition construction to its partition-metadata path while preserving identity-based readiness (no expected identity missing). #17450 is open and unmerged as of 2026-09-15; the implementation, diagrams, and full validation results in this description refer to `9513c3b51`. After integration, the replay tests and diagram will distinguish same-offset records skipped upstream from duplicate payloads arriving at new offsets.

An earlier revision of this PR carried a skip-before-dispatch guard in `Channel.consumeAvailable`. **That guard has been removed** and the branch rebuilt on current `main`.

| PR | Concern | Status |
|---|---|---|
| **#17933** | keep `controlTopicOffsets` monotonic | **merged** |
| **#17713** | skip already-consumed control records before dispatch | open; **this PR defers to it** |
| #17450 | leader election and coordinator hardening; changes the constructor and source-partition inventory | open; merge first, then reconcile expected identities here |
| **#17925 (this)** | readiness must cover the expected assignment | the remaining delta |
| #18006 | replacement-coordinator recovery via `earliest` | separate |

`Channel.java` is untouched, so the merged `TestChannel` and its `hasSize(7)` expectation are unchanged here.

The fixes are complementary. Skipping only helps when a replay is *behind* the tracked position; a replay that is not behind is dispatched normally. Neither offset monotonicity nor dispatch skipping prevents an unexpected or foreign partition from satisfying a count.

## Deliberate change to existing expectations

`TestCommitState` reused a single mocked `TopicPartitionOffset` for several assignments and asserted against integer counts. Those tests encoded the behaviour this change removes, so they now use distinct identities and expected sets. This is called out here rather than left for a reviewer to find.

## Tests

`TestCommitState`

- `testReplayedReadyDoesNotSatisfyQuorumTwice` — a redelivered response does not complete the quorum; the commit completes once the missing partition reports.
- `testOverlappingAssignmentsDoNotSatisfyQuorumTwice` — two workers claiming one partition cover one partition; a second topic pins that the key is `(topic, partition)`.
- `unexpectedPartitionsDoNotSatisfyReadiness` — an unexpected identity does not substitute for a missing expected one.
- `testIsCommitReadyIgnoresZombieCoordinatorPayloads` — the stale payload now carries a partition the current commit never reports, so a broken commit-id guard fails the assertion.
- `readinessRequiresActiveCommit`, `emptyAssignmentIsReadyDuringCommit` — pin the existing behaviour at the boundaries.

`TestCoordinator`

- `repeatedDataCompleteWaitsForEveryExpectedPartition` — parameterised over a **same-offset rewind** (`consumer.seek`) and duplicate payloads at **new offsets**. Asserts no snapshot, no completion event and no checkpoint advance while a partition is missing; then exactly one snapshot with one added file, `VALID_THROUGH_TS` equal to the **earlier** of the two timestamps, the expected `kafka.connect.offsets`, and the committed consumer offset.
- `unexpectedPartitionDoesNotCompleteCommit` — an unexpected topic does not complete the commit at coordinator level.

- `overlappingMemberAssignmentsRequireEachDistinctPartition`: two distinct members claim `{src-topic/0}` and `{src-topic/0, src-topic/1}`. The commit stays pending after partition 0 reports, then completes after one report for partition 1 without waiting for a duplicate claim or a timeout. Asserts one snapshot and file, the earlier non-null watermark in the snapshot and completion events, and the expected snapshot/control-consumer offsets. All three readiness scenarios share the member fixture helper.

### Negative controls

The following four controls were applied to production code, run, and reverted at `65320ff8f`. These are historical results, not controls rerun for `9513c3b51`:

| Mutation | Result |
|---|---|
| commit-id guard removed | zombie test fails |
| topic dropped from the recorded key | cross-topic test fails |
| cardinality readiness restored | both unexpected-partition tests fail; coordinator emits completion early |
| duplicate-accepting counting restored | the replay unit test and both coordinator replay variants fail; both coordinator variants produce a premature snapshot carrying the later timestamp, while the unit test fails its readiness assertion |

Source hashes were captured before and after and confirmed identical, so no mutation was left behind.

For `9513c3b51`, adding a summed-member assignment-count requirement alongside identity coverage made `overlappingMemberAssignmentsRequireEachDistinctPartition` fail at its completion assertion: only StartCommit was emitted (1 event instead of 3). Removing that control made the test pass again, and both production-file hashes matched their pre-control values.

## Validation

```sh
./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions=3 \
  :iceberg-kafka-connect:iceberg-kafka-connect:check -x integrationTest --rerun-tasks
```

At `9513c3b51`: **BUILD SUCCESSFUL**. 19 suites, **150 tests**, zero failures, errors or skips, including 9 `TestCommitState` tests and 21 coordinator cases. Spotless, both Checkstyle tasks, and class-uniqueness checks pass. `git diff --check` is clean.

Deterministic unit tests with an in-memory Iceberg catalog and Kafka mock clients. No live-broker rebalance was exercised.

## Out of scope

The only cross-restart deduplication floor is the `kafka.connect.offsets` summary that `lastCommittedOffsetsForTable` finds by walking snapshot ancestry. Custom summary properties are not propagated by `SnapshotProducer`, so once every snapshot carrying it has expired the floor is gone. That is independent of this change and of #18006.

---
**AI Disclosure**
- Model: Claude Opus 5; GPT-6 Astra.
- Platform/Tool: opencode; GitHub Copilot.
- Human Oversight: partially reviewed.
- Prompt Summary: AI assistance was used for codebase analysis, the readiness change, regression tests, negative controls, validation runs, and this description. Review feedback drove three revisions: the original reset-on-rebalance proposal was withdrawn after it was shown to risk data loss; the skip-before-dispatch guard was withdrawn once `merge(..., Long::max)` merged and the overlap with #17713 was identified; and count-based readiness was replaced with expected-set coverage after review showed cardinality alone does not establish it. Test claims were checked by mutating production code and confirming the intended tests fail.
