### PR TITLE
Parquet: Fix Variant conversion in default Avro writer

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.variants.Variant;
 
 class ParquetAvro {
 
@@ -220,6 +221,9 @@ class ParquetAvro {
             }
           } else if ("uuid".equals(logicalType.getName())) {
             return (Conversion<T>) uuidConversion;
+          } else if ("variant".equals(logicalType.getName())
+              && Variant.class.isAssignableFrom(datumClass)) {
+            return (Conversion<T>) variantConversion;
           }
           return super.getConversionByClass(datumClass, logicalType);
         }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.data.parquet.InternalReader;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
@@ -73,6 +74,8 @@ import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.RandomUtil;
 import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.Statistics;
@@ -600,6 +603,31 @@ public class TestParquet {
     assertThatThrownBy(() -> ParquetAvroWriter.buildWriter(schema))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Avro writer does not support variant types");
+  }
+
+  @Test
+  void writesVariantWithDefaultAvroWriter() throws IOException {
+    Schema schema = new Schema(required(1, "v", Types.VariantType.get()));
+    GenericData.Record record =
+        new GenericData.Record(AvroSchemaUtil.convert(schema.asStruct(), "table"));
+    Variant expected = Variant.of(Variants.emptyMetadata(), Variants.of(34));
+    record.put("v", expected);
+
+    File file = createTempFile(temp);
+    try (FileAppender<GenericData.Record> writer =
+        Parquet.write(Files.localOutput(file)).schema(schema).build()) {
+      writer.add(record);
+    }
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(Files.localInput(file))
+            .project(schema)
+            .createReaderFunc(fileSchema -> InternalReader.create(schema, fileSchema))
+            .build()) {
+      Variant actual = (Variant) getOnlyElement(rows).get(0);
+      VariantTestUtil.assertEqual(expected.metadata(), actual.metadata());
+      VariantTestUtil.assertEqual(expected.value(), actual.value());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Problem

The default Parquet Avro writer registers `VariantConversion`, but conversion lookup does not recognize implementations of the `Variant` interface.

Values created using `Variant.of(...)` have the runtime type `VariantData`. Avro's exact-class conversion lookup therefore misses the conversion registered for `Variant.class` and attempts to handle the value as an `IndexedRecord`, causing a `ClassCastException`.

### Changes

- Use `VariantConversion` for logical Variant values whose runtime classes implement `Variant`.
- Add a regression test that writes a `GenericData.Record` through the default Parquet writer and verifies the Variant value after reading it back.

### Testing

- `./gradlew :iceberg-parquet:test`
- `./gradlew spotlessCheck`
- `./gradlew build -x test -x integrationTest`
- Manually reproduced the failure and verified the fix using the Iceberg Spark 4.0 runtime.

Closes #17943

