### PR TITLE
Spark: Stop async preload when either limit is reached

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -479,7 +479,8 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
 
     // Continue loading more snapshots within safety limits
     if (current != null) {
-      while ((queuedRowCount.get() < targetRows || queuedFileCount.get() < targetFiles)
+      while (shouldContinueInitialPreload(
+              queuedRowCount.get(), queuedFileCount.get(), targetRows, targetFiles)
           && current.snapshotId() != preloadEndSnapshot.snapshotId()) {
         current = nextValidSnapshot(current);
         if (current != null) {
@@ -490,6 +491,11 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
         }
       }
     }
+  }
+
+  static boolean shouldContinueInitialPreload(
+      long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
+    return queuedRows < targetRows && queuedFiles < targetFiles;
   }
 
   private Snapshot initialPreloadEndSnapshot() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -493,6 +493,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     }
   }
 
+  @VisibleForTesting
   static boolean shouldContinueInitialPreload(
       long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
     return queuedRows < targetRows && queuedFiles < targetFiles;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -32,8 +32,7 @@ class TestAsyncSparkMicroBatchPlanner {
 
   @Test
   void initialPreloadStopsWhenEitherLimitIsReached() {
-    assertThat(
-            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+    assertThat(AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
         .isFalse();
     assertThat(
             AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -31,6 +31,16 @@ import org.junit.jupiter.api.Test;
 class TestAsyncSparkMicroBatchPlanner {
 
   @Test
+  void initialPreloadStopsWhenEitherLimitIsReached() {
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+        .isFalse();
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))
+        .isFalse();
+  }
+
+  @Test
   void reachedAvailableNowCapReturnsTrueOnlyForExactCapSnapshot() {
     Snapshot capSnapshot = mockSnapshot(10L);
     Snapshot laterSnapshotWithHigherId = mockSnapshot(20L);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -479,7 +479,8 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
 
     // Continue loading more snapshots within safety limits
     if (current != null) {
-      while ((queuedRowCount.get() < targetRows || queuedFileCount.get() < targetFiles)
+      while (shouldContinueInitialPreload(
+              queuedRowCount.get(), queuedFileCount.get(), targetRows, targetFiles)
           && current.snapshotId() != preloadEndSnapshot.snapshotId()) {
         current = nextValidSnapshot(current);
         if (current != null) {
@@ -490,6 +491,11 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
         }
       }
     }
+  }
+
+  static boolean shouldContinueInitialPreload(
+      long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
+    return queuedRows < targetRows && queuedFiles < targetFiles;
   }
 
   private Snapshot initialPreloadEndSnapshot() {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -493,6 +493,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     }
   }
 
+  @VisibleForTesting
   static boolean shouldContinueInitialPreload(
       long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
     return queuedRows < targetRows && queuedFiles < targetFiles;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -32,8 +32,7 @@ class TestAsyncSparkMicroBatchPlanner {
 
   @Test
   void initialPreloadStopsWhenEitherLimitIsReached() {
-    assertThat(
-            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+    assertThat(AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
         .isFalse();
     assertThat(
             AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -31,6 +31,16 @@ import org.junit.jupiter.api.Test;
 class TestAsyncSparkMicroBatchPlanner {
 
   @Test
+  void initialPreloadStopsWhenEitherLimitIsReached() {
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+        .isFalse();
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))
+        .isFalse();
+  }
+
+  @Test
   void reachedAvailableNowCapReturnsTrueOnlyForExactCapSnapshot() {
     Snapshot capSnapshot = mockSnapshot(10L);
     Snapshot laterSnapshotWithHigherId = mockSnapshot(20L);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -479,7 +479,8 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
 
     // Continue loading more snapshots within safety limits
     if (current != null) {
-      while ((queuedRowCount.get() < targetRows || queuedFileCount.get() < targetFiles)
+      while (shouldContinueInitialPreload(
+              queuedRowCount.get(), queuedFileCount.get(), targetRows, targetFiles)
           && current.snapshotId() != preloadEndSnapshot.snapshotId()) {
         current = nextValidSnapshot(current);
         if (current != null) {
@@ -490,6 +491,11 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
         }
       }
     }
+  }
+
+  static boolean shouldContinueInitialPreload(
+      long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
+    return queuedRows < targetRows && queuedFiles < targetFiles;
   }
 
   private Snapshot initialPreloadEndSnapshot() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -493,6 +493,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     }
   }
 
+  @VisibleForTesting
   static boolean shouldContinueInitialPreload(
       long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
     return queuedRows < targetRows && queuedFiles < targetFiles;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -31,6 +31,15 @@ import org.junit.jupiter.api.Test;
 class TestAsyncSparkMicroBatchPlanner {
 
   @Test
+  void initialPreloadStopsWhenEitherLimitIsReached() {
+    assertThat(AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+        .isFalse();
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))
+        .isFalse();
+  }
+
+  @Test
   void reachedAvailableNowCapReturnsTrueOnlyForExactCapSnapshot() {
     Snapshot capSnapshot = mockSnapshot(10L);
     Snapshot laterSnapshotWithHigherId = mockSnapshot(20L);

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -479,7 +479,8 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
 
     // Continue loading more snapshots within safety limits
     if (current != null) {
-      while ((queuedRowCount.get() < targetRows || queuedFileCount.get() < targetFiles)
+      while (shouldContinueInitialPreload(
+              queuedRowCount.get(), queuedFileCount.get(), targetRows, targetFiles)
           && current.snapshotId() != preloadEndSnapshot.snapshotId()) {
         current = nextValidSnapshot(current);
         if (current != null) {
@@ -490,6 +491,11 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
         }
       }
     }
+  }
+
+  static boolean shouldContinueInitialPreload(
+      long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
+    return queuedRows < targetRows && queuedFiles < targetFiles;
   }
 
   private Snapshot initialPreloadEndSnapshot() {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -493,6 +493,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     }
   }
 
+  @VisibleForTesting
   static boolean shouldContinueInitialPreload(
       long queuedRows, long queuedFiles, long targetRows, long targetFiles) {
     return queuedRows < targetRows && queuedFiles < targetFiles;

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -31,6 +31,15 @@ import org.junit.jupiter.api.Test;
 class TestAsyncSparkMicroBatchPlanner {
 
   @Test
+  void initialPreloadStopsWhenEitherLimitIsReached() {
+    assertThat(AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(1L, 100L, 100_000L, 100L))
+        .isFalse();
+    assertThat(
+            AsyncSparkMicroBatchPlanner.shouldContinueInitialPreload(100_000L, 1L, 100_000L, 100L))
+        .isFalse();
+  }
+
+  @Test
   void reachedAvailableNowCapReturnsTrueOnlyForExactCapSnapshot() {
     Snapshot capSnapshot = mockSnapshot(10L);
     Snapshot laterSnapshotWithHigherId = mockSnapshot(20L);


### PR DESCRIPTION
Async micro-batch initial preload currently combines its row and file safety limits with OR, so it keeps loading snapshots until both limits are reached. With skewed snapshots, this can substantially over-buffer files or rows during catch-up.

This changes the condition to AND so preload stops when either configured safety limit is reached across Spark 3.5, 4.0, 4.1, and 4.2. It also adds direct regression coverage for both asymmetric cases.

Fixes #17951

Tests:
- Focused `TestAsyncSparkMicroBatchPlanner` passes for Spark 3.5, 4.0, and 4.1
- Spark 4.2 focused test is currently blocked before test execution by an existing `main` compile failure in `RewriteDataFilesSparkAction` and `RewritePositionDeleteFilesSparkAction`
- `./gradlew -DsparkVersions=3.5,4.0,4.1,4.2 spotlessApply`

---
**AI Disclosure**
- Model: GPT-5 (Codex)
- Prompt Summary: Diagnose and fix async Spark micro-batch initial preload exceeding either configured safety limit, add regression tests, and prepare the contribution.