### PR TITLE
Core: Make MetricsConfig.forTable collect full metrics for order preserving transform source fields for V4 tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -118,7 +118,12 @@ public final class MetricsConfig implements Serializable {
    * @return a metrics config for the given table
    */
   public static MetricsConfig forTable(Table table) {
-    return from(table.properties(), table.schema(), table.sortOrder());
+    return from(
+        table.properties(),
+        table.schema(),
+        table.sortOrder(),
+        table.spec(),
+        TableUtil.formatVersion(table));
   }
 
   public Iterable<Integer> metricsFieldIds() {
@@ -255,9 +260,36 @@ public final class MetricsConfig implements Serializable {
    * @return metrics configuration
    */
   public static MetricsConfig from(Map<String, String> props, Schema schema, SortOrder order) {
-    int maxInferredDefaultColumns = maxInferredColumnDefaults(props);
     Map<Integer, String> idToName = Maps.newHashMap();
     Map<String, MetricsMode> columnModes = Maps.newHashMap();
+    MetricsMode defaultMode = defaultModeFor(props, schema, order, columnModes, idToName);
+    return new MetricsConfig(columnModes, defaultMode, idToName);
+  }
+
+  private static MetricsConfig from(
+      Map<String, String> props,
+      Schema schema,
+      SortOrder order,
+      PartitionSpec spec,
+      int formatVersion) {
+    Map<Integer, String> idToName = Maps.newHashMap();
+    Map<String, MetricsMode> columnModes = Maps.newHashMap();
+    MetricsMode defaultMode = defaultModeFor(props, schema, order, columnModes, idToName);
+
+    if (formatVersion >= 4) {
+      configureFullMetricsForPartitionSourceColumns(spec, schema, columnModes, idToName);
+    }
+
+    return new MetricsConfig(columnModes, defaultMode, idToName);
+  }
+
+  private static MetricsMode defaultModeFor(
+      Map<String, String> props,
+      Schema schema,
+      SortOrder order,
+      Map<String, MetricsMode> columnModes,
+      Map<Integer, String> idToName) {
+    int maxInferredDefaultColumns = maxInferredColumnDefaults(props);
 
     // Handle user override of default mode
     MetricsMode defaultMode;
@@ -302,7 +334,18 @@ public final class MetricsConfig implements Serializable {
           }
         });
 
-    // Handle user overrides of defaults
+    applyColumnOverrides(props, schema, defaultMode, columnModes, idToName);
+
+    return defaultMode;
+  }
+
+  // Handle user overrides of defaults
+  private static void applyColumnOverrides(
+      Map<String, String> props,
+      Schema schema,
+      MetricsMode defaultMode,
+      Map<String, MetricsMode> columnModes,
+      Map<Integer, String> idToName) {
     for (String key : props.keySet()) {
       if (key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX)) {
         String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
@@ -314,8 +357,25 @@ public final class MetricsConfig implements Serializable {
         }
       }
     }
+  }
 
-    return new MetricsConfig(columnModes, defaultMode, idToName);
+  private static void configureFullMetricsForPartitionSourceColumns(
+      PartitionSpec spec,
+      Schema schema,
+      Map<String, MetricsMode> columnModes,
+      Map<Integer, String> idToName) {
+    // configure metrics collection for partition fields ignoring any overrides
+    for (PartitionField field : spec.fields()) {
+      if (!field.transform().preservesOrder()) {
+        continue;
+      }
+
+      String name = schema.findColumnName(field.sourceId());
+      if (name != null) {
+        columnModes.put(name, MetricsModes.Full.get());
+        idToName.put(field.sourceId(), name);
+      }
+    }
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
@@ -48,7 +48,7 @@ public class TestMetricsConfig {
           optional(DATA, "data", Types.StringType.get()));
 
   @Test
-  public void testIdentityPartitionColumnFull() throws IOException {
+  public void testIdentityPartitionColumnFullInV4() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).identity("category").build();
     Table table =
         TestTables.create(temp, "identity", PARTITIONED_SCHEMA, spec, 4, ImmutableMap.of());
@@ -58,7 +58,7 @@ public class TestMetricsConfig {
   }
 
   @Test
-  public void testPartitionColumnCannotBeDisabled() throws IOException {
+  public void testPartitionColumnCannotBeDisabledInV4() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).identity("category").build();
     Map<String, String> props =
         ImmutableMap.of(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "category", "none");
@@ -70,7 +70,7 @@ public class TestMetricsConfig {
   }
 
   @Test
-  public void testBucketPartitionColumnIgnored() throws IOException {
+  public void testBucketPartitionColumnIgnoredInV4() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).bucket("category", 4).build();
     Table table =
         TestTables.create(temp, "bucket-v4", PARTITIONED_SCHEMA, spec, 4, ImmutableMap.of());
@@ -90,7 +90,7 @@ public class TestMetricsConfig {
   }
 
   @Test
-  public void testColumnModeAndFieldIdsFromPartitionSpec() throws IOException {
+  public void testColumnModeAndFieldIdsFromPartitionSpecInV4() throws IOException {
     PartitionSpec spec =
         PartitionSpec.builderFor(PARTITIONED_SCHEMA).day("event_time").identity("category").build();
     Table table =

--- a/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
@@ -22,13 +22,99 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestMetricsConfig {
+
+  @TempDir private File temp;
+
+  private static final int ID = 1;
+  private static final int EVENT_TIME = 2;
+  private static final int CATEGORY = 3;
+  private static final int DATA = 4;
+
+  private static final Schema PARTITIONED_SCHEMA =
+      new Schema(
+          required(ID, "id", Types.IntegerType.get()),
+          optional(EVENT_TIME, "event_time", Types.TimestampType.withoutZone()),
+          optional(CATEGORY, "category", Types.StringType.get()),
+          optional(DATA, "data", Types.StringType.get()));
+
+  @Test
+  public void testIdentityPartitionColumnFull() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).identity("category").build();
+    Table table =
+        TestTables.create(temp, "identity", PARTITIONED_SCHEMA, spec, 4, ImmutableMap.of());
+
+    assertThat(MetricsConfig.forTable(table).columnMode(CATEGORY))
+        .isEqualTo(MetricsModes.Full.get());
+  }
+
+  @Test
+  public void testPartitionColumnCannotBeDisabled() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).identity("category").build();
+    Map<String, String> props =
+        ImmutableMap.of(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "category", "none");
+    Table table = TestTables.create(temp, "identity-override", PARTITIONED_SCHEMA, spec, 4, props);
+
+    assertThat(MetricsConfig.forTable(table).columnMode(CATEGORY))
+        .as("column config should not be able to disable metrics for a partition column")
+        .isEqualTo(MetricsModes.Full.get());
+  }
+
+  @Test
+  public void testBucketPartitionColumnIgnored() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).bucket("category", 4).build();
+    Table table =
+        TestTables.create(temp, "bucket-v4", PARTITIONED_SCHEMA, spec, 4, ImmutableMap.of());
+
+    assertThat(MetricsConfig.forTable(table).columnMode(CATEGORY))
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+  }
+
+  @Test
+  public void testPartitionSpecIgnoredBeforeV4() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(PARTITIONED_SCHEMA).identity("category").build();
+    Table table =
+        TestTables.create(temp, "identity-v3", PARTITIONED_SCHEMA, spec, 3, ImmutableMap.of());
+
+    assertThat(MetricsConfig.forTable(table).columnMode(CATEGORY))
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+  }
+
+  @Test
+  public void testColumnModeAndFieldIdsFromPartitionSpec() throws IOException {
+    PartitionSpec spec =
+        PartitionSpec.builderFor(PARTITIONED_SCHEMA).day("event_time").identity("category").build();
+    Table table =
+        TestTables.create(temp, "day-and-identity", PARTITIONED_SCHEMA, spec, 4, ImmutableMap.of());
+
+    MetricsConfig config = MetricsConfig.forTable(table);
+
+    assertThat(config.metricsFieldIds())
+        .as("Should track field ids for partition and non-partition columns")
+        .containsExactlyInAnyOrder(ID, EVENT_TIME, CATEGORY, DATA);
+
+    assertThat(config.columnMode(EVENT_TIME))
+        .as("day partition source column should get full metrics")
+        .isEqualTo(MetricsModes.Full.get());
+    assertThat(config.columnMode(CATEGORY))
+        .as("identity partition source column should get full metrics")
+        .isEqualTo(MetricsModes.Full.get());
+    assertThat(config.columnMode(ID))
+        .as("non-partition column should keep the default mode")
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+    assertThat(config.columnMode(DATA))
+        .as("non-partition column should keep the default mode")
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+  }
 
   @Test
   public void testNestedStruct() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/WriterTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/WriterTestBase.java
@@ -21,15 +21,19 @@ package org.apache.iceberg.connect.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.TableReference;
@@ -64,7 +68,7 @@ public class WriterTestBase {
   public void before() {
     fileIO = new InMemoryFileIO();
 
-    table = mock(Table.class);
+    table = mock(Table.class, withSettings().extraInterfaces(HasTableOperations.class));
     when(table.schema()).thenReturn(SCHEMA);
     when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
     when(table.io()).thenReturn(fileIO);
@@ -72,6 +76,12 @@ public class WriterTestBase {
         .thenReturn(LocationProviders.locationsFor("file", ImmutableMap.of()));
     when(table.encryption()).thenReturn(PlaintextEncryptionManager.instance());
     when(table.properties()).thenReturn(ImmutableMap.of());
+
+    TableOperations ops = mock(TableOperations.class);
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.formatVersion()).thenReturn(2);
+    when(ops.current()).thenReturn(metadata);
+    when(((HasTableOperations) table).operations()).thenReturn(ops);
   }
 
   protected WriteResult writeTest(


### PR DESCRIPTION
For v4 tables, collect untruncated  metrics on the source column of any order-preserving partition transform, so bounds are usable to derive a partition value from stats instead of storing it explicitly. This is one of the primitives needed to eventually drop the v4 partition tuple. Note that we are not yet collecting information on bucket outputs.

Currently, all file format writers explicitly call MetricsConfig.forTable to build MetricsConfig instances. This change just adds the logic to the implementation of that API to require collecting full/untruncated stats for source columns of partition fields for V4 tables. If a user specified property says to not collect those, that property is ignored as it is ultimately neccessary to have these stats for the goal of dropping the partition tuple write requirement in V4.