### PR TITLE
GCP: Reject invalid GCS buffered read ranges

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -146,6 +146,7 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     Preconditions.checkState(!closed, "Cannot read: already closed");
+    Preconditions.checkPositionIndexes(off, off + len, b.length);
     byteBuffer = byteBuffer != null && byteBuffer.array() == b ? byteBuffer : ByteBuffer.wrap(b);
     int bytesRead = read(channel, byteBuffer, off, len);
     if (bytesRead == -1) {
@@ -195,7 +196,7 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
   private int read(ReadChannel readChannel, ByteBuffer buffer, int off, int len)
       throws IOException {
     buffer.position(off);
-    buffer.limit(Math.min(off + len, buffer.capacity()));
+    buffer.limit(off + len);
     try {
       return readChannel.read(buffer);
     } catch (IOException e) {

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -127,11 +127,15 @@ public class TestGCSInputStream {
     try (SeekableInputStream in =
         new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
       byte[] buffer = new byte[4];
-      assertThatThrownBy(() -> in.read(buffer, 2, 3)).isInstanceOf(IndexOutOfBoundsException.class);
+      assertThatThrownBy(() -> in.read(buffer, 2, 3))
+          .isInstanceOf(IndexOutOfBoundsException.class)
+          .hasMessageContaining("end index (5)");
       assertThatThrownBy(() -> in.read(buffer, -1, 1))
-          .isInstanceOf(IndexOutOfBoundsException.class);
+          .isInstanceOf(IndexOutOfBoundsException.class)
+          .hasMessageContaining("start index (-1)");
       assertThatThrownBy(() -> in.read(buffer, 0, -1))
-          .isInstanceOf(IndexOutOfBoundsException.class);
+          .isInstanceOf(IndexOutOfBoundsException.class)
+          .hasMessageContaining("end index (-1)");
     }
   }
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -114,8 +114,24 @@ public class TestGCSInputStream {
       assertThat(bytesRead).isEqualTo(dataSize);
       assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
 
-      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      assertThat(in.read(actual, 0, actual.length)).isEqualTo(EOF);
       assertThat(in.getPos()).isEqualTo(dataSize);
+    }
+  }
+
+  @Test
+  void bufferedReadRejectsInvalidRanges() throws Exception {
+    BlobId uri = BlobId.fromGsUtilUri("gs://bucket/path/to/read-bounds.dat");
+    writeGCSData(uri, new byte[] {1, 2, 3, 4});
+
+    try (SeekableInputStream in =
+        new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
+      byte[] buffer = new byte[4];
+      assertThatThrownBy(() -> in.read(buffer, 2, 3)).isInstanceOf(IndexOutOfBoundsException.class);
+      assertThatThrownBy(() -> in.read(buffer, -1, 1))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+      assertThatThrownBy(() -> in.read(buffer, 0, -1))
+          .isInstanceOf(IndexOutOfBoundsException.class);
     }
   }
 


### PR DESCRIPTION
## Summary

- validate `offset` and `length` in `GCSInputStream.read(byte[], int, int)`
- stop silently truncating reads whose requested range exceeds the destination buffer
- cover overflow, negative offset, and negative length cases

## Motivation

`GCSInputStream` used `Math.min` when setting the reusable `ByteBuffer` limit. A request such as reading three bytes at offset two into a four-byte array was silently shortened to two bytes instead of throwing `IndexOutOfBoundsException` as required by the `InputStream` contract.

The existing EOF test also passed a length larger than its buffer; it now uses the buffer's actual length so it continues to exercise EOF with a valid range.

## Testing

- `./gradlew :iceberg-gcp:spotlessApply :iceberg-gcp:test`

---
**AI Disclosure**
- Model: GPT-5 (Codex)
- Platform/Tool: OpenAI Codex
- Human Oversight: fully reviewed
- Prompt Summary: Used a detailed, repository-aware prompt to inspect buffered read contracts, reproduce silent range truncation, implement explicit validation, review the resulting diff, and run the complete affected module test suite.
