### PR TITLE
API, Spark: Support cleanup level in ExpireSnapshots action and procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * API for removing old {@link Snapshot snapshots} from a table.
@@ -45,7 +47,17 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
     /** Clean up only metadata files (manifests, manifest lists, statistics), retain data files. */
     METADATA_ONLY,
     /** Clean up both metadata and data files (default). */
-    ALL
+    ALL;
+
+    public static CleanupLevel fromString(String levelAsString) {
+      Preconditions.checkArgument(levelAsString != null, "Invalid cleanup level: null");
+      try {
+        return CleanupLevel.valueOf(levelAsString.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            String.format("Invalid cleanup level: %s", levelAsString), e);
+      }
+    }
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.actions;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.io.SupportsBulkOperations;
 
@@ -110,6 +111,25 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
    */
   default ExpireSnapshots cleanExpiredMetadata(boolean clean) {
     throw new UnsupportedOperationException("cleanExpiredMetadata is not supported");
+  }
+
+  /**
+   * Configures the cleanup level for expired files.
+   *
+   * <p>Identical to {@link org.apache.iceberg.ExpireSnapshots#cleanupLevel(CleanupLevel)}, but the
+   * files are determined and deleted using a query engine.
+   *
+   * <p>Consider {@link CleanupLevel#METADATA_ONLY} when data files are shared across tables or when
+   * using procedures like add-files that may reference the same data files. Content files are not
+   * listed at all in that case, so the manifests of expired snapshots do not have to be read.
+   *
+   * <p>Consider {@link CleanupLevel#NONE} to expire snapshots without deleting any files.
+   *
+   * @param level the cleanup level to use for expired snapshots
+   * @return this for method chaining
+   */
+  default ExpireSnapshots cleanupLevel(CleanupLevel level) {
+    throw new UnsupportedOperationException("cleanupLevel is not supported");
   }
 
   /** The action result that contains a summary of the execution. */

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -260,6 +260,9 @@ and their files which are no longer needed.
 This procedure will remove old snapshots and data files which are uniquely required by those old snapshots. This means
 the `expire_snapshots` procedure will never remove files which are still required by a non-expired snapshot.
 
+Use `cleanup_level` to narrow which files are deleted. This is useful when data files are not solely owned by the table,
+for example when they are shared with another table or were added with [`add_files`](#add_files).
+
 #### Usage
 
 | Argument Name | Required? | Type | Description |
@@ -271,6 +274,7 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `stream_results` |    | boolean       | When true, deletion files will be sent to Spark driver by RDD partition (by default, all the files will be sent to Spark driver). This option is recommended to set to `true` to prevent Spark driver OOM from large file size |
 | `snapshot_ids` |   | array of long       | Array of snapshot IDs to expire. |
 | `clean_expired_metadata` |   | boolean       | When true, cleans up metadata such as partition specs and schemas that are no longer referenced by snapshots. |
+| `cleanup_level` |   | string       | Which files to delete: `ALL` (default) deletes both metadata and data files, `METADATA_ONLY` deletes manifests, manifest lists and statistics files while retaining data files, and `NONE` removes the snapshots from table metadata without deleting any files. |
 
 If `older_than` and `retain_last` are omitted, the table's [expiration properties](configuration.md#table-behavior-properties) will be used.
 Snapshots that are still referenced by branches or tags won't be removed. By default, branches and tags never expire, but their retention policy can be changed with the table property `history.expire.max-ref-age-ms`. The `main` branch never expires.
@@ -298,6 +302,12 @@ Remove snapshots with snapshot ID `123` (note that this snapshot ID should not b
 
 ```sql
 CALL hive_prod.system.expire_snapshots(table => 'db.sample', snapshot_ids => ARRAY(123));
+```
+
+Remove snapshots older than specific day and time, but keep the data files they reference:
+
+```sql
+CALL hive_prod.system.expire_snapshots(table => 'db.sample', older_than => TIMESTAMP '2021-06-30 00:00:00.000', cleanup_level => 'METADATA_ONLY');
 ```
 
 ### `remove_orphan_files`

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -155,6 +155,69 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testExpireSnapshotsWithMetadataOnlyCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'metadata_only')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete data files", ImmutableList.of(row(0L, 0L, 0L, 1L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithNoneCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'none')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete any files", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithInvalidCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.expire_snapshots(table => '%s', cleanup_level => 'invalid')",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid cleanup level: invalid");
+  }
+
+  @TestTemplate
   public void testExpireSnapshotsGCDisabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -81,6 +81,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   private ExecutorService deleteExecutorService = null;
   private Dataset<FileInfo> expiredFileDS = null;
   private Boolean cleanExpiredMetadata = null;
+  private CleanupLevel cleanupLevel = CleanupLevel.ALL;
 
   ExpireSnapshotsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -137,6 +138,13 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     return this;
   }
 
+  @Override
+  public ExpireSnapshotsSparkAction cleanupLevel(CleanupLevel level) {
+    Preconditions.checkArgument(null != level, "Invalid cleanup level: null");
+    this.cleanupLevel = level;
+    return this;
+  }
+
   /**
    * Expires snapshots and commits the changes to the table, returning a Dataset of files to delete.
    *
@@ -170,7 +178,14 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
         expireSnapshots.cleanExpiredMetadata(cleanExpiredMetadata);
       }
 
+      // cleanup is always performed by this action, never by the core operation
       expireSnapshots.cleanupLevel(CleanupLevel.NONE).commit();
+
+      if (CleanupLevel.NONE == cleanupLevel) {
+        LOG.info("Skipping file cleanup for {} because the cleanup level is NONE", table.name());
+        this.expiredFileDS = spark().emptyDataset(FileInfo.ENCODER);
+        return expiredFileDS;
+      }
 
       // fetch valid files after expiration
       TableMetadata updatedMetadata = ops.refresh();
@@ -218,6 +233,10 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
       options.add("clean_expired_metadata=" + cleanExpiredMetadata);
     }
 
+    if (CleanupLevel.ALL != cleanupLevel) {
+      options.add("cleanup_level=" + cleanupLevel);
+    }
+
     return String.format("Expiring snapshots (%s) in %s", COMMA_JOINER.join(options), table.name());
   }
 
@@ -239,10 +258,17 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
 
   private Dataset<FileInfo> fileDS(TableMetadata metadata, Set<Long> snapshotIds) {
     Table staticTable = newStaticTable(metadata, table.io());
-    return contentFileDS(staticTable, snapshotIds)
-        .union(manifestDS(staticTable, snapshotIds))
-        .union(manifestListDS(staticTable, snapshotIds))
-        .union(statisticsFileDS(staticTable, snapshotIds));
+    Dataset<FileInfo> metadataFileDS =
+        manifestDS(staticTable, snapshotIds)
+            .union(manifestListDS(staticTable, snapshotIds))
+            .union(statisticsFileDS(staticTable, snapshotIds));
+
+    // listing content files requires reading every manifest, so skip it unless it is needed
+    if (CleanupLevel.METADATA_ONLY == cleanupLevel) {
+      return metadataFileDS;
+    }
+
+    return contentFileDS(staticTable, snapshotIds).union(metadataFileDS);
   }
 
   private Set<Long> findExpiredSnapshotIds(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.io.SupportsBulkOperations;
@@ -59,6 +60,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType));
   private static final ProcedureParameter CLEAN_EXPIRED_METADATA_PARAM =
       optionalInParameter("clean_expired_metadata", DataTypes.BooleanType);
+  private static final ProcedureParameter CLEANUP_LEVEL_PARAM =
+      optionalInParameter("cleanup_level", DataTypes.StringType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
@@ -68,7 +71,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         MAX_CONCURRENT_DELETES_PARAM,
         STREAM_RESULTS_PARAM,
         SNAPSHOT_IDS_PARAM,
-        CLEAN_EXPIRED_METADATA_PARAM
+        CLEAN_EXPIRED_METADATA_PARAM,
+        CLEANUP_LEVEL_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -121,6 +125,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Boolean streamResult = input.asBoolean(STREAM_RESULTS_PARAM, null);
     long[] snapshotIds = input.asLongArray(SNAPSHOT_IDS_PARAM, null);
     Boolean cleanExpiredMetadata = input.asBoolean(CLEAN_EXPIRED_METADATA_PARAM, null);
+    String cleanupLevel = input.asString(CLEANUP_LEVEL_PARAM, null);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
@@ -167,6 +172,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
           if (cleanExpiredMetadata != null) {
             action.cleanExpiredMetadata(cleanExpiredMetadata);
+          }
+
+          if (cleanupLevel != null) {
+            action.cleanupLevel(CleanupLevel.fromString(cleanupLevel));
           }
 
           ExpireSnapshots.Result result = action.execute();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.ManifestFile;
@@ -211,6 +212,64 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
+  }
+
+  @TestTemplate
+  public void testMetadataOnlyCleanupLevelRetainsContentFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.METADATA_ONLY)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    // same metadata files as CleanupLevel.ALL, but FILE_A is retained
+    checkExpirationResults(0L, 0L, 0L, 1L, 2L, results);
+    assertThat(deletedFiles).doesNotContain(FILE_A.location());
+  }
+
+  @TestTemplate
+  public void testNoneCleanupLevelRetainsAllFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.NONE)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    checkExpirationResults(0L, 0L, 0L, 0L, 0L, results);
+    assertThat(deletedFiles).isEmpty();
+  }
+
+  @TestTemplate
+  public void testInvalidCleanupLevel() {
+    assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).cleanupLevel(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid cleanup level: null");
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -154,6 +154,69 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testExpireSnapshotsWithMetadataOnlyCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'metadata_only')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete data files", ImmutableList.of(row(0L, 0L, 0L, 1L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithNoneCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'none')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete any files", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithInvalidCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.expire_snapshots(table => '%s', cleanup_level => 'invalid')",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid cleanup level: invalid");
+  }
+
+  @TestTemplate
   public void testExpireSnapshotsGCDisabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -81,6 +81,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   private ExecutorService deleteExecutorService = null;
   private Dataset<FileInfo> expiredFileDS = null;
   private Boolean cleanExpiredMetadata = null;
+  private CleanupLevel cleanupLevel = CleanupLevel.ALL;
 
   ExpireSnapshotsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -137,6 +138,13 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     return this;
   }
 
+  @Override
+  public ExpireSnapshotsSparkAction cleanupLevel(CleanupLevel level) {
+    Preconditions.checkArgument(null != level, "Invalid cleanup level: null");
+    this.cleanupLevel = level;
+    return this;
+  }
+
   /**
    * Expires snapshots and commits the changes to the table, returning a Dataset of files to delete.
    *
@@ -170,7 +178,14 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
         expireSnapshots.cleanExpiredMetadata(cleanExpiredMetadata);
       }
 
+      // cleanup is always performed by this action, never by the core operation
       expireSnapshots.cleanupLevel(CleanupLevel.NONE).commit();
+
+      if (CleanupLevel.NONE == cleanupLevel) {
+        LOG.info("Skipping file cleanup for {} because the cleanup level is NONE", table.name());
+        this.expiredFileDS = spark().emptyDataset(FileInfo.ENCODER);
+        return expiredFileDS;
+      }
 
       // fetch valid files after expiration
       TableMetadata updatedMetadata = ops.refresh();
@@ -218,6 +233,10 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
       options.add("clean_expired_metadata=" + cleanExpiredMetadata);
     }
 
+    if (CleanupLevel.ALL != cleanupLevel) {
+      options.add("cleanup_level=" + cleanupLevel);
+    }
+
     return String.format("Expiring snapshots (%s) in %s", COMMA_JOINER.join(options), table.name());
   }
 
@@ -239,10 +258,17 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
 
   private Dataset<FileInfo> fileDS(TableMetadata metadata, Set<Long> snapshotIds) {
     Table staticTable = newStaticTable(metadata, table.io());
-    return contentFileDS(staticTable, snapshotIds)
-        .union(manifestDS(staticTable, snapshotIds))
-        .union(manifestListDS(staticTable, snapshotIds))
-        .union(statisticsFileDS(staticTable, snapshotIds));
+    Dataset<FileInfo> metadataFileDS =
+        manifestDS(staticTable, snapshotIds)
+            .union(manifestListDS(staticTable, snapshotIds))
+            .union(statisticsFileDS(staticTable, snapshotIds));
+
+    // listing content files requires reading every manifest, so skip it unless it is needed
+    if (CleanupLevel.METADATA_ONLY == cleanupLevel) {
+      return metadataFileDS;
+    }
+
+    return contentFileDS(staticTable, snapshotIds).union(metadataFileDS);
   }
 
   private Set<Long> findExpiredSnapshotIds(

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.Iterator;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.io.SupportsBulkOperations;
@@ -64,6 +65,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType));
   private static final ProcedureParameter CLEAN_EXPIRED_METADATA_PARAM =
       optionalInParameter("clean_expired_metadata", DataTypes.BooleanType);
+  private static final ProcedureParameter CLEANUP_LEVEL_PARAM =
+      optionalInParameter("cleanup_level", DataTypes.StringType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
@@ -73,7 +76,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         MAX_CONCURRENT_DELETES_PARAM,
         STREAM_RESULTS_PARAM,
         SNAPSHOT_IDS_PARAM,
-        CLEAN_EXPIRED_METADATA_PARAM
+        CLEAN_EXPIRED_METADATA_PARAM,
+        CLEANUP_LEVEL_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -126,6 +130,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Boolean streamResult = input.asBoolean(STREAM_RESULTS_PARAM, null);
     long[] snapshotIds = input.asLongArray(SNAPSHOT_IDS_PARAM, null);
     Boolean cleanExpiredMetadata = input.asBoolean(CLEAN_EXPIRED_METADATA_PARAM, null);
+    String cleanupLevel = input.asString(CLEANUP_LEVEL_PARAM, null);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
@@ -172,6 +177,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
           if (cleanExpiredMetadata != null) {
             action.cleanExpiredMetadata(cleanExpiredMetadata);
+          }
+
+          if (cleanupLevel != null) {
+            action.cleanupLevel(CleanupLevel.fromString(cleanupLevel));
           }
 
           ExpireSnapshots.Result result = action.execute();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.ManifestFile;
@@ -211,6 +212,64 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
+  }
+
+  @TestTemplate
+  public void testMetadataOnlyCleanupLevelRetainsContentFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.METADATA_ONLY)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    // same metadata files as CleanupLevel.ALL, but FILE_A is retained
+    checkExpirationResults(0L, 0L, 0L, 1L, 2L, results);
+    assertThat(deletedFiles).doesNotContain(FILE_A.location());
+  }
+
+  @TestTemplate
+  public void testNoneCleanupLevelRetainsAllFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.NONE)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    checkExpirationResults(0L, 0L, 0L, 0L, 0L, results);
+    assertThat(deletedFiles).isEmpty();
+  }
+
+  @TestTemplate
+  public void testInvalidCleanupLevel() {
+    assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).cleanupLevel(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid cleanup level: null");
   }
 
   @TestTemplate

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -154,6 +154,69 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testExpireSnapshotsWithMetadataOnlyCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'metadata_only')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete data files", ImmutableList.of(row(0L, 0L, 0L, 1L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithNoneCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s', older_than => TIMESTAMP '%s', cleanup_level => 'none')",
+            catalogName, tableIdent, currentTimestamp);
+    assertEquals(
+        "Should not delete any files", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsWithInvalidCleanupLevel() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.expire_snapshots(table => '%s', cleanup_level => 'invalid')",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid cleanup level: invalid");
+  }
+
+  @TestTemplate
   public void testExpireSnapshotsGCDisabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -81,6 +81,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   private ExecutorService deleteExecutorService = null;
   private Dataset<FileInfo> expiredFileDS = null;
   private Boolean cleanExpiredMetadata = null;
+  private CleanupLevel cleanupLevel = CleanupLevel.ALL;
 
   ExpireSnapshotsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -137,6 +138,13 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     return this;
   }
 
+  @Override
+  public ExpireSnapshotsSparkAction cleanupLevel(CleanupLevel level) {
+    Preconditions.checkArgument(null != level, "Invalid cleanup level: null");
+    this.cleanupLevel = level;
+    return this;
+  }
+
   /**
    * Expires snapshots and commits the changes to the table, returning a Dataset of files to delete.
    *
@@ -170,7 +178,14 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
         expireSnapshots.cleanExpiredMetadata(cleanExpiredMetadata);
       }
 
+      // cleanup is always performed by this action, never by the core operation
       expireSnapshots.cleanupLevel(CleanupLevel.NONE).commit();
+
+      if (CleanupLevel.NONE == cleanupLevel) {
+        LOG.info("Skipping file cleanup for {} because the cleanup level is NONE", table.name());
+        this.expiredFileDS = spark().emptyDataset(FileInfo.ENCODER);
+        return expiredFileDS;
+      }
 
       // fetch valid files after expiration
       TableMetadata updatedMetadata = ops.refresh();
@@ -218,6 +233,10 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
       options.add("clean_expired_metadata=" + cleanExpiredMetadata);
     }
 
+    if (CleanupLevel.ALL != cleanupLevel) {
+      options.add("cleanup_level=" + cleanupLevel);
+    }
+
     return String.format("Expiring snapshots (%s) in %s", COMMA_JOINER.join(options), table.name());
   }
 
@@ -239,10 +258,17 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
 
   private Dataset<FileInfo> fileDS(TableMetadata metadata, Set<Long> snapshotIds) {
     Table staticTable = newStaticTable(metadata, table.io());
-    return contentFileDS(staticTable, snapshotIds)
-        .union(manifestDS(staticTable, snapshotIds))
-        .union(manifestListDS(staticTable, snapshotIds))
-        .union(statisticsFileDS(staticTable, snapshotIds));
+    Dataset<FileInfo> metadataFileDS =
+        manifestDS(staticTable, snapshotIds)
+            .union(manifestListDS(staticTable, snapshotIds))
+            .union(statisticsFileDS(staticTable, snapshotIds));
+
+    // listing content files requires reading every manifest, so skip it unless it is needed
+    if (CleanupLevel.METADATA_ONLY == cleanupLevel) {
+      return metadataFileDS;
+    }
+
+    return contentFileDS(staticTable, snapshotIds).union(metadataFileDS);
   }
 
   private Set<Long> findExpiredSnapshotIds(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.Iterator;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.io.SupportsBulkOperations;
@@ -64,6 +65,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType));
   private static final ProcedureParameter CLEAN_EXPIRED_METADATA_PARAM =
       optionalInParameter("clean_expired_metadata", DataTypes.BooleanType);
+  private static final ProcedureParameter CLEANUP_LEVEL_PARAM =
+      optionalInParameter("cleanup_level", DataTypes.StringType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
@@ -73,7 +76,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         MAX_CONCURRENT_DELETES_PARAM,
         STREAM_RESULTS_PARAM,
         SNAPSHOT_IDS_PARAM,
-        CLEAN_EXPIRED_METADATA_PARAM
+        CLEAN_EXPIRED_METADATA_PARAM,
+        CLEANUP_LEVEL_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -126,6 +130,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Boolean streamResult = input.asBoolean(STREAM_RESULTS_PARAM, null);
     long[] snapshotIds = input.asLongArray(SNAPSHOT_IDS_PARAM, null);
     Boolean cleanExpiredMetadata = input.asBoolean(CLEAN_EXPIRED_METADATA_PARAM, null);
+    String cleanupLevel = input.asString(CLEANUP_LEVEL_PARAM, null);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
@@ -172,6 +177,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
           if (cleanExpiredMetadata != null) {
             action.cleanExpiredMetadata(cleanExpiredMetadata);
+          }
+
+          if (cleanupLevel != null) {
+            action.cleanupLevel(CleanupLevel.fromString(cleanupLevel));
           }
 
           ExpireSnapshots.Result result = action.execute();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ExpireSnapshots.CleanupLevel;
 import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.ManifestFile;
@@ -211,6 +212,64 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
+  }
+
+  @TestTemplate
+  public void testMetadataOnlyCleanupLevelRetainsContentFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.METADATA_ONLY)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    // same metadata files as CleanupLevel.ALL, but FILE_A is retained
+    checkExpirationResults(0L, 0L, 0L, 1L, 2L, results);
+    assertThat(deletedFiles).doesNotContain(FILE_A.location());
+  }
+
+  @TestTemplate
+  public void testNoneCleanupLevelRetainsAllFiles() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+
+    long end = rightAfterSnapshot();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    ExpireSnapshots.Result results =
+        SparkActions.get()
+            .expireSnapshots(table)
+            .expireOlderThan(end)
+            .cleanupLevel(CleanupLevel.NONE)
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
+
+    checkExpirationResults(0L, 0L, 0L, 0L, 0L, results);
+    assertThat(deletedFiles).isEmpty();
+  }
+
+  @TestTemplate
+  public void testInvalidCleanupLevel() {
+    assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).cleanupLevel(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid cleanup level: null");
   }
 
   @TestTemplate


### PR DESCRIPTION
`CleanupLevel` was added to the expire snapshots interface in #14287 but is not reachable from any engine. Spark users cannot ask for metadata-only cleanup, and the only way to expire snapshots without deleting files is the core Java API.

Exposing it is not a pass-through. `ExpireSnapshotsSparkAction` already commits the core expiration with `CleanupLevel.NONE` and works out what to delete itself, by anti-joining the file lists before and after expiration, so forwarding the level to core would have no effect. The level is applied to that diff instead: `ALL` behaves as before, `METADATA_ONLY` deletes manifests, manifest lists and statistics files but retains content files, and `NONE` commits the expiration and deletes nothing. `METADATA_ONLY` drops `contentFileDS` from both sides of the anti-join rather than filtering the result, so the manifests of expired snapshots are never read.

Flink remains untouched in this PR

