### PR TITLE
Dell: Validate ECS stream seeks and closed state

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * A {@link SeekableInputStream} implementation that warp {@link S3Client#readObjectStream(String,
@@ -69,6 +70,7 @@ class EcsSeekableInputStream extends SeekableInputStream {
 
   @Override
   public void seek(long inputNewPos) {
+    Preconditions.checkArgument(inputNewPos >= 0, "Position is negative: %s", inputNewPos);
     if (pos == inputNewPos) {
       return;
     }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -52,6 +52,7 @@ class EcsSeekableInputStream extends SeekableInputStream {
   private long pos = -1;
 
   private InputStream internalStream;
+  private boolean closed;
 
   private final Counter readBytes;
   private final Counter readOperations;
@@ -70,7 +71,8 @@ class EcsSeekableInputStream extends SeekableInputStream {
 
   @Override
   public void seek(long inputNewPos) {
-    Preconditions.checkArgument(inputNewPos >= 0, "Position is negative: %s", inputNewPos);
+    Preconditions.checkState(!closed, "already closed");
+    Preconditions.checkArgument(inputNewPos >= 0, "position is negative: %s", inputNewPos);
     if (pos == inputNewPos) {
       return;
     }
@@ -98,6 +100,7 @@ class EcsSeekableInputStream extends SeekableInputStream {
   }
 
   private void checkAndUseNewPos() throws IOException {
+    Preconditions.checkState(!closed, "Cannot read: already closed");
     if (newPos < 0) {
       return;
     }
@@ -118,6 +121,7 @@ class EcsSeekableInputStream extends SeekableInputStream {
 
   @Override
   public void close() throws IOException {
+    closed = true;
     if (internalStream != null) {
       internalStream.close();
     }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.dell.ecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
@@ -88,6 +89,24 @@ public class TestEcsSeekableInputStream {
       assertThat(new String(buffer, StandardCharsets.UTF_8))
           .as("The first 3 bytes should be 012")
           .isEqualTo("012");
+    }
+  }
+
+  @Test
+  void seekRejectsNegativePositionWithoutChangingState() throws IOException {
+    String objectName = rule.randomObjectName();
+    rule.client()
+        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      input.seek(2);
+      assertThatThrownBy(() -> input.seek(-1))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Position is negative: -1");
+      assertThat(input.getPos()).isEqualTo(2);
+      assertThat(input.read()).isEqualTo('2');
     }
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -28,6 +28,8 @@ import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestEcsSeekableInputStream {
 
@@ -104,9 +106,39 @@ public class TestEcsSeekableInputStream {
       input.seek(2);
       assertThatThrownBy(() -> input.seek(-1))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Position is negative: -1");
+          .hasMessage("position is negative: -1");
       assertThat(input.getPos()).isEqualTo(2);
       assertThat(input.read()).isEqualTo('2');
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void rejectsSeekAndReadAfterClose(boolean readBeforeClose) throws IOException {
+    String objectName = rule.randomObjectName();
+    rule.client()
+        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      if (readBeforeClose) {
+        assertThat(input.read()).isEqualTo('0');
+      }
+
+      long position = input.getPos();
+      input.close();
+
+      assertThatThrownBy(() -> input.seek(2))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("already closed");
+      assertThatThrownBy(input::read)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot read: already closed");
+      assertThatThrownBy(() -> input.read(new byte[1], 0, 1))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot read: already closed");
+      assertThat(input.getPos()).isEqualTo(position);
     }
   }
 }


### PR DESCRIPTION
ECS streams could lose their pending seek position after a negative seek, and did not track closure, allowing later access to reuse or reopen the underlying stream.

Validate seeks before changing state, using the same messages as S3. Track closure and reject subsequent seeks and reads. Regression tests verify that rejected seeks preserve position and data, and that access is rejected after closing both an unopened and an already-opened stream.

## Validation

- `./gradlew :iceberg-dell:test :iceberg-dell:spotlessCheck :iceberg-dell:checkstyleMain :iceberg-dell:checkstyleTest`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed (earlier revision reviewed by a maintainer; follow-up changes awaiting review)
- Prompt Summary: Use repository conventions and reviewer feedback to validate ECS stream positions and closure, preserve state after rejected operations, add regression coverage, and run the complete affected module test suite and style checks.
