### PR TITLE
Kafka Connect: Track control topic offsets as a high-water mark

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -122,8 +122,11 @@ abstract class Channel {
       records.forEach(
           record -> {
             // the consumer stores the offsets that corresponds to the next record to consume,
-            // so increment the record offset by one
-            controlTopicOffsets.put(record.partition(), record.offset() + 1);
+            // so increment the record offset by one. Keep the highest position seen for the
+            // partition: a re-read of the control topic, e.g. after a rebalance resumes from the
+            // last committed offsets, would otherwise move the tracked position backwards and
+            // commit a consumer offset behind records that were already handled.
+            controlTopicOffsets.merge(record.partition(), record.offset() + 1, Long::max);
 
             Event event = AvroUtil.decode(record.value());
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.connect.IcebergSinkConfig;
+import org.apache.iceberg.connect.events.AvroUtil;
+import org.apache.iceberg.connect.events.Event;
+import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.Test;
+
+public class TestChannel extends ChannelTestBase {
+
+  private static final TopicPartition CTL_TOPIC_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+  @Test
+  public void controlTopicOffsetsTrackTheHighestPositionConsumed() {
+    TestChannelImpl channel = startChannel();
+
+    consume(channel, 0, 1, 2, 3, 4);
+    assertThat(channel.controlTopicOffsets()).isEqualTo(ImmutableMap.of(0, 5L));
+
+    // a re-read of the control topic, as happens when a rebalance resumes the consumer from the
+    // last committed offsets, delivers records that were already handled. Only part of the replay
+    // arrives in this batch, so the last record seen is behind the position reached above.
+    consumer.seek(CTL_TOPIC_PARTITION, 1L);
+    consume(channel, 1, 2);
+
+    assertThat(channel.controlTopicOffsets()).isEqualTo(ImmutableMap.of(0, 5L));
+    assertThat(channel.received()).hasSize(7);
+  }
+
+  @Test
+  public void committedControlTopicOffsetsDoNotRegressOnReplay() {
+    TestChannelImpl channel = startChannel();
+
+    consume(channel, 0, 1, 2, 3, 4);
+    consumer.seek(CTL_TOPIC_PARTITION, 1L);
+    consume(channel, 1, 2);
+
+    channel.commitConsumerOffsets();
+
+    // the offset committed for the group is what a restarted channel resumes from, and what the
+    // coordinator stamps on the snapshot, so a regression here is durable
+    assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
+        .containsEntry(CTL_TOPIC_PARTITION, new OffsetAndMetadata(5L));
+  }
+
+  @Test
+  public void controlTopicOffsetsAreTrackedPerPartition() {
+    TestChannelImpl channel = startChannel();
+    TopicPartition other = new TopicPartition(CTL_TOPIC_NAME, 1);
+    consumer.rebalance(Lists.newArrayList(CTL_TOPIC_PARTITION, other));
+    consumer.updateBeginningOffsets(ImmutableMap.of(CTL_TOPIC_PARTITION, 0L, other, 0L));
+
+    addRecord(0, 0);
+    addRecord(0, 1);
+    addRecord(1, 0);
+    channel.consumeAvailable(Duration.ZERO);
+
+    assertThat(channel.controlTopicOffsets()).isEqualTo(ImmutableMap.of(0, 2L, 1, 1L));
+  }
+
+  private TestChannelImpl startChannel() {
+    TestChannelImpl channel =
+        new TestChannelImpl(config, clientFactory, mock(SinkTaskContext.class));
+    channel.start();
+
+    // init consumer after subscribe()
+    initConsumer();
+    return channel;
+  }
+
+  private void consume(TestChannelImpl channel, int... offsets) {
+    for (int offset : offsets) {
+      addRecord(0, offset);
+    }
+    channel.consumeAvailable(Duration.ZERO);
+  }
+
+  private void addRecord(int partition, long offset) {
+    Event event = new Event(CONNECT_CONSUMER_GROUP_ID, new StartCommit(UUID.randomUUID()));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, partition, offset, "key", AvroUtil.encode(event)));
+  }
+
+  private static class TestChannelImpl extends Channel {
+    private final List<Envelope> received = Lists.newArrayList();
+
+    TestChannelImpl(
+        IcebergSinkConfig config, KafkaClientFactory clientFactory, SinkTaskContext context) {
+      super("test", CONNECT_CONSUMER_GROUP_ID + "-test", config, clientFactory, context);
+    }
+
+    @Override
+    protected boolean receive(Envelope envelope) {
+      received.add(envelope);
+      return true;
+    }
+
+    List<Envelope> received() {
+      return received;
+    }
+  }
+}


### PR DESCRIPTION
Closes #17340.

Opening this at @ericyangliu's invitation on the issue — the diagnosis and the production evidence
(149 double-referenced files, ~112k duplicated rows) are his.

## The bug

`Channel.consumeAvailable` recorded the consumed position with an unconditional `put`:

```java
controlTopicOffsets.put(record.partition(), record.offset() + 1);
```

Nothing compares against the value already stored, so any re-read of a control topic partition —
a rebalance resuming the consumer from the last committed group offsets, as in the report — moves
the tracked position **backwards**.

That regression is durable rather than transient, because the map is not just bookkeeping:

- `commitConsumerOffsets()` commits it for the consumer group, so the next restart resumes from the
  regressed offset and re-reads more.
- `Coordinator.commitToTable` merges it into `kafka.connect.offsets` on the snapshot, which is the
  watermark the min-offset filter uses on subsequent commits.

Once the watermark is behind, replayed `DataWritten` envelopes pass that filter. `distinctByKey`
only dedupes within one commit and append does no path-level dedup, so the same data files are
committed again and every scan reads them twice.

## The change

One line: keep the highest position seen for the partition.

```java
controlTopicOffsets.merge(record.partition(), record.offset() + 1, Long::max);
```

This is what every reader of `controlTopicOffsets()` already assumes — `commitToTable` even folds
it in with `Long::max` against the last committed offsets. Making the map itself monotonic is
consistent with that, and it does not change the offsets recorded on the forward path.

## Tests

`TestChannel` drives a `Channel` over a `MockConsumer`. Consuming offsets 0-4 reaches a watermark
of 5; a seek back to 1 then delivers a partial replay ending at offset 2, which is the shape of the
re-read in the report.

- `controlTopicOffsetsTrackTheHighestPositionConsumed` — the map stays at 5. With the fix reverted
  it is 3.
- `committedControlTopicOffsetsDoNotRegressOnReplay` — asserts what the channel actually commits to
  Kafka, `OffsetAndMetadata{offset=5}`. With the fix reverted it commits 3, which is the offset a
  restarted channel would resume from.
- `controlTopicOffsetsAreTrackedPerPartition` — partitions stay independent.

Both regression tests fail on `main` without the change. Full module suite passes (136 tests), as
do `spotlessCheck` and checkstyle.

## Not included

The issue also floats a bounded set of recently committed file locations in the coordinator as a
content-level backstop for replays the offset arithmetic cannot see. That is a design call for
maintainers and a larger change, so I have left it out rather than hold up the correctness fix.
Happy to follow up if it is wanted.
