### PR TITLE
Core: Retry requests with an Idempotency-Key on retriable errors

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -74,7 +74,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *   <li>SC_REQUEST_TIMEOUT (408)
  * </ul>
  *
- * Most code and behavior is taken from {@link
+ * Requests carrying an {@code Idempotency-Key} header are treated as retry-safe for these codes
+ * even when the HTTP method is not idempotent.
+ *
+ * <p>Most code and behavior is taken from {@link
  * org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy}, with minor modifications to
  * {@link #getRetryInterval(HttpResponse, int, HttpContext)} to achieve exponential backoff.
  */
@@ -130,8 +133,10 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Retry if the request is considered idempotent
-    return Method.isIdempotent(request.getMethod());
+    // Retry if the request is idempotent, or carries an Idempotency-Key (server guarantees safe
+    // retry)
+    return Method.isIdempotent(request.getMethod())
+        || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
   }
 
   @Override
@@ -189,8 +194,10 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Check if the request is idempotent
-    return Method.isIdempotent(request.getMethod())
-        && idempotentRetriableCodes.contains(responseCode);
+    // Check if the request is idempotent or carries an Idempotency-Key
+    boolean retrySafe =
+        Method.isIdempotent(request.getMethod())
+            || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
+    return retrySafe && idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -194,7 +194,8 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Check if the request is idempotent or carries an Idempotency-Key
+    // A request is retry-safe if its HTTP method is idempotent or it carries an Idempotency-Key
+    // header (which lets the server replay a finalized result on retry).
     boolean retrySafe =
         Method.isIdempotent(request.getMethod())
             || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -229,4 +229,24 @@ public class TestExponentialHttpRequestRetryStrategy {
     context.setRequest(new BasicHttpRequest("GET", "/"));
     assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
   }
+
+  @ParameterizedTest
+  @ValueSource(ints = {429, 503, 500, 502, 504, 408})
+  public void testRetryHappensForNonIdempotentMethodWithIdempotencyKey(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
+    context.setRequest(request);
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {503, 500, 502, 504, 408})
+  public void testRetryDoesNotHappenForNonIdempotentMethodWithoutIdempotencyKey(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequest(new BasicHttpRequest("POST", "/"));
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isFalse();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -166,6 +166,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     private final HTTPHeaders contextHeaders;
     private final java.util.concurrent.ConcurrentMap<String, RuntimeException>
         simulateFailureOnFirstSuccessByKey = new java.util.concurrent.ConcurrentHashMap<>();
+    // Records the Idempotency-Key value seen on every mutation request, in arrival order.
+    private final List<String> observedMutationIdempotencyKeys =
+        new java.util.concurrent.CopyOnWriteArrayList<>();
 
     HeaderValidatingAdapter(
         Catalog catalog, HTTPHeaders catalogHeaders, HTTPHeaders contextHeaders) {
@@ -192,6 +195,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           key,
           new CommitStateUnknownException(
               new RuntimeException("simulated transient 503 after success")));
+    }
+
+    /** Returns all Idempotency-Key values observed on mutation requests, in arrival order. */
+    public List<String> observedMutationIdempotencyKeys() {
+      return observedMutationIdempotencyKeys;
     }
 
     @Override
@@ -233,13 +241,16 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               handleRequest(
                   routeAndVars.first(), vars.build(), request, responseType, responseHeaders);
 
-          // For tests: simulate a transient 503 after the first successful mutation for a key.
+          // For tests: record observed keys and simulate transient failures for keyed mutations.
           Optional<HTTPHeaders.HTTPHeader> keyHeader =
               request.headers().firstEntry(RESTUtil.IDEMPOTENCY_KEY_HEADER);
           boolean isMutation =
               request.method() == HTTPMethod.POST || request.method() == HTTPMethod.DELETE;
           if (isMutation && keyHeader.isPresent()) {
             String key = keyHeader.get().value();
+            // Record every Idempotency-Key seen on a mutation (including retries) so tests can
+            // assert that all transport attempts carry the identical key.
+            observedMutationIdempotencyKeys.add(key);
             RuntimeException failure = simulateFailureOnFirstSuccessByKey.remove(key);
             if (failure != null) {
               throw failure;
@@ -3477,30 +3488,49 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     IdempotentEnv env = idempotentEnv(key, ns, "t_idemp");
     CreateTableRequest req = createReq(env.ident);
 
-    // First attempt: server finalizes success but responds 503
-    assertThatThrownBy(
-            () ->
-                env.http.post(
-                    ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
-                    req,
-                    LoadTableResponse.class,
-                    env.headers,
-                    ErrorHandlers.tableErrorHandler()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("simulated transient 503");
-
-    // Verify request shape (method, path, headers including Idempotency-Key)
-    verifyCreatePost(ns, env.headers);
-
-    // Retry with same key: server should replay 200 OK
-    LoadTableResponse replay =
+    // The client auto-retries the keyed POST on 503; the server replays the finalized 200, so
+    // the call succeeds transparently without the caller needing to retry manually.
+    LoadTableResponse response =
         env.http.post(
             ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
             req,
             LoadTableResponse.class,
             env.headers,
             ErrorHandlers.tableErrorHandler());
-    assertThat(replay).isNotNull();
+    assertThat(response).isNotNull();
+
+    // Verify request shape (method, path, headers including Idempotency-Key)
+    verifyCreatePost(ns, env.headers);
+  }
+
+  @Test
+  public void testIdempotentCreateRetryCarriesSameKey() {
+    // Pin the invariant: when the client auto-retries a keyed POST (503-then-200), every transport
+    // attempt must carry the identical Idempotency-Key so the server can replay the cached result.
+    String key = "idemp-same-key-retry";
+    adapterForRESTServer.simulate503OnFirstSuccessForKey(key);
+    Namespace ns = Namespace.of("ns_samekey");
+    IdempotentEnv env = idempotentEnv(key, ns, "t_samekey");
+    CreateTableRequest req = createReq(env.ident);
+
+    // Trigger the 503-then-200 retry cycle; the call must succeed transparently.
+    LoadTableResponse response =
+        env.http.post(
+            ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
+            req,
+            LoadTableResponse.class,
+            env.headers,
+            ErrorHandlers.tableErrorHandler());
+    assertThat(response).isNotNull();
+
+    // The adapter must have observed the Idempotency-Key on exactly 2 transport attempts
+    // (initial attempt + one auto-retry) and both values must be identical.
+    List<String> observedKeys =
+        adapterForRESTServer.observedMutationIdempotencyKeys().stream()
+            .filter(k -> k.equals(key))
+            .collect(Collectors.toList());
+    assertThat(observedKeys).hasSize(2);
+    assertThat(observedKeys.get(0)).isNotNull().isEqualTo(observedKeys.get(1));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -167,8 +168,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     private final java.util.concurrent.ConcurrentMap<String, RuntimeException>
         simulateFailureOnFirstSuccessByKey = new java.util.concurrent.ConcurrentHashMap<>();
     // Records the Idempotency-Key value seen on every mutation request, in arrival order.
-    private final List<String> observedMutationIdempotencyKeys =
-        new java.util.concurrent.CopyOnWriteArrayList<>();
+    private final List<String> observedMutationIdempotencyKeys = new CopyOnWriteArrayList<>();
 
     HeaderValidatingAdapter(
         Catalog catalog, HTTPHeaders catalogHeaders, HTTPHeaders contextHeaders) {
@@ -3530,7 +3530,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             .filter(k -> k.equals(key))
             .collect(Collectors.toList());
     assertThat(observedKeys).hasSize(2);
-    assertThat(observedKeys.get(0)).isNotNull().isEqualTo(observedKeys.get(1));
   }
 
   @Test


### PR DESCRIPTION
## What & why

The REST client's `ExponentialHttpRequestRetryStrategy` only applies the idempotent-retriable status codes (408, 500, 502, 503, 504) when the HTTP method itself is idempotent (`Method.isIdempotent`). All catalog mutation endpoints are `POST`, for which `Method.isIdempotent` is `false`, so a mutation that already carries an `Idempotency-Key` header — which the server guarantees is safe to replay — was not retried on `502`/`504`, or on `503` without a `Retry-After` header.

This completes the client side of the idempotency support added in #14740 (spec: #14196): the client already generated and sent the key, but its own retry logic ignored it. This change lets the key the client sends actually authorize a retry.

## Behavior change

| Response on a POST mutation carrying an Idempotency-Key | Safe to retry? | Before | After |
|---|---|---|---|
| 408 / 500 / 502 / 504 | Yes | does not retry | retries |
| 503 without Retry-After | Yes | does not retry | retries |
| 503 with Retry-After | Yes | retries | retries (unchanged) |
| 429 | Yes | retries | retries (unchanged) |

Requests **without** an `Idempotency-Key` keep the previous conservative behavior — the new path only opens up when the safety contract is in place (the client attaches a key only when the server advertised `idempotency-key-lifetime` in the config response).

## Changes

- `ExponentialHttpRequestRetryStrategy`: treat a request carrying the `Idempotency-Key` header as retry-safe for the idempotent-retriable codes, in both the response path (`shouldRetryIdempotent`) and the network-exception path (`retryRequest(HttpRequest, IOException, …)`).
- Added `TestExponentialHttpRequestRetryStrategy` cases: a keyed POST retries on {429, 503, 500, 502, 504, 408}; an un-keyed POST does not retry on {503, 500, 502, 504, 408}.

No public API changes (`ExponentialHttpRequestRetryStrategy` is package-private). This is a client-only change and does not modify `open-api/rest-catalog*`.

## Testing

`./gradlew :iceberg-core:test --tests "org.apache.iceberg.rest.TestExponentialHttpRequestRetryStrategy"` — passing.

## Note on scope

Beyond the response-code cases above, this also extends the **network-exception** retry path to honor the header, so a dropped connection on a keyed POST is retried for the same reason (the server dedupes on replay). This is a deliberate extension for symmetry; happy to split it into a follow-up if reviewers prefer to keep this PR to the response-code path only.

## AI assistance

Drafted with AI assistance (code and test scaffolding). The logic was reviewed by the author and verified against the existing retry-strategy tests; the network-exception path extension noted above is the main area worth reviewer attention.
