### PR TITLE
Spark 4.2: Fix build failures from missed cleanups

### DIFF
--- a/spark/v4.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v4.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -861,7 +861,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
     assumeThat(catalogName).isEqualTo(SparkCatalogConfig.HADOOP.catalogName());
 
     TableIdentifier identifier =
-        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replaceAll("`", ""));
+        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replace("`", ""));
     sql(
         "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg",
         tableName(QUOTED_SPECIAL_CHARS_TABLE_NAME));
@@ -899,7 +899,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
     assumeThat(catalogName).isEqualTo(SparkCatalogConfig.HADOOP.catalogName());
 
     TableIdentifier identifier =
-        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replaceAll("`", ""));
+        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replace("`", ""));
     sql(
         "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg",
         tableName(QUOTED_SPECIAL_CHARS_TABLE_NAME));
@@ -942,7 +942,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
     assumeThat(catalogName).isEqualTo(SparkCatalogConfig.HADOOP.catalogName());
 
     TableIdentifier identifier =
-        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replaceAll("`", ""));
+        TableIdentifier.of("default", QUOTED_SPECIAL_CHARS_TABLE_NAME.replace("`", ""));
     sql(
         "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg",
         tableName(QUOTED_SPECIAL_CHARS_TABLE_NAME));

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -52,7 +52,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Queues;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -258,7 +257,7 @@ public class RewriteDataFilesSparkAction
       RewriteDataFilesCommitManager commitManager) {
     ExecutorService rewriteService = rewriteService();
 
-    ConcurrentLinkedQueue<RewriteFileGroup> rewrittenGroups = Queues.newConcurrentLinkedQueue();
+    ConcurrentLinkedQueue<RewriteFileGroup> rewrittenGroups = new ConcurrentLinkedQueue<>();
 
     Tasks.Builder<RewriteFileGroup> rewriteTaskBuilder =
         Tasks.foreach(plan.groups())

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -52,7 +52,6 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Queues;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -199,7 +198,7 @@ public class RewritePositionDeleteFilesSparkAction
     ExecutorService rewriteService = rewriteService();
 
     ConcurrentLinkedQueue<RewritePositionDeletesGroup> rewrittenGroups =
-        Queues.newConcurrentLinkedQueue();
+        new ConcurrentLinkedQueue<>();
 
     Tasks.Builder<RewritePositionDeletesGroup> rewriteTaskBuilder =
         Tasks.foreach(plan.groups())

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
@@ -294,7 +294,7 @@ public class CreateChangelogViewProcedure extends BaseProcedure {
     if (delimited) {
       return columnName;
     } else {
-      return "`" + columnName.replaceAll("`", "``") + "`";
+      return "`" + columnName.replace("`", "``") + "`";
     }
   }
 


### PR DESCRIPTION
The Spark 4.2 module was branched from v4.1 before two cleanups landed, so its copies still reference code that no longer exists:

- #17888 removed Guava Queues from the bundled Guava jar and replaced its usages with JDK equivalents. The two rewrite actions still import it, which fails compileScala.
- #17484 added a checkstyle rule forbidding replaceAll for literal replacements and fixed every site, but not the 4.2 copies.

Both changes mirror what v3.5, v4.0 and v4.1 already have. Since defaultSparkVersions is 4.2, this breaks a bare ./gradlew build.