### PR TITLE
Core: Fix incorrect error message in InMemoryPlanningState.markAsyncPlanFailed

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/InMemoryPlanningState.java
+++ b/core/src/main/java/org/apache/iceberg/rest/InMemoryPlanningState.java
@@ -103,7 +103,7 @@ class InMemoryPlanningState {
     Preconditions.checkArgument(existingStatus != null, "Cannot find plan %s", plan);
     Preconditions.checkArgument(
         existingStatus == PlanStatus.SUBMITTED,
-        "Cannot mark plan %s as completed as it is %s",
+        "Cannot mark plan %s as failed as it is %s",
         plan,
         existingStatus);
     asyncPlanningStates.put(plan, PlanStatus.FAILED);


### PR DESCRIPTION
`markAsyncPlanFailed` reuses the precondition message from `markAsyncPlanAsComplete`, so when a plan is not in `SUBMITTED` state it reports "Cannot mark plan ... as completed" on the failure path. Corrected the wording to "failed". Message-only change