### PR TITLE
Core: Defensively copy TableMetadata.encryptionKeys to an immutable list

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -353,7 +353,7 @@ public class TableMetadata implements Serializable {
     this.snapshotsLoaded = snapshotsSupplier == null;
     this.snapshotLog = snapshotLog;
     this.previousFiles = previousFiles;
-    this.encryptionKeys = encryptionKeys;
+    this.encryptionKeys = ImmutableList.copyOf(encryptionKeys);
 
     // changes are carried through until metadata is read from a file
     this.changes = changes;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -353,7 +353,7 @@ public class TableMetadata implements Serializable {
     this.snapshotsLoaded = snapshotsSupplier == null;
     this.snapshotLog = snapshotLog;
     this.previousFiles = previousFiles;
-    this.encryptionKeys = ImmutableList.copyOf(encryptionKeys);
+    this.encryptionKeys = encryptionKeys;
 
     // changes are carried through until metadata is read from a file
     this.changes = changes;
@@ -1607,7 +1607,7 @@ public class TableMetadata implements Serializable {
               .flatMap(List::stream)
               .collect(Collectors.toList()),
           nextRowId,
-          encryptionKeys,
+          ImmutableList.copyOf(encryptionKeys),
           discardChanges ? ImmutableList.of() : ImmutableList.copyOf(changes));
     }
 


### PR DESCRIPTION
Metadata encryption keys are returned my `encryptionKeys`, but they are _not_ copied into immutable lists on construction anywhere, differing from the other lists like snapshots, statistics files, etc.