### PR TITLE
Core: Reject negative ByteBuffer stream seeks

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -68,6 +69,7 @@ class MultiBufferInputStream extends ByteBufferInputStream {
 
   @Override
   public void seek(long newPosition) throws IOException {
+    Preconditions.checkArgument(newPosition >= 0, "Position is negative: %s", newPosition);
     if (newPosition > length) {
       throw new EOFException(
           String.format("Cannot seek to position after end of file: %s", newPosition));

--- a/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * This ByteBufferInputStream does not consume the ByteBuffer being passed in, but will create a
@@ -82,6 +83,7 @@ class SingleBufferInputStream extends ByteBufferInputStream {
 
   @Override
   public void seek(long newPosition) throws IOException {
+    Preconditions.checkArgument(newPosition >= 0, "Position is negative: %s", newPosition);
     if (newPosition > length) {
       throw new EOFException(
           String.format("Cannot seek to position after end of file: %s", newPosition));

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -363,6 +363,17 @@ public abstract class TestByteBufferInputStreams {
   }
 
   @Test
+  void seekRejectsNegativePositionWithoutChangingState() throws Exception {
+    ByteBufferInputStream stream = newStream();
+    assertThat(stream.read()).isEqualTo(0);
+
+    assertThatThrownBy(() -> stream.seek(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Position is negative: -1");
+    assertThat(stream.getPos()).isEqualTo(1);
+  }
+
+  @Test
   public void testMark() throws Exception {
     ByteBufferInputStream stream = newStream();
 

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -363,14 +363,29 @@ public abstract class TestByteBufferInputStreams {
   }
 
   @Test
-  void seekRejectsNegativePositionWithoutChangingState() throws Exception {
+  public void testSeekRejectsNegativePosition() throws Exception {
     ByteBufferInputStream stream = newStream();
-    assertThat(stream.read()).isEqualTo(0);
+    assertThat(stream.getPos()).isEqualTo(0);
+
+    assertThatThrownBy(() -> stream.seek(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Position is negative: -1");
+    assertThat(stream.getPos()).isEqualTo(0);
+    assertThat(stream.read()).isGreaterThanOrEqualTo(0);
+    assertThat(stream.getPos()).isEqualTo(1);
+  }
+
+  @Test
+  public void testSeekRejectsNegativePositionWithoutChangingState() throws Exception {
+    ByteBufferInputStream stream = newStream();
+    assertThat(stream.read()).isGreaterThanOrEqualTo(0);
 
     assertThatThrownBy(() -> stream.seek(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Position is negative: -1");
     assertThat(stream.getPos()).isEqualTo(1);
+    assertThat(stream.read()).isGreaterThanOrEqualTo(0);
+    assertThat(stream.getPos()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
Negative seeks behaved inconsistently across `ByteBufferInputStream` implementations: the multi-buffer stream silently reset to position 0, while the single-buffer stream could throw after resetting its state.

Both now reject negative positions before changing state. Shared tests cover rejection at position 0 and after reading, preserve the current position, and verify that subsequent reads still work.

## Validation

- `./gradlew :iceberg-core:test --tests org.apache.iceberg.io.TestSingleBufferInputStream --tests org.apache.iceberg.io.TestMultiBufferInputStream`
- `./gradlew :iceberg-core:spotlessCheck :iceberg-core:checkstyleTest`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed (earlier revision approved by reviewers; test follow-up awaiting review)
- Prompt Summary: Compare seek boundary behavior across implementations, reproduce inconsistent negative-position handling, preserve stream state, and address reviewer requests for initial-position coverage, continued readability, and consistent test naming.
