### PR TITLE
Docs: Add 1.11.0 release note for dropped flink-metrics-dropwizard dependency

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -77,7 +77,7 @@ The 1.11.0 release contains bug fixes and new features. For full release notes v
     - Drop support for Java 11 ([\#14400](https://github.com/apache/iceberg/pull/14400))
     - Spark 3.4: Deprecate support ([\#14099](https://github.com/apache/iceberg/pull/14099))
     - Flink: Remove Flink 1.19 support ([\#13714](https://github.com/apache/iceberg/pull/13714))
-    - Flink: Do not ship optional `flink-metrics-dropwizard` dependency in the `iceberg-flink-runtime` fat jar. Without it the `dataFilesSizeHistogram` and `deleteFilesSizeHistogram` histogram metrics are no longer published; add the dependency manually to keep publishing them ([\#16155](https://github.com/apache/iceberg/pull/16155))
+    - Flink: Do not ship optional `flink-metrics-dropwizard` dependency in the `iceberg-flink-runtime` fat jar. Without it, the `dataFilesSizeHistogram` and `deleteFilesSizeHistogram` histogram metrics are no longer published; add the dependency manually to keep publishing them ([\#16155](https://github.com/apache/iceberg/pull/16155))
     - AWS, Core, Data, Spark: Remove deprecations for 1.11.0 ([\#14059](https://github.com/apache/iceberg/pull/14059))
 * Spec
     - Introduce SQL UDF specification ([\#14117](https://github.com/apache/iceberg/pull/14117))

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -77,6 +77,7 @@ The 1.11.0 release contains bug fixes and new features. For full release notes v
     - Drop support for Java 11 ([\#14400](https://github.com/apache/iceberg/pull/14400))
     - Spark 3.4: Deprecate support ([\#14099](https://github.com/apache/iceberg/pull/14099))
     - Flink: Remove Flink 1.19 support ([\#13714](https://github.com/apache/iceberg/pull/13714))
+    - Flink: Do not ship optional `flink-metrics-dropwizard` dependency in the `iceberg-flink-runtime` fat jar. Without it the `dataFilesSizeHistogram` and `deleteFilesSizeHistogram` histogram metrics are no longer published; add the dependency manually to keep publishing them ([\#16155](https://github.com/apache/iceberg/pull/16155))
     - AWS, Core, Data, Spark: Remove deprecations for 1.11.0 ([\#14059](https://github.com/apache/iceberg/pull/14059))
 * Spec
     - Introduce SQL UDF specification ([\#14117](https://github.com/apache/iceberg/pull/14117))


### PR DESCRIPTION
`flink-metrics-dropwizard` stopped being shipped in the `iceberg-flink-runtime` jar in 1.11.0 (#16155), which silently stops publishing the `dataFilesSizeHistogram` and `deleteFilesSizeHistogram` metrics. It was missed in the release notes.

Closes #16170

### Testing

`cd site && make lint`

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Ducc
- Human Oversight: fully reviewed
- Prompt Summary: Add the 1.11.0 release note entry requested by the issue reporter for the dropwizard dependency removal.
