### PR TITLE
Core, Hive, Spark: Auto close JsonGenerator using try-with-resources

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -131,6 +131,7 @@ public class TableMetadataParser {
         OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8);
         JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       toJson(metadata, generator);
+      generator.flush();
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile.location());
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -128,10 +128,9 @@ public class TableMetadataParser {
     boolean isGzip = Codec.fromFileName(outputFile.location()) == Codec.GZIP;
     OutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
     try (OutputStream ou = isGzip ? new GZIPOutputStream(stream) : stream;
-        OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8)) {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+        OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8);
+        JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       toJson(metadata, generator);
-      generator.flush();
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile.location());
     }
@@ -151,8 +150,8 @@ public class TableMetadataParser {
   }
 
   public static String toJson(TableMetadata metadata) {
-    try (StringWriter writer = new StringWriter()) {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (StringWriter writer = new StringWriter();
+        JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       toJson(metadata, generator);
       generator.flush();
       return writer.toString();

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -190,11 +190,10 @@ public class ViewMetadataParser {
     boolean isGzip = Codec.fromFileName(outputFile.location()) == Codec.GZIP;
     OutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
     try (OutputStreamWriter writer =
-        new OutputStreamWriter(
-            isGzip ? new GZIPOutputStream(stream) : stream, StandardCharsets.UTF_8)) {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+            new OutputStreamWriter(
+                isGzip ? new GZIPOutputStream(stream) : stream, StandardCharsets.UTF_8);
+        JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       toJson(metadata, generator);
-      generator.flush();
     } catch (IOException e) {
       throw new UncheckedIOException(
           String.format("Failed to write json to file: %s", outputFile.location()), e);

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -194,6 +194,7 @@ public class ViewMetadataParser {
                 isGzip ? new GZIPOutputStream(stream) : stream, StandardCharsets.UTF_8);
         JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       toJson(metadata, generator);
+      generator.flush();
     } catch (IOException e) {
       throw new UncheckedIOException(
           String.format("Failed to write json to file: %s", outputFile.location()), e);

--- a/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
@@ -38,19 +38,19 @@ public class TestAllManifestsTableTaskParser {
   @Test
   public void nullCheck() throws Exception {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
+      assertThatThrownBy(() -> AllManifestsTableTaskParser.toJson(null, generator))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid manifest task: null");
 
-    assertThatThrownBy(() -> AllManifestsTableTaskParser.toJson(null, generator))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid manifest task: null");
+      assertThatThrownBy(() -> AllManifestsTableTaskParser.toJson(createTask(), null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON generator: null");
 
-    assertThatThrownBy(() -> AllManifestsTableTaskParser.toJson(createTask(), null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON generator: null");
-
-    assertThatThrownBy(() -> AllManifestsTableTaskParser.fromJson(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON node for manifest task: null");
+      assertThatThrownBy(() -> AllManifestsTableTaskParser.fromJson(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON node for manifest task: null");
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
@@ -62,19 +62,19 @@ public class TestDataTaskParser {
   @Test
   public void nullCheck() throws Exception {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
+      assertThatThrownBy(() -> DataTaskParser.toJson(null, generator))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid data task: null");
 
-    assertThatThrownBy(() -> DataTaskParser.toJson(null, generator))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid data task: null");
+      assertThatThrownBy(() -> DataTaskParser.toJson((StaticDataTask) createDataTask(), null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON generator: null");
 
-    assertThatThrownBy(() -> DataTaskParser.toJson((StaticDataTask) createDataTask(), null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON generator: null");
-
-    assertThatThrownBy(() -> DataTaskParser.fromJson(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON node for data task: null");
+      assertThatThrownBy(() -> DataTaskParser.fromJson(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON node for data task: null");
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestFilesTableTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFilesTableTaskParser.java
@@ -38,19 +38,19 @@ public class TestFilesTableTaskParser {
   @Test
   public void nullCheck() throws Exception {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
+      assertThatThrownBy(() -> FilesTableTaskParser.toJson(null, generator))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid files task: null");
 
-    assertThatThrownBy(() -> FilesTableTaskParser.toJson(null, generator))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid files task: null");
+      assertThatThrownBy(() -> FilesTableTaskParser.toJson(createTask(), null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON generator: null");
 
-    assertThatThrownBy(() -> FilesTableTaskParser.toJson(createTask(), null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON generator: null");
-
-    assertThatThrownBy(() -> FilesTableTaskParser.fromJson(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON node for files task: null");
+      assertThatThrownBy(() -> FilesTableTaskParser.fromJson(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON node for files task: null");
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestFileParser.java
@@ -37,19 +37,19 @@ public class TestManifestFileParser {
   @Test
   public void nullCheck() throws Exception {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
+      assertThatThrownBy(() -> ManifestFileParser.toJson(null, generator))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid manifest file: null");
 
-    assertThatThrownBy(() -> ManifestFileParser.toJson(null, generator))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid manifest file: null");
+      assertThatThrownBy(() -> ManifestFileParser.toJson(createManifestFile(), null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON generator: null");
 
-    assertThatThrownBy(() -> ManifestFileParser.toJson(createManifestFile(), null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON generator: null");
-
-    assertThatThrownBy(() -> ManifestFileParser.fromJson(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid JSON node for manifest file: null");
+      assertThatThrownBy(() -> ManifestFileParser.fromJson(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid JSON node for manifest file: null");
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -564,6 +564,8 @@ public class TestTableMetadata {
       // skip the snapshot log
 
       generator.writeEndObject(); // end table metadata object
+
+      generator.flush();
     } catch (IOException e) {
       throw new UncheckedIOException(String.format("Failed to write json for: %s", metadata), e);
     }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -534,9 +534,7 @@ public class TestTableMetadata {
 
   private static String toJsonWithoutSpecAndSchemaList(TableMetadata metadata) {
     StringWriter writer = new StringWriter();
-    try {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       generator.writeStartObject(); // start table metadata object
 
       generator.writeNumberField(FORMAT_VERSION, 1);
@@ -566,8 +564,6 @@ public class TestTableMetadata {
       // skip the snapshot log
 
       generator.writeEndObject(); // end table metadata object
-
-      generator.flush();
     } catch (IOException e) {
       throw new UncheckedIOException(String.format("Failed to write json for: %s", metadata), e);
     }

--- a/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
@@ -55,21 +55,22 @@ public class TestHashWriter {
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), "file:///tmp/table", icebergTblProperties);
 
-    JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter);
-    TableMetadataParser.toJson(tableMetadata, generator);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter)) {
+      TableMetadataParser.toJson(tableMetadata, generator);
 
-    // Expecting to see 3 write() invocations (and therefore incremental hash calculations)
-    verify(hashWriter, times(3)).write(any(char[].class), anyInt(), anyInt());
+      // Expecting to see 3 write() invocations (and therefore incremental hash calculations)
+      verify(hashWriter, times(3)).write(any(char[].class), anyInt(), anyInt());
 
-    // +1 after flushing
-    generator.flush();
-    verify(hashWriter, times(4)).write(any(char[].class), anyInt(), anyInt());
+      // +1 after flushing
+      generator.flush();
+      verify(hashWriter, times(4)).write(any(char[].class), anyInt(), anyInt());
 
-    // Expected hash is calculated on the whole object i.e. without streaming
-    byte[] expectedHash =
-        MessageDigest.getInstance("SHA-256")
-            .digest(TableMetadataParser.toJson(tableMetadata).getBytes(StandardCharsets.UTF_8));
-    assertThat(hashWriter.getHash()).isEqualTo(expectedHash);
-    assertThatThrownBy(() -> hashWriter.getHash()).hasMessageContaining("HashWriter is closed.");
+      // Expected hash is calculated on the whole object i.e. without streaming
+      byte[] expectedHash =
+          MessageDigest.getInstance("SHA-256")
+              .digest(TableMetadataParser.toJson(tableMetadata).getBytes(StandardCharsets.UTF_8));
+      assertThat(hashWriter.getHash()).isEqualTo(expectedHash);
+      assertThatThrownBy(() -> hashWriter.getHash()).hasMessageContaining("HashWriter is closed.");
+    }
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HMSTablePropertyHelper.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HMSTablePropertyHelper.java
@@ -296,8 +296,8 @@ public class HMSTablePropertyHelper {
   }
 
   private static byte[] hashOf(TableMetadata tableMetadata) {
-    try (HashWriter hashWriter = new HashWriter("SHA-256", StandardCharsets.UTF_8)) {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter);
+    try (HashWriter hashWriter = new HashWriter("SHA-256", StandardCharsets.UTF_8);
+        JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter)) {
       TableMetadataParser.toJson(tableMetadata, generator);
       generator.flush();
       return hashWriter.getHash();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -93,6 +93,8 @@ class StreamingOffset extends Offset {
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
+      generator.flush();
+
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -86,16 +86,13 @@ class StreamingOffset extends Offset {
   @Override
   public String json() {
     StringWriter writer = new StringWriter();
-    try {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       generator.writeStartObject();
       generator.writeNumberField(VERSION, CURR_VERSION);
       generator.writeNumberField(SNAPSHOT_ID, snapshotId);
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
-      generator.flush();
-
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -93,6 +93,8 @@ class StreamingOffset extends Offset {
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
+      generator.flush();
+
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -86,16 +86,13 @@ class StreamingOffset extends Offset {
   @Override
   public String json() {
     StringWriter writer = new StringWriter();
-    try {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       generator.writeStartObject();
       generator.writeNumberField(VERSION, CURR_VERSION);
       generator.writeNumberField(SNAPSHOT_ID, snapshotId);
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
-      generator.flush();
-
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -93,6 +93,8 @@ class StreamingOffset extends Offset {
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
+      generator.flush();
+
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StreamingOffset.java
@@ -86,16 +86,13 @@ class StreamingOffset extends Offset {
   @Override
   public String json() {
     StringWriter writer = new StringWriter();
-    try {
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       generator.writeStartObject();
       generator.writeNumberField(VERSION, CURR_VERSION);
       generator.writeNumberField(SNAPSHOT_ID, snapshotId);
       generator.writeNumberField(POSITION, position);
       generator.writeBooleanField(SCAN_ALL_FILES, scanAllFiles);
       generator.writeEndObject();
-      generator.flush();
-
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to write StreamingOffset to json", e);
     }


### PR DESCRIPTION
`com.fasterxml.jackson.core.JsonGenerator` implements Closeable and this PR attempt to close with try-with-resource in existing code base, to allow reuse of internal char buffer.  Verified locally with no introduction of double close

Following the existing pattern in https://github.com/apache/iceberg/blob/6ee69282ab18ef578243da96ab1e522b654811da/core/src/main/java/org/apache/iceberg/util/JsonUtil.java#L74-L87
