### PR TITLE
Core, Hive: Commit manifest list encryption keys with the snapshot that uses them

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.NativeEncryptionKeyMetadata;
 import org.apache.iceberg.encryption.StandardEncryptionManager;
+import org.apache.iceberg.encryption.StandardEncryptionManager.ManifestListEncryptionKeys;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
@@ -36,6 +37,9 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   private final StandardEncryptionManager standardEncryptionManager;
   private final NativeEncryptionKeyMetadata manifestListKeyMetadata;
   private final OutputFile outputFile;
+  private boolean closed = false;
+  private ManifestListFile manifestListFile;
+  private ManifestListEncryptionKeys encryptionKeys;
 
   private ManifestListWriter(
       OutputFile file, EncryptionManager encryptionManager, Map<String, String> meta) {
@@ -82,6 +86,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   @Override
   public void close() throws IOException {
     writer.close();
+    this.closed = true;
   }
 
   @Override
@@ -94,14 +99,26 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   }
 
   public ManifestListFile toManifestListFile() {
-    if (manifestListKeyMetadata != null && manifestListKeyMetadata.encryptionKey() != null) {
-      String manifestListKeyID =
-          standardEncryptionManager.addManifestListKeyMetadata(
-              manifestListKeyMetadata.copyWithLength(writer.length()));
-      return new BaseManifestListFile(outputFile.location(), manifestListKeyID);
-    } else {
-      return new BaseManifestListFile(outputFile.location(), null);
+    Preconditions.checkState(closed, "Cannot build ManifestListFile, writer is not closed");
+    if (manifestListFile == null) {
+      if (manifestListKeyMetadata != null && manifestListKeyMetadata.encryptionKey() != null) {
+        this.encryptionKeys =
+            standardEncryptionManager.registerManifestListKeyMetadata(
+                manifestListKeyMetadata.copyWithLength(writer.length()));
+        this.manifestListFile =
+            new BaseManifestListFile(
+                outputFile.location(), encryptionKeys.manifestListKey().keyId());
+      } else {
+        this.manifestListFile = new BaseManifestListFile(outputFile.location(), null);
+      }
     }
+
+    return manifestListFile;
+  }
+
+  ManifestListEncryptionKeys encryptionKeys() {
+    toManifestListFile();
+    return encryptionKeys;
   }
 
   static class V4Writer extends ManifestListWriter {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.StandardEncryptionManager.ManifestListEncryptionKeys;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -113,6 +114,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private MetricsReporter reporter = LoggingMetricsReporter.instance();
   private volatile Long snapshotId = null;
   private TableMetadata base;
+  // Encryption keys required by the manifest list written in the current commit attempt.
+  private ManifestListEncryptionKeys manifestListEncryptionKeys;
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
   private SnapshotAncestryValidator snapshotAncestryValidator =
@@ -353,6 +356,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
           replacedRecords);
     }
 
+    ManifestListFile manifestListFile = writer.toManifestListFile();
+    this.manifestListEncryptionKeys = writer.encryptionKeys();
+
     return new BaseSnapshot(
         sequenceNumber,
         snapshotId(),
@@ -364,7 +370,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         manifestList.location(),
         nextRowId,
         assignedRows,
-        writer.toManifestListFile().encryptionKeyID());
+        manifestListFile.encryptionKeyID());
   }
 
   private void runValidations(Snapshot parentSnapshot) {
@@ -498,10 +504,17 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   if (base.snapshot(newSnapshot.snapshotId()) != null) {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);
-                  } else if (stageOnly) {
-                    update.addSnapshot(newSnapshot);
                   } else {
-                    update.setBranchSnapshot(newSnapshot, targetBranch);
+                    if (manifestListEncryptionKeys != null) {
+                      update.addEncryptionKey(manifestListEncryptionKeys.keyEncryptionKey());
+                      update.addEncryptionKey(manifestListEncryptionKeys.manifestListKey());
+                    }
+
+                    if (stageOnly) {
+                      update.addSnapshot(newSnapshot);
+                    } else {
+                      update.setBranchSnapshot(newSnapshot, targetBranch);
+                    }
                   }
 
                   TableMetadata updated = update.build();

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -184,11 +184,29 @@ public class StandardEncryptionManager implements EncryptionManager {
     return unwrappedKeyCache().get(encryptedKeyMetadata.encryptedById());
   }
 
+  /**
+   * Encrypts and registers manifest-list key metadata.
+   *
+   * @return the ID of the encrypted metadata
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+   *     #registerManifestListKeyMetadata(NativeEncryptionKeyMetadata)} instead.
+   */
+  @Deprecated
   public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
+    return registerManifestListKeyMetadata(keyMetadata).manifestListKey().keyId();
+  }
+
+  /**
+   * Encrypts and registers manifest-list key metadata.
+   *
+   * @return the encrypted metadata and its wrapping key
+   */
+  public ManifestListEncryptionKeys registerManifestListKeyMetadata(
+      NativeEncryptionKeyMetadata keyMetadata) {
     String manifestListKeyID = generateKeyId();
     String keyEncryptionKeyID = keyEncryptionKeyID();
-    String keyEncryptionKeyTimestamp =
-        encryptionKeys.get(keyEncryptionKeyID).properties().get(KEY_TIMESTAMP);
+    EncryptedKey keyEncryptionKey = encryptionKeys.get(keyEncryptionKeyID);
+    String keyEncryptionKeyTimestamp = keyEncryptionKey.properties().get(KEY_TIMESTAMP);
     ByteBuffer encryptedKeyMetadata =
         EncryptionUtil.encryptManifestListKeyMetadata(
             unwrappedKeyCache().get(keyEncryptionKeyID), keyEncryptionKeyTimestamp, keyMetadata);
@@ -197,7 +215,7 @@ public class StandardEncryptionManager implements EncryptionManager {
 
     encryptionKeys.put(key.keyId(), key);
 
-    return manifestListKeyID;
+    return new ManifestListEncryptionKeys(keyEncryptionKey, key);
   }
 
   private String generateKeyId() {
@@ -211,6 +229,10 @@ public class StandardEncryptionManager implements EncryptionManager {
     workerRNG().nextBytes(newKey);
     return ByteBuffer.wrap(newKey);
   }
+
+  /** Encrypted manifest-list key metadata and its wrapping key. */
+  public record ManifestListEncryptionKeys(
+      EncryptedKey keyEncryptionKey, EncryptedKey manifestListKey) {}
 
   private class StandardEncryptedOutputFile implements NativeEncryptionOutputFile {
     private final OutputFile plainOutputFile;

--- a/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionTestHelpers;
 import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.StandardEncryptionManager.ManifestListEncryptionKeys;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
@@ -43,7 +45,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestManifestListEncryption {
   private static final String PATH = "s3://bucket/table/m1.avro";
@@ -96,6 +100,13 @@ public class TestManifestListEncryption {
           DELETED_FILES,
           DELETED_ROWS,
           FIRST_ROW_ID);
+
+  @TempDir private File temp;
+
+  @AfterEach
+  void cleanup() {
+    TestTables.clearTables();
+  }
 
   @Test
   public void testEncryption() throws IOException {
@@ -204,6 +215,129 @@ public class TestManifestListEncryption {
     assertThat(mlkmCount).isEqualTo(1);
   }
 
+  @Test
+  void snapshotKeysSurviveManagerReplacementAndRetry() {
+    // Later manager lookups cannot recover the writer's uncommitted keys.
+    TestTables.TestTable table = createTableWithFreshEncryptionManagers();
+    table.ops().failCommits(1);
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    TableMetadata metadata = table.ops().current();
+    assertThat(metadata.encryptionKeys()).hasSize(2);
+    assertThat(readManifestListWithCommittedKeys(metadata, metadata.currentSnapshot())).hasSize(1);
+  }
+
+  @Test
+  void retryDoesNotPersistAbandonedKeys() {
+    EncryptionManager encryptionManager = EncryptionTestHelpers.createEncryptionManager();
+    TestTables.TestTable table = createEncryptedTable(encryptionManager);
+    int failedAttempts = 2;
+    table.ops().failCommits(failedAttempts);
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    // The manager retains the KEK and every attempted manifest-list key.
+    assertThat(EncryptionUtil.encryptionKeys(encryptionManager)).hasSize(failedAttempts + 2);
+    TableMetadata metadata = table.ops().current();
+    assertThat(metadata.encryptionKeys()).hasSize(2);
+    assertThat(readManifestListWithCommittedKeys(metadata, metadata.currentSnapshot())).hasSize(1);
+  }
+
+  @Test
+  void keyRotationPreservesSnapshotReadability() {
+    EncryptionManager encryptionManager = EncryptionTestHelpers.createEncryptionManager();
+    TestTables.TestTable table = createEncryptedTable(encryptionManager);
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+    Snapshot originalSnapshot = table.currentSnapshot();
+
+    EncryptionTestHelpers.shiftEncryptionManagerTime(
+        encryptionManager, TimeUnit.DAYS.toMillis(800));
+
+    table.newFastAppend().appendFile(TestBase.FILE_B).commit();
+
+    TableMetadata metadata = table.ops().current();
+    assertThat(metadata.encryptionKeys()).hasSize(4);
+    assertThat(readManifestListWithCommittedKeys(metadata, originalSnapshot)).hasSize(1);
+    assertThat(readManifestListWithCommittedKeys(metadata, metadata.currentSnapshot())).hasSize(2);
+  }
+
+  @Test
+  void stagedSnapshotPersistsManifestListKeys() {
+    TestTables.TestTable table = createTableWithFreshEncryptionManagers();
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.newFastAppend().appendFile(TestBase.FILE_B).stageOnly().commit();
+
+    TableMetadata metadata = table.ops().current();
+    assertThat(metadata.currentSnapshot().snapshotId()).isEqualTo(currentSnapshotId);
+    assertThat(metadata.snapshots()).hasSize(2);
+    assertThat(readManifestListWithCommittedKeys(metadata, metadata.snapshots().get(1))).hasSize(2);
+  }
+
+  @Test
+  void recommittingSnapshotDoesNotAddKeys() {
+    TestTables.TestTable table = createTableWithFreshEncryptionManagers();
+    AppendFiles append = table.newFastAppend();
+    append.commit();
+    List<EncryptedKey> keys = table.ops().current().encryptionKeys();
+    assertThat(keys).hasSize(2);
+
+    append.commit();
+
+    assertThat(table.ops().current().encryptionKeys()).containsExactlyElementsOf(keys);
+    assertThat(table.snapshots()).hasSize(1);
+  }
+
+  private TestTables.TestTable createTableWithFreshEncryptionManagers() {
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations("encrypted", temp) {
+          @Override
+          public EncryptionManager encryption() {
+            return EncryptionTestHelpers.createEncryptionManager(current().encryptionKeys());
+          }
+
+          @Override
+          public FileIO io() {
+            return EncryptingFileIO.combine(super.io(), encryption());
+          }
+        };
+    return createEncryptedTable(ops);
+  }
+
+  private TestTables.TestTable createEncryptedTable(TestTables.TestTableOperations ops) {
+    return TestTables.create(
+        temp, "encrypted", TestBase.SCHEMA, TestBase.SPEC, SortOrder.unsorted(), 3, ops);
+  }
+
+  private TestTables.TestTable createEncryptedTable(EncryptionManager encryptionManager) {
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations(
+            "encrypted",
+            temp,
+            EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryptionManager)) {
+          @Override
+          public EncryptionManager encryption() {
+            return encryptionManager;
+          }
+        };
+    return createEncryptedTable(ops);
+  }
+
+  private List<ManifestFile> readManifestListWithCommittedKeys(
+      TableMetadata metadata, Snapshot snapshot) {
+    try (FileIO io =
+        EncryptingFileIO.combine(
+            new TestTables.LocalFileIO(),
+            EncryptionTestHelpers.createEncryptionManager(metadata.encryptionKeys()))) {
+      return ManifestLists.read(
+          io.newInputFile(
+              new BaseManifestListFile(snapshot.manifestListLocation(), snapshot.keyId())));
+    }
+  }
+
   private ManifestFile writeAndReadEncryptedManifestList(EncryptionManager em) throws IOException {
     FileIO io = new InMemoryFileIO();
     EncryptingFileIO encryptingFileIO = EncryptingFileIO.combine(io, em);
@@ -218,9 +352,17 @@ public class TestManifestListEncryption {
             SNAPSHOT_ID - 1,
             SEQ_NUM,
             SNAPSHOT_FIRST_ROW_ID);
-    writer.add(TEST_MANIFEST);
-    writer.close();
+    try (writer) {
+      assertThatThrownBy(writer::toManifestListFile)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot build ManifestListFile, writer is not closed");
+      writer.add(TEST_MANIFEST);
+    }
+
     ManifestListFile manifestListFile = writer.toManifestListFile();
+    assertThat(writer.toManifestListFile().encryptionKeyID())
+        .isEqualTo(manifestListFile.encryptionKeyID());
+    ManifestListEncryptionKeys encryptionKeys = writer.encryptionKeys();
 
     // First try to read without decryption
     assertThatThrownBy(() -> ManifestLists.read(outputFile.toInputFile()))
@@ -228,10 +370,14 @@ public class TestManifestListEncryption {
         .hasMessageContaining("Failed to open file")
         .hasCauseInstanceOf(InvalidAvroMagicException.class);
 
-    List<ManifestFile> manifests =
-        ManifestLists.read(encryptingFileIO.newInputFile(manifestListFile));
-    assertThat(manifests.size()).isEqualTo(1);
-
-    return manifests.get(0);
+    try (FileIO readingIO =
+        EncryptingFileIO.combine(
+            io,
+            EncryptionTestHelpers.createEncryptionManager(
+                List.of(encryptionKeys.keyEncryptionKey(), encryptionKeys.manifestListKey())))) {
+      List<ManifestFile> manifests = ManifestLists.read(readingIO.newInputFile(manifestListFile));
+      assertThat(manifests).hasSize(1);
+      return manifests.get(0);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/encryption/EncryptionTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/EncryptionTestHelpers.java
@@ -30,6 +30,10 @@ public class EncryptionTestHelpers {
   private EncryptionTestHelpers() {}
 
   public static EncryptionManager createEncryptionManager() {
+    return createEncryptionManager(List.of());
+  }
+
+  public static EncryptionManager createEncryptionManager(List<EncryptedKey> keys) {
     Map<String, String> catalogProperties = Maps.newHashMap();
     catalogProperties.put(
         CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
@@ -37,7 +41,7 @@ public class EncryptionTestHelpers {
     tableProperties.put(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1);
 
     return EncryptionUtil.createEncryptionManager(
-        List.of(), tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
+        keys, tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
   }
 
   public static String keyEncryptionKeyID(EncryptionManager em) {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -219,6 +218,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
               .map(Lists::newLinkedList)
               .orElseGet(Lists::newLinkedList);
 
+      // Active transactions may still need keys that are not in committed metadata.
       if (encryptionManager != null) {
         Set<String> keyIdsFromMetadata =
             encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
@@ -240,34 +240,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     boolean newTable = base == null;
-    final TableMetadata tableMetadata;
     encryptionPropsFromMetadata(metadata.properties());
 
-    String newMetadataLocation;
-    EncryptionManager encrManager = encryption();
-    if (encrManager instanceof StandardEncryptionManager) {
-      // Add new encryption keys to the metadata
-      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
-      for (Map.Entry<String, EncryptedKey> entry :
-          EncryptionUtil.encryptionKeys(encrManager).entrySet()) {
-        builder.addEncryptionKey(entry.getValue());
-      }
+    String newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
 
-      tableMetadata = builder.build();
-    } else {
-      tableMetadata = metadata;
-    }
-
-    newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
-
-    boolean hiveEngineEnabled = hiveEngineEnabled(tableMetadata, conf);
+    boolean hiveEngineEnabled = hiveEngineEnabled(metadata, conf);
     boolean keepHiveStats = conf.getBoolean(ConfigProperties.KEEP_HIVE_STATS, false);
 
     BaseMetastoreOperations.CommitStatus commitStatus =
         BaseMetastoreOperations.CommitStatus.FAILURE;
     boolean updateHiveTable = false;
 
-    HiveLock lock = lockObject(base != null ? base : tableMetadata);
+    HiveLock lock = lockObject(base != null ? base : metadata);
     try {
       lock.lock();
 
@@ -291,14 +275,14 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       } else {
         tbl =
             newHmsTable(
-                tableMetadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
+                metadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
         LOG.debug("Committing new table: {}", fullName);
       }
 
       tbl.setSd(
           HiveOperationsBase.storageDescriptor(
-              tableMetadata.schema(),
-              tableMetadata.location(),
+              metadata.schema(),
+              metadata.location(),
               hiveEngineEnabled)); // set to pickup any schema changes
 
       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
@@ -314,7 +298,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       if (base != null) {
         removedProps =
             base.properties().keySet().stream()
-                .filter(key -> !tableMetadata.properties().containsKey(key))
+                .filter(key -> !metadata.properties().containsKey(key))
                 .collect(Collectors.toSet());
 
         Preconditions.checkArgument(
@@ -331,7 +315,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       HMSTablePropertyHelper.updateHmsTableForIcebergTable(
           newMetadataLocation,
           tbl,
-          tableMetadata,
+          metadata,
           removedProps,
           hiveEngineEnabled,
           maxHiveTablePropertySize,
@@ -388,7 +372,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
           // issue for example, and triggers this exception. So we need double-check to make sure
           // this is really a concurrent modification. Hitting this exception means no pending
           // requests, if any, can succeed later, so it's safe to check status in strict mode
-          commitStatus = checkCommitStatusStrict(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatusStrict(newMetadataLocation, metadata);
           if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
             throw new CommitFailedException(
                 e, "The table %s.%s has been modified concurrently", database, tableName);
@@ -399,7 +383,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
               database,
               tableName,
               e);
-          commitStatus = checkCommitStatus(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatus(newMetadataLocation, metadata);
         }
 
         switch (commitStatus) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
@@ -139,6 +140,28 @@ public class TestTableEncryption extends CatalogTestBase {
     // add an arbitrary datafile
     append.appendFile(dataFiles.get(0));
     append.commit();
+    transaction.commitTransaction();
+
+    assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);
+  }
+
+  @TestTemplate
+  void transactionCanReadAfterTableRefresh() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<DataFile> dataFiles = currentDataFiles(table);
+    DataFile file = dataFiles.get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // Refresh must preserve the keys for the transaction's uncommitted snapshot.
+    table.refresh();
+
+    assertThat(SnapshotChanges.builderFor(transaction.table()).build().addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(file.location());
+
     transaction.commitTransaction();
 
     assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
@@ -139,6 +140,28 @@ public class TestTableEncryption extends CatalogTestBase {
     // add an arbitrary datafile
     append.appendFile(dataFiles.get(0));
     append.commit();
+    transaction.commitTransaction();
+
+    assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);
+  }
+
+  @TestTemplate
+  void transactionCanReadAfterTableRefresh() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<DataFile> dataFiles = currentDataFiles(table);
+    DataFile file = dataFiles.get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // Refresh must preserve the keys for the transaction's uncommitted snapshot.
+    table.refresh();
+
+    assertThat(SnapshotChanges.builderFor(transaction.table()).build().addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(file.location());
+
     transaction.commitTransaction();
 
     assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
@@ -139,6 +140,28 @@ public class TestTableEncryption extends CatalogTestBase {
     // add an arbitrary datafile
     append.appendFile(dataFiles.get(0));
     append.commit();
+    transaction.commitTransaction();
+
+    assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);
+  }
+
+  @TestTemplate
+  void transactionCanReadAfterTableRefresh() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<DataFile> dataFiles = currentDataFiles(table);
+    DataFile file = dataFiles.get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // Refresh must preserve the keys for the transaction's uncommitted snapshot.
+    table.refresh();
+
+    assertThat(SnapshotChanges.builderFor(transaction.table()).build().addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(file.location());
+
     transaction.commitTransaction();
 
     assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 1);


### PR DESCRIPTION
Closes #17990 and #17989. Related to #16525.

Concurrent refreshes can replace a writer's encryption manager, allowing a snapshot to commit without the keys needed to read its manifest list.

The writer now returns the encrypted key metadata and its wrapping key directly, and `SnapshotProducer` commits them with the snapshot. Manifest-list conversion is idempotent.

Hive's commit-time key collection is removed because snapshot updates now include their required keys. Refresh-time key merging remains to support reads from active transactions.

---
**AI Disclosure**
- Model: GPT-6 (this follow-up); earlier models [unknown - human to fill in]
- Platform/Tool: Codex; Claude Code is also attributed in the existing commit
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix manifest-list key persistence and address review feedback with generic registration names.
