### PR TITLE
Docs: Bump site Flink version to 2.3

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -113,8 +113,8 @@ markdown_extensions:
 extra:
   icebergVersion: '1.11.0'
   nessieVersion: '0.105.3'
-  flinkVersion: '2.1.0'
-  flinkVersionMajor: '2.1'
+  flinkVersion: '2.3.0'
+  flinkVersionMajor: '2.3'
   sparkVersionMajor: '4.1_2.13'
   slackInviteUrl: &slackInviteUrl 'https://s.apache.org/iceberg-slack'
   social:


### PR DESCRIPTION
Updates the flinkVersion / flinkVersionMajor site variables from 2.1.0 / 2.1 to 2.3.0 / 2.3, matching the current default Flink version on main (defaultFlinkVersions=2.3, Flink dependency pinned to 2.3.0).

Follow-up to #17869