### PR TITLE
Core, AWS: Fix case-insensitive handling of REST response header field names

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -308,9 +308,7 @@ public abstract class S3V4RestSignerClient
       signedComponent = cachedSignedComponent;
     } else {
       // Case-insensitive because canBeCached looks Cache-Control up by its traditional spelling,
-      // while a server may hand the header over in any case and HTTP/2 requires lowercase.
-      // Case-insensitive because canBeCached looks Cache-Control up by its traditional spelling,
-      // while a server may hand the header over in any case and HTTP/2 requires lowercase.
+      // while a server may hand the header over in any case (RFC 9110).
       Map<String, String> responseHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
       Consumer<Map<String, String>> responseHeadersConsumer = responseHeaders::putAll;
       RemoteSignResponse remoteSignResponse =

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -307,7 +307,11 @@ public abstract class S3V4RestSignerClient
     if (null != cachedSignedComponent) {
       signedComponent = cachedSignedComponent;
     } else {
-      Map<String, String> responseHeaders = Maps.newHashMap();
+      // Case-insensitive because canBeCached looks Cache-Control up by its traditional spelling,
+      // while a server may hand the header over in any case and HTTP/2 requires lowercase.
+      // Case-insensitive because canBeCached looks Cache-Control up by its traditional spelling,
+      // while a server may hand the header over in any case and HTTP/2 requires lowercase.
+      Map<String, String> responseHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
       Consumer<Map<String, String>> responseHeadersConsumer = responseHeaders::putAll;
       RemoteSignResponse remoteSignResponse =
           httpClient()

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
@@ -22,7 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.rest.RESTCatalogProperties;
@@ -31,14 +36,23 @@ import org.apache.iceberg.rest.auth.AuthProperties;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.responses.ImmutableRemoteSignResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.rest.responses.RemoteSignResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.IoUtils;
 
 class TestS3V4RestSignerClient {
@@ -94,6 +108,69 @@ class TestS3V4RestSignerClient {
   void afterEach() {
     IoUtils.closeQuietlyV2(S3V4RestSignerClient.authManager, null);
     S3V4RestSignerClient.authManager = null;
+  }
+
+  /**
+   * A server may write the Cache-Control field name in any case, and HTTP/2 requires it to be
+   * lowercase, so the spelling it chose must not decide whether the signed component is cached.
+   */
+  @SuppressWarnings("deprecation")
+  @ParameterizedTest
+  @ValueSource(strings = {"Cache-Control", "cache-control"})
+  void signedComponentIsCachedRegardlessOfCacheControlHeaderCase(String cacheControlHeader)
+      throws Exception {
+    // the signing cache is static and keyed on method, region and URI
+    URI uri = URI.create("https://bucket.s3.us-west-2.amazonaws.com/" + UUID.randomUUID());
+    AtomicInteger signRequests = new AtomicInteger();
+
+    when(S3V4RestSignerClient.httpClient.post(
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.eq(RemoteSignResponse.class),
+            Mockito.anyMap(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              signRequests.incrementAndGet();
+              Consumer<Map<String, String>> responseHeaders = invocation.getArgument(5);
+              responseHeaders.accept(Map.of(cacheControlHeader, "private"));
+              return ImmutableRemoteSignResponse.builder()
+                  .uri(uri)
+                  .headers(Map.of("Authorization", List.of("AWS4-HMAC-SHA256 Credential=key")))
+                  .build();
+            });
+
+    ExecutionAttributes executionAttributes =
+        ExecutionAttributes.builder()
+            .put(
+                AwsSignerExecutionAttribute.AWS_CREDENTIALS,
+                AwsBasicCredentials.create("accessKeyId", "secretAccessKey"))
+            .put(AwsSignerExecutionAttribute.SIGNING_REGION, Region.US_WEST_2)
+            .put(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, "s3")
+            .build();
+
+    try (S3V4RestSignerClient client =
+        ImmutableS3V4RestSignerClient.builder()
+            .properties(
+                Map.of(
+                    CatalogProperties.URI,
+                    "https://signer.com",
+                    RESTCatalogProperties.REMOTE_SIGNING_ENDPOINT,
+                    "v1/namespaces/ns1/tables/t1/sign",
+                    OAuth2Properties.TOKEN,
+                    "token"))
+            .build()) {
+      SdkHttpFullRequest request =
+          SdkHttpFullRequest.builder().uri(uri).method(SdkHttpMethod.GET).build();
+
+      client.sign(request, executionAttributes);
+      client.sign(request, executionAttributes);
+    }
+
+    assertThat(signRequests.get())
+        .as("the signed component should be cached, so the repeated request must not sign again")
+        .isEqualTo(1);
   }
 
   @ParameterizedTest

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -337,7 +337,9 @@ public class HTTPClient extends BaseHTTPClient {
       Consumer<Map<String, String>> responseHeaders,
       ParserContext parserContext)
       throws IOException {
-    Map<String, String> respHeaders = Maps.newHashMap();
+    // Field names are case-insensitive (RFC 9110), and HTTP/2 requires them to be lowercase, so
+    // callers cannot rely on a server's chosen spelling to look a header up.
+    Map<String, String> respHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     for (Header header : response.getHeaders()) {
       respHeaders.put(header.getName(), header.getValue());
     }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -337,8 +337,8 @@ public class HTTPClient extends BaseHTTPClient {
       Consumer<Map<String, String>> responseHeaders,
       ParserContext parserContext)
       throws IOException {
-    // Field names are case-insensitive (RFC 9110), and HTTP/2 requires them to be lowercase, so
-    // callers cannot rely on a server's chosen spelling to look a header up.
+    // Field names are case-insensitive (RFC 9110), so callers cannot rely on the spelling a
+    // server chose to look a header up.
     Map<String, String> respHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     for (Header header : response.getHeaders()) {
       respHeaders.put(header.getName(), header.getValue());

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -470,7 +470,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     TableIdentifier loadedIdent;
 
     // Case-insensitive because the ETag below is read back by its traditional spelling, while a
-    // server may hand the header over in any case and HTTP/2 requires lowercase.
+    // server may hand the header over in any case (RFC 9110).
     Map<String, String> responseHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     TableWithETag cachedTable = tableCache.getIfPresent(context.sessionId(), identifier);
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -469,7 +469,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     LoadTableResponse response;
     TableIdentifier loadedIdent;
 
-    Map<String, String> responseHeaders = Maps.newHashMap();
+    // Case-insensitive because the ETag below is read back by its traditional spelling, while a
+    // server may hand the header over in any case and HTTP/2 requires lowercase.
+    Map<String, String> responseHeaders = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
     TableWithETag cachedTable = tableCache.getIfPresent(context.sessionId(), identifier);
 
     try {

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -325,6 +326,31 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     Mockito.verify(adapterForRESTServer, times(2))
         .execute(
             matches(HTTPRequest.HTTPMethod.GET, RESOURCE_PATHS.table(TABLE)), any(), any(), any());
+  }
+
+  @Test
+  public void freshnessAwareLoadingWithLowercaseETagHeader() {
+    RESTCatalogAdapter adapter = adapterWithLowercaseResponseHeaders();
+    RESTCatalog catalog = new RESTCatalog(DEFAULT_SESSION_CONTEXT, config -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+    catalog.createNamespace(TABLE.namespace());
+    catalog.createTable(TABLE, SCHEMA);
+
+    Cache<SessionIdTableId, TableWithETag> tableCache =
+        catalog.sessionCatalog().tableCache().cache();
+    BaseTable tableAfterFirstLoad = (BaseTable) catalog.loadTable(TABLE);
+
+    assertThat(tableCache.asMap())
+        .containsOnlyKeys(SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE));
+
+    expectNotModifiedResponseForLoadTable(TABLE, adapter);
+    BaseTable tableAfterSecondLoad = (BaseTable) catalog.loadTable(TABLE);
+
+    assertThat(tableAfterSecondLoad.operations().current().metadataFileLocation())
+        .isEqualTo(tableAfterFirstLoad.operations().current().metadataFileLocation());
   }
 
   @Test
@@ -885,6 +911,31 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
             eq(LoadTableResponse.class),
             any(),
             any());
+  }
+
+  /**
+   * An adapter that reports its response headers in the lowercase form HTTP/2 mandates, which any
+   * server is also free to use over HTTP/1, instead of the traditional "ETag" spelling.
+   */
+  private RESTCatalogAdapter adapterWithLowercaseResponseHeaders() {
+    return Mockito.spy(
+        new RESTCatalogAdapter(backendCatalog) {
+          @Override
+          public <T extends RESTResponse> T execute(
+              HTTPRequest request,
+              Class<T> responseType,
+              Consumer<ErrorResponse> errorHandler,
+              Consumer<Map<String, String>> responseHeaders) {
+            Consumer<Map<String, String>> lowercased =
+                headers -> {
+                  Map<String, String> renamed = Maps.newHashMap();
+                  headers.forEach(
+                      (name, value) -> renamed.put(name.toLowerCase(Locale.ROOT), value));
+                  responseHeaders.accept(renamed);
+                };
+            return super.execute(request, responseType, errorHandler, lowercased);
+          }
+        });
   }
 
   private RESTCatalogAdapter adapterCapturingResponseHeaders(Map<String, String> respHeaders) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -42,6 +42,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -53,6 +54,7 @@ import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
@@ -586,6 +588,30 @@ public class TestHTTPClient {
 
     // No exception should be thrown, and the second request should succeed
     doExecuteRequest(method, path, loadTableRequestBody, errorHandler, headers -> {});
+  }
+
+  @Test
+  public void responseHeadersAreReadWithoutRegardToCase() throws JsonProcessingException {
+    String path = "response_header_case";
+    // A server may write a field name in any case, and over HTTP/2 it has to be lowercase, so the
+    // spelling it chose must not decide whether a caller can find the header.
+    mockServer
+        .when(
+            request("/" + path)
+                .withMethod("GET")
+                .withHeader("Authorization", "Bearer " + BEARER_AUTH_TOKEN),
+            Times.exactly(1))
+        .respond(
+            response()
+                .withStatusCode(200)
+                .withBody(MAPPER.writeValueAsString(new Item(0L, "hank")))
+                .withHeader("etag", "W/\"1\""));
+
+    AtomicReference<Map<String, String>> responseHeaders = new AtomicReference<>();
+    doExecuteRequest(HttpMethod.GET, path, null, mock(ErrorHandler.class), responseHeaders::set);
+
+    assertThat(responseHeaders.get().get(HttpHeaders.ETAG)).isEqualTo("W/\"1\"");
+    assertThat(responseHeaders.get().get("etag")).isEqualTo("W/\"1\"");
   }
 
   public static void testHttpMethodOnSuccess(HttpMethod method) throws JsonProcessingException {


### PR DESCRIPTION
Closes #17978.

Freshness-aware table loading did nothing at all when the catalog server wrote the `ETag` response header in any spelling other than `ETag`. `HTTPClient` collected response headers into a map keyed by the name exactly as received, `RESTSessionCatalog` copied that into another `HashMap` and read the tag back as `HttpHeaders.ETAG`, so a server that sent `etag` left `tableCache` empty. No later load sent `If-None-Match`, and nothing surfaced the fact that the server had answered with a tag.

Header field names are case-insensitive (RFC 9110 section 5.1), and lowercase is mandatory in HTTP/2 (RFC 9113 section 8.2.1), so a client cannot key on the spelling a server happened to choose. Both maps are now case-insensitive, which fixes the lookup without changing what callers see otherwise.

I hit this against an Armeria-based catalog server, which writes HTTP/1 header names in their lowercase HTTP/2 form by default: the server returned a correct `ETag` for a conditional `loadTable` and the client could not see it. The same applies to any server reached over HTTP/2.

Tests:

- `TestHTTPClient.responseHeadersAreReadWithoutRegardToCase` has the mock server answer with `etag` and asserts the map handed to the caller resolves both spellings, covering the collection point.
- `TestFreshnessAwareLoading.freshnessAwareLoadingWithLowercaseETagHeader` drives a catalog through an adapter that reports its response headers lowercased, and asserts the table cache is still populated and the second load is answered from it, covering the consumer.
- Both fail on an unfixed tree. `./gradlew :iceberg-core:test --tests "org.apache.iceberg.rest.*"` passes.
