### PR TITLE
Aliyun, Dell: Handle EOF in OSS and ECS InputStream read() variants

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -82,12 +82,17 @@ class OSSInputStream extends SeekableInputStream {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     positionStream();
 
+    int bytesRead = stream.read();
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += 1;
     next += 1;
     readBytes.increment();
     readOperations.increment();
 
-    return stream.read();
+    return bytesRead;
   }
 
   @Override
@@ -96,6 +101,10 @@ class OSSInputStream extends SeekableInputStream {
     positionStream();
 
     int bytesRead = stream.read(b, off, len);
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += bytesRead;
     next += bytesRead;
     readBytes.increment(bytesRead);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
 
 public class TestOSSInputStream extends AliyunOSSTestBase {
+  private static final int EOF = -1;
+
   private final Random random = ThreadLocalRandom.current();
 
   @Test
@@ -90,6 +92,39 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
     assertThat(actual)
         .as("Should have expected range data")
         .isEqualTo(Arrays.copyOfRange(original, (int) rangeStart, (int) rangeEnd));
+  }
+
+  @Test
+  public void testReadSingleEOF() throws Exception {
+    OSSURI uri = new OSSURI(location("read-single-eof.dat"));
+    byte[] data = new byte[] {1, 2};
+
+    writeOSSData(uri, data);
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      assertThat(in.read()).isEqualTo(1);
+      assertThat(in.read()).isEqualTo(2);
+      assertThat(in.read()).isEqualTo(EOF);
+    }
+  }
+
+  @Test
+  public void testReadBufferedEOF() throws Exception {
+    OSSURI uri = new OSSURI(location("read-buffered-eof.dat"));
+    int dataSize = 8;
+    byte[] expected = randomData(dataSize);
+    byte[] actual = new byte[dataSize + 1];
+
+    writeOSSData(uri, expected);
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      int bytesRead = in.read(actual, 0, dataSize + 1);
+      assertThat(bytesRead).isEqualTo(dataSize);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
+
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      assertThat(in.getPos()).isEqualTo(dataSize);
+    }
   }
 
   @Test

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -105,6 +105,7 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
       assertThat(in.read()).isEqualTo(1);
       assertThat(in.read()).isEqualTo(2);
       assertThat(in.read()).isEqualTo(EOF);
+      assertThat(in.getPos()).isEqualTo(data.length);
     }
   }
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -79,16 +79,25 @@ class EcsSeekableInputStream extends SeekableInputStream {
   @Override
   public int read() throws IOException {
     checkAndUseNewPos();
+    int byteRead = internalStream.read();
+    if (byteRead == -1) {
+      return -1;
+    }
+
     pos += 1;
     readBytes.increment();
     readOperations.increment();
-    return internalStream.read();
+    return byteRead;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     checkAndUseNewPos();
     int delta = internalStream.read(b, off, len);
+    if (delta == -1) {
+      return -1;
+    }
+
     pos += delta;
     readBytes.increment(delta);
     readOperations.increment();

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -23,12 +23,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TestEcsSeekableInputStream {
+  private static final int EOF = -1;
 
   @RegisterExtension public static EcsS3MockRule rule = EcsS3MockRule.create();
 
@@ -88,6 +90,39 @@ public class TestEcsSeekableInputStream {
       assertThat(new String(buffer, StandardCharsets.UTF_8))
           .as("The first 3 bytes should be 012")
           .isEqualTo("012");
+    }
+  }
+
+  @Test
+  public void testReadSingleEOF() throws IOException {
+    String objectName = rule.randomObjectName();
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, "01".getBytes()));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      assertThat(input.read()).isEqualTo('0');
+      assertThat(input.read()).isEqualTo('1');
+      assertThat(input.read()).isEqualTo(EOF);
+    }
+  }
+
+  @Test
+  public void testReadBufferedEOF() throws IOException {
+    String objectName = rule.randomObjectName();
+    byte[] data = "0123456789".getBytes(StandardCharsets.UTF_8);
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, data));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      byte[] actual = new byte[data.length + 1];
+      int bytesRead = input.read(actual, 0, actual.length);
+      assertThat(bytesRead).isEqualTo(data.length);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(data);
+
+      assertThat(input.read(actual, 0, actual.length)).isEqualTo(EOF);
+      assertThat(input.getPos()).isEqualTo(data.length);
     }
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -96,7 +96,8 @@ public class TestEcsSeekableInputStream {
   @Test
   public void testReadSingleEOF() throws IOException {
     String objectName = rule.randomObjectName();
-    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, "01".getBytes()));
+    byte[] data = "01".getBytes(StandardCharsets.UTF_8);
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, data));
 
     try (EcsSeekableInputStream input =
         new EcsSeekableInputStream(
@@ -104,6 +105,7 @@ public class TestEcsSeekableInputStream {
       assertThat(input.read()).isEqualTo('0');
       assertThat(input.read()).isEqualTo('1');
       assertThat(input.read()).isEqualTo(EOF);
+      assertThat(input.getPos()).isEqualTo(data.length);
     }
   }
 


### PR DESCRIPTION
## Why is this change needed?

`OSSInputStream` (aliyun) and `EcsSeekableInputStream` (dell) advance `pos` (and `next`, in OSS's case) and increment the `readBytes`/`readOperations` metric counters *before* checking whether the underlying stream has reached EOF (`-1`). When a read call actually returns `-1`:

- The tracked position is advanced by one byte (`read()`) or decremented by one byte (`read(byte[], int, int)`, since `-1` is added to `pos`/`next`), desyncing the stream's internal position bookkeeping from the real position in the object.
- The `readBytes` counter is incremented by `-1` in the buffered-read path, producing a nonsensical negative byte count in read metrics.

`S3InputStream`, `GCSInputStream`, and `ADLSInputStream` already guard against this (fixed in #16055); `OSSInputStream` and `EcsSeekableInputStream` were the two implementations left over from that fix. This PR applies the same guard to both.

A previous attempt at this exact fix (#16266) was opened but auto-closed for inactivity rather than rejected on merit — this PR picks that up with tests added for both the single-byte and buffered `read()` overloads on each class.

Closes #16062

## What user-facing changes does this include?

None. This only affects internal position tracking and read metrics inside `OSSInputStream` and `EcsSeekableInputStream` when a read reaches EOF; there is no change to any public API, table format, or configuration.

## Are there any user-facing changes?

- Fixes metrics reporting a negative byte count when a buffered read hits EOF.
- Fixes internal position tracking so a stream that has hit EOF doesn't end up with a position off by one byte relative to the actual object length.

## How was this change tested?

Added `testReadSingleEOF` and `testReadBufferedEOF` to both `TestOSSInputStream` and `TestEcsSeekableInputStream`, mirroring the tests added for `S3InputStream`/`GCSInputStream`/`ADLSInputStream` in #16055.
Verified locally that all four new tests fail against the pre-fix code and pass after the fix; ran `spotlessCheck` for both modules.