### PR TITLE
REST spec: Add create/drop/exists function endpoints to OpenAPI spec

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -2115,7 +2115,8 @@ class CreateFunctionRequest(BaseModel):
         description="The function's base location. This is used to store function metadata files.",
     )
     definitions: list[FunctionDefinition] = Field(
-        ..., description='List of function definition entities.'
+        ...,
+        description='List of function definition entities. The server assigns `definition-id`, `current-version-id`, and the `version-id` and `timestamp-ms` of each version, replacing any values sent by the client.\n',
     )
     properties: dict[str, str] | None = Field(
         None, description='A string-to-string map of properties.'

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -2099,6 +2099,31 @@ class LoadFunctionResult(BaseModel):
     metadata: FunctionMetadata
 
 
+class CreateFunctionRequest(BaseModel):
+    """
+    Request to create a function with all of its definitions.
+
+
+    The server assigns `function-uuid`, `format-version`, and `definition-log`, so those fields
+    are not part of this request.
+
+    """
+
+    name: str
+    location: str | None = Field(
+        None,
+        description="The function's base location. This is used to store function metadata files.",
+    )
+    definitions: list[FunctionDefinition] = Field(
+        ..., description='List of function definition entities.'
+    )
+    properties: dict[str, str] | None = Field(
+        None, description='A string-to-string map of properties.'
+    )
+    secure: bool | None = Field(False, description='Whether it is a secure function.')
+    doc: str | None = Field(None, description='Documentation string.')
+
+
 class FunctionMetadata(BaseModel):
     """
     Portable UDF metadata format.
@@ -2500,6 +2525,7 @@ CreateTableRequest.model_rebuild()
 CreateViewRequest.model_rebuild()
 ScanReport.model_rebuild()
 LoadFunctionResult.model_rebuild()
+CreateFunctionRequest.model_rebuild()
 FunctionMetadata.model_rebuild()
 FunctionDefinition.model_rebuild()
 FunctionParameter.model_rebuild()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -665,12 +665,12 @@ paths:
       tags:
         - Catalog API
       summary: Create a function in the given namespace
-      description:
+      description: >
         Create a function in the given namespace.
+
 
         The function is created with all of its definitions. The server assigns `function-uuid`,
         `format-version`, and `definition-log`, so those must not be sent in the request.
-
       operationId: createFunction
       parameters:
         - $ref: '#/components/parameters/idempotency-key'
@@ -761,11 +761,11 @@ paths:
       tags:
         - Catalog API
       summary: Drop a function from the catalog
-      description:
+      description: >
         Remove a function from the catalog.
 
-        All definitions of the function are removed.
 
+        All definitions of the function are removed.
       operationId: dropFunction
       parameters:
         - $ref: '#/components/parameters/idempotency-key'
@@ -806,11 +806,20 @@ paths:
         204:
           description: Success, no content
         400:
-          description: Bad Request
+          $ref: '#/components/responses/BadRequestErrorResponse'
         401:
-          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
         404:
-          description: Not Found
+          description: Not Found - NoSuchFunctionException, function not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                FunctionNotFound:
+                  $ref: '#/components/examples/NoSuchFunctionError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -5097,7 +5106,10 @@ components:
           description: The function's base location. This is used to store function metadata files.
         definitions:
           type: array
-          description: List of function definition entities.
+          description: >
+            List of function definition entities. The server assigns `definition-id`,
+            `current-version-id`, and the `version-id` and `timestamp-ms` of each version,
+            replacing any values sent by the client.
           items:
             $ref: '#/components/schemas/FunctionDefinition'
         properties:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -661,6 +661,59 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+    post:
+      tags:
+        - Catalog API
+      summary: Create a function in the given namespace
+      description:
+        Create a function in the given namespace.
+
+        The function is created with all of its definitions. The server assigns `function-uuid`,
+        `format-version`, and `definition-log`, so those must not be sent in the request.
+
+      operationId: createFunction
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFunctionRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/LoadFunctionResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description: Not Found - The namespace specified does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NamespaceNotFound:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        409:
+          description: Conflict - The function already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                FunctionAlreadyExists:
+                  $ref: '#/components/examples/FunctionAlreadyExistsError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /v1/{prefix}/namespaces/{namespace}/functions/{function}:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -697,6 +750,67 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
                 FunctionNotFound:
                   $ref: '#/components/examples/NoSuchFunctionError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+    delete:
+      tags:
+        - Catalog API
+      summary: Drop a function from the catalog
+      description:
+        Remove a function from the catalog.
+
+        All definitions of the function are removed.
+
+      operationId: dropFunction
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
+      responses:
+        204:
+          description: Success, no content
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found - NoSuchFunctionException, function to drop does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                FunctionToDeleteDoesNotExist:
+                  $ref: '#/components/examples/NoSuchFunctionError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+    head:
+      tags:
+        - Catalog API
+      summary: Check if a function exists
+      description:
+        Check if a function exists within a given namespace. This request does not return a response body.
+      operationId: functionExists
+      responses:
+        204:
+          description: Success, no content
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
+        404:
+          description: Not Found
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -4964,6 +5078,41 @@ components:
         metadata:
           $ref: '#/components/schemas/FunctionMetadata'
 
+    CreateFunctionRequest:
+      description: |
+        Request to create a function with all of its definitions.
+
+
+        The server assigns `function-uuid`, `format-version`, and `definition-log`, so those fields
+        are not part of this request.
+      type: object
+      required:
+        - name
+        - definitions
+      properties:
+        name:
+          type: string
+        location:
+          type: string
+          description: The function's base location. This is used to store function metadata files.
+        definitions:
+          type: array
+          description: List of function definition entities.
+          items:
+            $ref: '#/components/schemas/FunctionDefinition'
+        properties:
+          type: object
+          description: A string-to-string map of properties.
+          additionalProperties:
+            type: string
+        secure:
+          type: boolean
+          description: Whether it is a secure function.
+          default: false
+        doc:
+          type: string
+          description: Documentation string.
+
     FunctionMetadata:
       description: |
         Portable UDF metadata format.
@@ -6319,6 +6468,16 @@ components:
       value: {
         "error": {
           "message": "The requested view identifier already exists",
+          "type": "AlreadyExistsException",
+          "code": 409
+        }
+      }
+
+    FunctionAlreadyExistsError:
+      summary: The requested function identifier already exists
+      value: {
+        "error": {
+          "message": "The requested function identifier already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }


### PR DESCRIPTION


Follow-up to #15180, which added listFunctions and loadFunction. This adds
the remaining function lifecycle operations that do not require a metadata
update model:

- createFunction (POST .../functions)
- dropFunction (DELETE .../functions/{function})
- functionExists (HEAD .../functions/{function})

createFunction takes a new CreateFunctionRequest carrying the function name
and its definitions. The server assigns function-uuid, format-version and
definition-log, so those are not part of the request. Within each definition
the server also assigns definition-id, current-version-id, and each version's
version-id and timestamp-ms, replacing any values sent by the client. This
mirrors CreateViewRequest, which embeds a full ViewVersion and documents the
server replacing schema-id. createFunction returns the loaded function so
clients do not need a follow-up load to learn the assigned UUID and metadata
location.

Errors use IcebergErrorResponse to match the existing function endpoints, and
a FunctionAlreadyExistsError example is added for the 409 case.

updateFunction is left for a follow-up, since committing changes to a function
requires a metadata update and requirement model that the UDF spec does not
define yet. Until it lands there is no in-place update: modifying a function
means dropFunction followed by createFunction, which is not atomic, mints a
new function-uuid, and does not preserve definition-log. Rename is also
deferred: the function endpoints use CatalogObjectIdentifier while
RenameTableRequest uses TableIdentifier, and which shape rename should use is
worth settling separately.