### PR TITLE
API, Core: Expose co-located deletion vector through DataFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -164,4 +164,9 @@ public interface DataFile extends ContentFile<DataFile> {
   default List<Integer> equalityFieldIds() {
     return null;
   }
+
+  /** Returns the deletion vector co-located with this data file, or null if there is none. */
+  default DeleteFile deletionVector() {
+    return null;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -165,8 +165,13 @@ public interface DataFile extends ContentFile<DataFile> {
     return null;
   }
 
-  /** Returns the deletion vector co-located with this data file, or null if there is none. */
-  default DeleteFile deletionVector() {
+  /**
+   * Returns the deletion vector co-located or tracked with this data file, or null if there isn't
+   * one.
+   *
+   * <p>A delete manifest can contain a deletion vector even if this co-located DV is null.
+   */
+  default DeletionVector deletionVector() {
     return null;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/DeletionVector.java
+++ b/api/src/main/java/org/apache/iceberg/DeletionVector.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.types.Types;
  * <p>Tracks where a DV blob can be read. The DV blob follows the format defined by the
  * deletion-vector-v1 blob type in the Puffin spec.
  */
-interface DeletionVector {
+public interface DeletionVector {
   Types.NestedField LOCATION =
       Types.NestedField.required(
           155, "location", Types.StringType.get(), "Location of the file containing the DV");

--- a/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
@@ -215,6 +215,11 @@ class TrackedFileAdapters {
     }
 
     @Override
+    public DeleteFile deletionVector() {
+      return file().deletionVector() != null ? new TrackedDVDeleteFile(file(), spec()) : null;
+    }
+
+    @Override
     public DataFile copy() {
       return new TrackedDataFile(file().copy(), spec());
     }

--- a/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
@@ -215,8 +215,8 @@ class TrackedFileAdapters {
     }
 
     @Override
-    public DeleteFile deletionVector() {
-      return file().deletionVector() != null ? new TrackedDVDeleteFile(file(), spec()) : null;
+    public DeletionVector deletionVector() {
+      return file().deletionVector();
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -98,7 +100,7 @@ class TestTrackedFileAdapters {
     tracking.setManifestLocation(MANIFEST_LOCATION);
     tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
 
-    DeletionVector dv = deletionVector();
+    DeletionVector dv = mock(DeletionVector.class);
     TrackedFile file =
         new TrackedFileStruct(
             tracking,
@@ -338,10 +340,12 @@ class TestTrackedFileAdapters {
 
   @Test
   void dataFileWithoutDeletionVectorReturnsNull() {
-    DataFile dataFile =
-        TrackedFileAdapters.asDataFile(dummyTrackedFile(FileContent.DATA), UNPARTITIONED);
+    TrackedFile fileWithoutDv = mock(TrackedFile.class);
+    when(fileWithoutDv.contentType()).thenReturn(FileContent.DATA);
+    when(fileWithoutDv.deletionVector()).thenReturn(null);
 
-    assertThat(dataFile.deletionVector()).isNull();
+    assertThat(TrackedFileAdapters.asDataFile(fileWithoutDv, UNPARTITIONED).deletionVector())
+        .isNull();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -356,13 +356,7 @@ class TestTrackedFileAdapters {
             null,
             null);
 
-    DeleteFile dvFile = TrackedFileAdapters.asDataFile(file, UNPARTITIONED).deletionVector();
-
-    assertThat(dvFile.content()).isEqualTo(FileContent.POSITION_DELETES);
-    assertThat(dvFile.format()).isEqualTo(FileFormat.PUFFIN);
-    assertThat(dvFile.location()).isEqualTo(dv.location());
-    assertThat(dvFile.recordCount()).isEqualTo(dv.cardinality());
-    assertThat(dvFile.referencedDataFile()).isEqualTo(DATA_FILE_LOCATION);
+    assertThat(TrackedFileAdapters.asDataFile(file, UNPARTITIONED).deletionVector()).isSameAs(dv);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -98,6 +98,7 @@ class TestTrackedFileAdapters {
     tracking.setManifestLocation(MANIFEST_LOCATION);
     tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
 
+    DeletionVector dv = deletionVector();
     TrackedFile file =
         new TrackedFileStruct(
             tracking,
@@ -111,7 +112,7 @@ class TestTrackedFileAdapters {
             PARTITION,
             CONTENT_STATS,
             3,
-            null,
+            dv,
             null,
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L, 100L),
@@ -134,6 +135,7 @@ class TestTrackedFileAdapters {
     assertThat(dataFile.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(dataFile.splitOffsets()).containsExactly(50L, 100L);
     assertThat(dataFile.manifestLocation()).isEqualTo(MANIFEST_LOCATION);
+    assertThat(dataFile.deletionVector()).isSameAs(dv);
     assertThat(dataFile.equalityFieldIds()).isNull();
     assertThat(dataFile.columnSizes()).isNull();
     assertThat(dataFile.valueCounts()).containsOnly(Map.entry(1, 100L), Map.entry(2, 100L));
@@ -332,31 +334,6 @@ class TestTrackedFileAdapters {
     assertThatThrownBy(() -> TrackedFileAdapters.asDVDeleteFile(file, UNPARTITIONED))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot create DV delete file: no deletion vector");
-  }
-
-  @Test
-  void dataFileExposesColocatedDeletionVector() {
-    DeletionVector dv = deletionVector();
-    TrackedFileStruct file =
-        new TrackedFileStruct(
-            null,
-            FileContent.DATA,
-            FORMAT_VERSION_V4,
-            DATA_FILE_LOCATION,
-            FileFormat.PARQUET,
-            100L,
-            1024L,
-            null,
-            null,
-            null,
-            null,
-            dv,
-            null,
-            null,
-            null,
-            null);
-
-    assertThat(TrackedFileAdapters.asDataFile(file, UNPARTITIONED).deletionVector()).isSameAs(dv);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -335,6 +335,45 @@ class TestTrackedFileAdapters {
   }
 
   @Test
+  void dataFileExposesColocatedDeletionVector() {
+    DeletionVector dv = deletionVector();
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            null,
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            DATA_FILE_LOCATION,
+            FileFormat.PARQUET,
+            100L,
+            1024L,
+            null,
+            null,
+            null,
+            null,
+            dv,
+            null,
+            null,
+            null,
+            null);
+
+    DeleteFile dvFile = TrackedFileAdapters.asDataFile(file, UNPARTITIONED).deletionVector();
+
+    assertThat(dvFile.content()).isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(dvFile.format()).isEqualTo(FileFormat.PUFFIN);
+    assertThat(dvFile.location()).isEqualTo(dv.location());
+    assertThat(dvFile.recordCount()).isEqualTo(dv.cardinality());
+    assertThat(dvFile.referencedDataFile()).isEqualTo(DATA_FILE_LOCATION);
+  }
+
+  @Test
+  void dataFileWithoutDeletionVectorReturnsNull() {
+    DataFile dataFile =
+        TrackedFileAdapters.asDataFile(dummyTrackedFile(FileContent.DATA), UNPARTITIONED);
+
+    assertThat(dataFile.deletionVector()).isNull();
+  }
+
+  @Test
   void nullContentStatsReturnsNullStats() {
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 


### PR DESCRIPTION
V4 co-locates a data file's deletion vector on the data entry. Add DataFile.deletionVector() returning the DV as a DeletionVector.

Related discussion thread:
https://github.com/apache/iceberg/pull/17541/changes#r3787760198