### PR TITLE
Data: Skip empty files while migrating tables to iceberg

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -45,8 +46,11 @@ import org.apache.iceberg.orc.OrcMetrics;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TableMigrationUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(TableMigrationUtil.class);
   private static final PathFilter HIDDEN_PATH_FILTER =
       p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
@@ -57,6 +61,9 @@ public class TableMigrationUtil {
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
+   *
+   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
+   * reducer output; they contain no rows.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -87,6 +94,9 @@ public class TableMigrationUtil {
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
+   *
+   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
+   * reducer output; they contain no rows.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -129,6 +139,9 @@ public class TableMigrationUtil {
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
+   *
+   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
+   * reducer output; they contain no rows.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -185,23 +198,27 @@ public class TableMigrationUtil {
       } else if (format.contains("parquet")) {
         task.run(
             index -> {
-              Metrics metrics =
-                  getParquetMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
-              datafiles[index] =
-                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "parquet");
+              FileStatus status = fileStatus.get(index);
+              if (skipEmptyFile(status)) {
+                return;
+              }
+              Metrics metrics = getParquetMetrics(status.getPath(), conf, metricsSpec, mapping);
+              datafiles[index] = buildDataFile(status, partitionValues, spec, metrics, "parquet");
             });
       } else if (format.contains("orc")) {
         task.run(
             index -> {
-              Metrics metrics =
-                  getOrcMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
-              datafiles[index] =
-                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "orc");
+              FileStatus status = fileStatus.get(index);
+              if (skipEmptyFile(status)) {
+                return;
+              }
+              Metrics metrics = getOrcMetrics(status.getPath(), conf, metricsSpec, mapping);
+              datafiles[index] = buildDataFile(status, partitionValues, spec, metrics, "orc");
             });
       } else {
         throw new UnsupportedOperationException("Unknown partition format: " + format);
       }
-      return Arrays.asList(datafiles);
+      return Arrays.stream(datafiles).filter(Objects::nonNull).collect(Collectors.toList());
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to list files in partition: " + partitionUri, e);
     } finally {
@@ -209,6 +226,14 @@ public class TableMigrationUtil {
         service.shutdown();
       }
     }
+  }
+
+  private static boolean skipEmptyFile(FileStatus status) {
+    if (status.getLen() == 0) {
+      LOG.warn("Skipping empty file during table migration: {}", status.getPath());
+      return true;
+    }
+    return false;
   }
 
   private static Metrics getAvroMetrics(Path path, Configuration conf) {

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -23,7 +23,6 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -46,11 +45,8 @@ import org.apache.iceberg.orc.OrcMetrics;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TableMigrationUtil {
-  private static final Logger LOG = LoggerFactory.getLogger(TableMigrationUtil.class);
   private static final PathFilter HIDDEN_PATH_FILTER =
       p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
@@ -61,9 +57,6 @@ public class TableMigrationUtil {
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
-   *
-   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
-   * reducer output; they contain no rows.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -94,9 +87,6 @@ public class TableMigrationUtil {
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
-   *
-   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
-   * reducer output; they contain no rows.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -140,9 +130,6 @@ public class TableMigrationUtil {
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics other than row count are set to null.
    *
-   * <p>Zero-length files are skipped. Hive often leaves such files in a table location after empty
-   * reducer output; they contain no rows.
-   *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
    *
@@ -178,7 +165,7 @@ public class TableMigrationUtil {
       FileSystem fs = partitionDir.getFileSystem(conf);
       List<FileStatus> fileStatus =
           Arrays.stream(fs.listStatus(partitionDir, HIDDEN_PATH_FILTER))
-              .filter(FileStatus::isFile)
+              .filter(status -> status.isFile() && status.getLen() > 0)
               .collect(Collectors.toList());
       DataFile[] datafiles = new DataFile[fileStatus.size()];
       Tasks.Builder<Integer> task =
@@ -198,27 +185,23 @@ public class TableMigrationUtil {
       } else if (format.contains("parquet")) {
         task.run(
             index -> {
-              FileStatus status = fileStatus.get(index);
-              if (skipEmptyFile(status)) {
-                return;
-              }
-              Metrics metrics = getParquetMetrics(status.getPath(), conf, metricsSpec, mapping);
-              datafiles[index] = buildDataFile(status, partitionValues, spec, metrics, "parquet");
+              Metrics metrics =
+                  getParquetMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
+              datafiles[index] =
+                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "parquet");
             });
       } else if (format.contains("orc")) {
         task.run(
             index -> {
-              FileStatus status = fileStatus.get(index);
-              if (skipEmptyFile(status)) {
-                return;
-              }
-              Metrics metrics = getOrcMetrics(status.getPath(), conf, metricsSpec, mapping);
-              datafiles[index] = buildDataFile(status, partitionValues, spec, metrics, "orc");
+              Metrics metrics =
+                  getOrcMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
+              datafiles[index] =
+                  buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "orc");
             });
       } else {
         throw new UnsupportedOperationException("Unknown partition format: " + format);
       }
-      return Arrays.stream(datafiles).filter(Objects::nonNull).collect(Collectors.toList());
+      return Arrays.asList(datafiles);
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to list files in partition: " + partitionUri, e);
     } finally {
@@ -226,14 +209,6 @@ public class TableMigrationUtil {
         service.shutdown();
       }
     }
-  }
-
-  private static boolean skipEmptyFile(FileStatus status) {
-    if (status.getLen() == 0) {
-      LOG.warn("Skipping empty file during table migration: {}", status.getPath());
-      return true;
-    }
-    return false;
   }
 
   private static Metrics getAvroMetrics(Path path, Configuration conf) {

--- a/data/src/test/java/org/apache/iceberg/data/TestTableMigrationUtil.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestTableMigrationUtil.java
@@ -94,6 +94,21 @@ class TestTableMigrationUtil {
         .hasRootCauseInstanceOf(FileNotFoundException.class);
   }
 
+  @Test
+  void testListPartitionSkipsEmptyFiles() throws IOException {
+    Path partitionPath = tempTableLocation.resolve("id=1");
+    String partitionUri = partitionPath.toUri().toString();
+    java.nio.file.Files.createDirectories(partitionPath);
+    writePartitionFile(partitionPath.toFile());
+    java.nio.file.Files.write(partitionPath.resolve("empty"), new byte[0]);
+
+    List<DataFile> dataFiles =
+        TableMigrationUtil.listPartition(
+            PARTITION, partitionUri, FORMAT, SPEC, CONF, MetricsConfig.getDefault(), null);
+
+    assertThat(dataFiles).as("Zero-length files should be skipped").hasSize(1);
+  }
+
   private static void writePartitionFile(File outputDir) throws IOException {
     Iterable<GenericData.Record> records = RandomAvroData.generate(SCHEMA, 1000, 54310);
     File testFile = new File(outputDir, "junit" + System.nanoTime() + ".parquet");

--- a/data/src/test/java/org/apache/iceberg/data/TestTableMigrationUtil.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestTableMigrationUtil.java
@@ -82,6 +82,21 @@ class TestTableMigrationUtil {
   }
 
   @Test
+  void testListPartitionWithOnlyEmptyFile() throws IOException {
+    Path partitionPath = tempTableLocation.resolve("id=1");
+    String partitionUri = partitionPath.toUri().toString();
+    java.nio.file.Files.createDirectories(partitionPath);
+    java.nio.file.Files.write(partitionPath.resolve("empty.parquet"), new byte[0]);
+
+    List<DataFile> dataFiles =
+        TableMigrationUtil.listPartition(
+            PARTITION, partitionUri, FORMAT, SPEC, CONF, MetricsConfig.getDefault(), null);
+    assertThat(dataFiles)
+        .as("List partition with only a zero-length file should return 0 DataFile")
+        .isEmpty();
+  }
+
+  @Test
   void testListPartitionMissingFilesFailure() {
     String partitionUri = tempTableLocation.resolve("id=1").toUri().toString();
 
@@ -92,21 +107,6 @@ class TestTableMigrationUtil {
         .hasMessageContaining("Unable to list files in partition: " + partitionUri)
         .isInstanceOf(RuntimeException.class)
         .hasRootCauseInstanceOf(FileNotFoundException.class);
-  }
-
-  @Test
-  void testListPartitionSkipsEmptyFiles() throws IOException {
-    Path partitionPath = tempTableLocation.resolve("id=1");
-    String partitionUri = partitionPath.toUri().toString();
-    java.nio.file.Files.createDirectories(partitionPath);
-    writePartitionFile(partitionPath.toFile());
-    java.nio.file.Files.write(partitionPath.resolve("empty"), new byte[0]);
-
-    List<DataFile> dataFiles =
-        TableMigrationUtil.listPartition(
-            PARTITION, partitionUri, FORMAT, SPEC, CONF, MetricsConfig.getDefault(), null);
-
-    assertThat(dataFiles).as("Zero-length files should be skipped").hasSize(1);
   }
 
   private static void writePartitionFile(File outputDir) throws IOException {


### PR DESCRIPTION
ORC:

```
java.lang.IllegalArgumentException: ORC schema does not contain Iceberg IDs
  at org.apache.iceberg.orc.ORCSchemaUtil.convert(ORCSchemaUtil.java:293)
  at org.apache.iceberg.orc.OrcMetrics.buildOrcMetrics(OrcMetrics.java:143)
  at org.apache.iceberg.orc.OrcMetrics.fromInputFile(OrcMetrics.java:93)
  at org.apache.iceberg.orc.OrcMetrics.fromInputFile(OrcMetrics.java:87)
  at org.apache.iceberg.data.TableMigrationUtil.getOrcMetrics(TableMigrationUtil.java:296)
  at org.apache.iceberg.data.TableMigrationUtil.lambda$listPartition$4(TableMigrationUtil.java:244)
```

Parquet:

```
java.lang.RuntimeException: mig_parquet_sample/date_key=2026-09-02/1_folder is not a Parquet file (length is too low: 0)
	at org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:599)
	at org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:578)
	at org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader.<init>(ParquetFileReader.java:971)
	at org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader.<init>(ParquetFileReader.java:961)
	at org.apache.iceberg.shaded.org.apache.parquet.hadoop.ParquetFileReader.open(ParquetFileReader.java:718)
	at org.apache.iceberg.parquet.ParquetUtil.fileMetrics(ParquetUtil.java:64)
	at org.apache.iceberg.data.TableMigrationUtil.getParquetMetrics(TableMigrationUtil.java:287)
	at org.apache.iceberg.data.TableMigrationUtil.lambda$listPartition$3(TableMigrationUtil.java:236)
```

Avro is working fine.

Fixes #17926