### PR TITLE
Core: Serialize commits in BaseCommitService

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -37,9 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An async service which allows for committing multiple file groups as their rewrites complete. The
- * service also allows for partial-progress since commits can fail. Once the service has been closed
- * no new file groups should not be offered.
+ * A service that commits file groups as rewrites complete. Commits are serialized and may run in a
+ * thread offering a file group or in the service executor during close. Other offering threads
+ * continue without waiting for an active commit. Failed commits permit partial progress. No groups
+ * may be offered after the service is closed.
  *
  * <p>Specific implementations provide implementations for {@link #commitOrClean(Set)} and {@link
  * #abortFileGroup(Object)}
@@ -59,13 +61,14 @@ abstract class BaseCommitService<T> implements Closeable {
   private final int rewritesPerCommit;
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final long timeoutInMS;
+  private final ReentrantLock commitLock = new ReentrantLock();
   private int succeededCommits = 0;
 
   /**
    * Constructs a {@link BaseCommitService}
    *
    * @param table table to perform commit on
-   * @param rewritesPerCommit number of file groups to include in a commit
+   * @param rewritesPerCommit positive number of file groups to include in a commit
    */
   BaseCommitService(Table table, int rewritesPerCommit) {
     this(table, rewritesPerCommit, TIMEOUT_IN_MS_DEFAULT);
@@ -75,11 +78,15 @@ abstract class BaseCommitService<T> implements Closeable {
    * Constructs a {@link BaseCommitService}
    *
    * @param table table to perform commit on
-   * @param rewritesPerCommit number of file groups to include in a commit
+   * @param rewritesPerCommit positive number of file groups to include in a commit
    * @param timeoutInMS The timeout to wait for commits to complete after all rewrite jobs have been
    *     completed
    */
   BaseCommitService(Table table, int rewritesPerCommit, long timeoutInMS) {
+    Preconditions.checkArgument(
+        rewritesPerCommit > 0,
+        "Invalid number of file groups per commit: %s (must be positive)",
+        rewritesPerCommit);
     this.table = table;
     LOG.info(
         "Creating commit service for table {} with {} groups per commit", table, rewritesPerCommit);
@@ -209,29 +216,50 @@ abstract class BaseCommitService<T> implements Closeable {
   }
 
   private void commitReadyCommitGroups() {
-    Set<T> batch = null;
-    if (canCreateCommitGroup()) {
-      synchronized (completedRewrites) {
-        if (canCreateCommitGroup()) {
-          batch = Sets.newHashSetWithExpectedSize(rewritesPerCommit);
-          for (int i = 0; i < rewritesPerCommit && !completedRewrites.isEmpty(); i++) {
-            batch.add(completedRewrites.poll());
+    while (canCreateCommitGroup()) {
+      if (!commitLock.tryLock()) {
+        return;
+      }
+
+      try {
+        while (canCreateCommitGroup()) {
+          Set<T> batch = null;
+          String inProgressCommitToken = null;
+          try {
+            synchronized (completedRewrites) {
+              if (canCreateCommitGroup()) {
+                batch = Sets.newHashSetWithExpectedSize(rewritesPerCommit);
+                // The committer may exit as soon as both queues are empty.
+                inProgressCommitToken = UUID.randomUUID().toString();
+                inProgressCommits.add(inProgressCommitToken);
+                for (int i = 0; i < rewritesPerCommit && !completedRewrites.isEmpty(); i++) {
+                  batch.add(completedRewrites.poll());
+                }
+              }
+            }
+
+            if (batch != null) {
+              commitBatch(batch);
+            }
+          } finally {
+            if (inProgressCommitToken != null) {
+              inProgressCommits.remove(inProgressCommitToken);
+            }
           }
         }
+      } finally {
+        commitLock.unlock();
       }
     }
+  }
 
-    if (batch != null) {
-      String inProgressCommitToken = UUID.randomUUID().toString();
-      inProgressCommits.add(inProgressCommitToken);
-      try {
-        commitOrClean(batch);
-        committedRewrites.addAll(batch);
-        succeededCommits++;
-      } catch (Exception e) {
-        LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
-      }
-      inProgressCommits.remove(inProgressCommitToken);
+  private void commitBatch(Set<T> batch) {
+    try {
+      commitOrClean(batch);
+      committedRewrites.addAll(batch);
+      succeededCommits++;
+    } catch (Exception e) {
+      LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -150,11 +150,11 @@ public class RewriteDataFilesCommitManager {
   }
 
   /**
-   * An async service which allows for committing multiple file groups as their rewrites complete.
-   * The service also allows for partial-progress since commits can fail. Once the service has been
-   * closed no new file groups should not be offered.
+   * A service that commits file groups as rewrites complete. Commits are serialized and may run in
+   * the thread offering a file group. Failed commits permit partial progress. No groups may be
+   * offered after the service is closed.
    *
-   * @param rewritesPerCommit number of file groups to include in a commit
+   * @param rewritesPerCommit positive number of file groups to include in a commit
    * @return the service for handling commits
    */
   public CommitService service(int rewritesPerCommit) {

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -115,11 +115,11 @@ public class RewritePositionDeletesCommitManager {
   }
 
   /**
-   * An async service which allows for committing multiple file groups as their rewrites complete.
-   * The service also allows for partial-progress since commits can fail. Once the service has been
-   * closed no new file groups should not be offered.
+   * A service that commits file groups as rewrites complete. Commits are serialized and may run in
+   * the thread offering a file group. Failed commits permit partial progress. No groups may be
+   * offered after the service is closed.
    *
-   * @param rewritesPerCommit number of file groups to include in a commit
+   * @param rewritesPerCommit positive number of file groups to include in a commit
    * @return the service for handling commits
    */
   public CommitService service(int rewritesPerCommit) {

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -26,9 +26,13 @@ import static org.mockito.Mockito.spy;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -42,10 +46,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestCommitService extends TestBase {
+  private static final int BATCH_EXTRACTION_TIMEOUT_MS = 1000;
 
   @Parameters(name = "formatVersion = {0}")
   protected static List<Object> parameters() {
     return Arrays.asList(1);
+  }
+
+  @TestTemplate
+  void rejectsNonPositiveCommitGroupSize() {
+    assertThatThrownBy(() -> new CustomCommitService(table, 0, 10000))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid number of file groups per commit: 0 (must be positive)");
+    assertThatThrownBy(() -> new CustomCommitService(table, -1, 10000))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid number of file groups per commit: -1 (must be positive)");
   }
 
   @TestTemplate
@@ -64,81 +79,373 @@ public class TestCommitService extends TestBase {
   }
 
   @TestTemplate
-  public void testAbortFileGroupsAfterTimeout() {
-    CustomCommitService commitService = new CustomCommitService(table, 5, 200);
+  public void testAbortFileGroupsAfterTimeout() throws Exception {
+    BlockingCommitService commitService = new BlockingCommitService(table, 5, 100);
     commitService.start();
 
-    // Add file groups [0-3] for commit.
-    // There are less than the rewritesPerCommit, and thus will not trigger a commit action. Those
-    // file groups will be added to the completedRewrites queue.
-    // Now the queue has 4 file groups that need to commit.
-    for (int i = 0; i < 4; i++) {
-      commitService.offer(i);
-    }
-
-    // Add file groups [4-7] for commit
-    // These are gated to not be able to commit, so all those 4 file groups will be added to the
-    // queue as well.
-    // Now the queue has 8 file groups that need to commit.
     CustomCommitService spyCommitService = spy(commitService);
     doReturn(false).when(spyCommitService).canCreateCommitGroup();
-    for (int i = 4; i < 8; i++) {
+    for (int i = 0; i < 7; i++) {
       spyCommitService.offer(i);
     }
 
-    // close commitService.
-    // This allows committerService thread to start to commit the remaining file groups [0-7] in the
-    // completedRewrites queue. And also the main thread waits for the committerService thread to
-    // finish within a timeout.
+    ExecutorService offerExecutor = Executors.newSingleThreadExecutor();
+    ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> commitResult = offerExecutor.submit(() -> commitService.offer(7));
+      assertThat(commitService.commitStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-    // The committerService thread commits file groups [0-4]. These will wait a fixed duration to
-    // simulate timeout on the main thread, which then tries to abort file groups [5-7].
-    // This tests the race conditions, as the committerService is also trying to commit groups
-    // [5-7].
-    assertThatThrownBy(commitService::close)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Timeout occurred when waiting for commits")
-        .hasMessageNotContaining("{}")
-        .hasMessageMatching(
-            ".*\\d+ file groups committed\\. \\d+ file groups remain uncommitted\\..*");
+      Future<Throwable> closeResult =
+          closeExecutor.submit(
+              () -> {
+                try {
+                  commitService.close();
+                  return null;
+                } catch (Throwable e) {
+                  return e;
+                }
+              });
 
-    // Wait for the commitService to finish. Committed all file groups or aborted remaining file
-    // groups.
+      assertThat(closeResult.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Timeout occurred when waiting for commits")
+          .hasMessageNotContaining("{}")
+          .hasMessageMatching(
+              ".*\\d+ file groups committed\\. \\d+ file groups remain uncommitted\\..*");
+      assertThat(commitService.aborted).containsExactlyInAnyOrder(5, 6, 7);
+      commitService.releaseCommit.countDown();
+      commitResult.get(5, TimeUnit.SECONDS);
+    } finally {
+      commitService.releaseCommit.countDown();
+      offerExecutor.shutdownNow();
+      closeExecutor.shutdownNow();
+      closeQuietly(commitService);
+    }
+
+    assertThat(offerExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(closeExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
         .pollInSameThread()
         .untilAsserted(() -> assertThat(commitService.completedRewritesAllCommitted()).isTrue());
-    if (commitService.aborted.isEmpty()) {
-      // All file groups are committed
-      assertThat(commitService.results()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7);
-    } else {
-      // File groups [5-7] are aborted
-      assertThat(commitService.results()).doesNotContainAnyElementsOf(commitService.aborted);
-      assertThat(commitService.results()).containsExactly(0, 1, 2, 3, 4);
-      assertThat(commitService.aborted).containsExactly(5, 6, 7);
+    assertThat(commitService.results()).containsExactlyInAnyOrder(0, 1, 2, 3, 4);
+  }
+
+  @TestTemplate
+  void closeReportsTimeoutWhileBatchExtractionIsInProgress() throws Exception {
+    BlockingHashCodeCommitService commitService =
+        new BlockingHashCodeCommitService(table, 1, BATCH_EXTRACTION_TIMEOUT_MS);
+    BlockingHashCodeGroup group = new BlockingHashCodeGroup();
+    commitService.start();
+
+    ExecutorService offerExecutor = Executors.newSingleThreadExecutor();
+    ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> commitResult = offerExecutor.submit(() -> commitService.offer(group));
+      assertThat(group.hashCodeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      Future<Throwable> closeResult =
+          closeExecutor.submit(
+              () -> {
+                try {
+                  commitService.close();
+                  return null;
+                } catch (Throwable e) {
+                  return e;
+                }
+              });
+
+      assertThat(closeResult.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Timeout occurred when waiting for commits");
+      group.releaseHashCode.countDown();
+      commitResult.get(5, TimeUnit.SECONDS);
+    } finally {
+      group.releaseHashCode.countDown();
+      offerExecutor.shutdownNow();
+      closeExecutor.shutdownNow();
+      closeQuietly(commitService);
+    }
+
+    assertThat(offerExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(closeExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(commitService.results()).containsExactly(group);
+  }
+
+  @TestTemplate
+  void failedBatchExtractionDoesNotStrandClose() {
+    ThrowingHashCodeCommitService commitService =
+        new ThrowingHashCodeCommitService(table, 1, BATCH_EXTRACTION_TIMEOUT_MS);
+    commitService.start();
+
+    boolean closed = false;
+    try {
+      assertThatThrownBy(() -> commitService.offer(new ThrowingHashCodeGroup()))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot hash file group");
+
+      commitService.close();
+      closed = true;
+    } finally {
+      if (!closed) {
+        closeQuietly(commitService);
+      }
     }
   }
 
-  private static class CustomCommitService extends BaseCommitService<Integer> {
-    private final Set<Integer> aborted = Sets.newConcurrentHashSet();
+  @TestTemplate
+  void serializesCommitsWithoutBlockingOtherOffers() throws Exception {
+    TrackingCommitService commitService = new TrackingCommitService(table);
+    commitService.start();
 
-    CustomCommitService(Table table, int rewritesPerCommit, int timeoutInSeconds) {
-      super(table, rewritesPerCommit, timeoutInSeconds);
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    boolean closed = false;
+    try {
+      Future<?> firstCommit = executorService.submit(() -> commitService.offer(0));
+      assertThat(commitService.firstCommitStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      Future<?> secondCommit = executorService.submit(() -> commitService.offer(1));
+      secondCommit.get(5, TimeUnit.SECONDS);
+      assertThat(commitService.secondCommitStarted.getCount()).isEqualTo(1);
+      assertThat(commitService.maxConcurrentCommits.get()).isEqualTo(1);
+
+      commitService.releaseCommits.countDown();
+      firstCommit.get(5, TimeUnit.SECONDS);
+      assertThat(commitService.secondCommitStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      commitService.close();
+      closed = true;
+    } finally {
+      commitService.releaseCommits.countDown();
+      executorService.shutdownNow();
+      if (!closed) {
+        closeQuietly(commitService);
+      }
+    }
+
+    assertThat(executorService.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(commitService.results()).containsExactlyInAnyOrder(0, 1);
+  }
+
+  @TestTemplate
+  void drainOwnerProcessesBatchOfferedDuringHandoff() throws Exception {
+    HandoffCommitService commitService = new HandoffCommitService(table);
+    commitService.start();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    boolean closed = false;
+    try {
+      Future<?> firstCommit = executorService.submit(() -> commitService.offer(0));
+      assertThat(commitService.firstCommitStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      commitService.releaseFirstCommit.countDown();
+      assertThat(commitService.ownerObservedEmptyQueue.await(5, TimeUnit.SECONDS)).isTrue();
+
+      Future<?> handoffOffer = executorService.submit(() -> commitService.offer(1));
+      handoffOffer.get(5, TimeUnit.SECONDS);
+      assertThat(commitService.secondCommitStarted.getCount()).isEqualTo(1);
+
+      commitService.releaseOwner.countDown();
+      assertThat(commitService.secondCommitStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      firstCommit.get(5, TimeUnit.SECONDS);
+      commitService.close();
+      closed = true;
+    } finally {
+      commitService.releaseFirstCommit.countDown();
+      commitService.releaseOwner.countDown();
+      executorService.shutdownNow();
+      if (!closed) {
+        closeQuietly(commitService);
+      }
+    }
+
+    assertThat(executorService.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(commitService.results()).containsExactlyInAnyOrder(0, 1);
+  }
+
+  private static class CustomCommitService extends BaseCommitService<Integer> {
+    CustomCommitService(Table table, int rewritesPerCommit, int timeoutInMS) {
+      super(table, rewritesPerCommit, timeoutInMS);
+    }
+
+    @Override
+    protected void commitOrClean(Set<Integer> batch) {}
+
+    @Override
+    protected void abortFileGroup(Integer group) {}
+  }
+
+  private static class BlockingCommitService extends CustomCommitService {
+    private final Set<Integer> aborted = Sets.newConcurrentHashSet();
+    private final CountDownLatch commitStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseCommit = new CountDownLatch(1);
+
+    BlockingCommitService(Table table, int rewritesPerCommit, int timeoutInMS) {
+      super(table, rewritesPerCommit, timeoutInMS);
     }
 
     @Override
     protected void commitOrClean(Set<Integer> batch) {
-      try {
-        // Slightly longer than timeout
-        Thread.sleep(210);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
+      commitStarted.countDown();
+      await(releaseCommit);
     }
 
     @Override
     protected void abortFileGroup(Integer group) {
       aborted.add(group);
+    }
+  }
+
+  private static class BlockingHashCodeCommitService
+      extends BaseCommitService<BlockingHashCodeGroup> {
+
+    BlockingHashCodeCommitService(Table table, int rewritesPerCommit, int timeoutInMS) {
+      super(table, rewritesPerCommit, timeoutInMS);
+    }
+
+    @Override
+    protected void commitOrClean(Set<BlockingHashCodeGroup> batch) {}
+
+    @Override
+    protected void abortFileGroup(BlockingHashCodeGroup group) {}
+  }
+
+  private static class BlockingHashCodeGroup {
+    private final CountDownLatch hashCodeStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseHashCode = new CountDownLatch(1);
+
+    @Override
+    public int hashCode() {
+      hashCodeStarted.countDown();
+      await(releaseHashCode);
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return this == other;
+    }
+  }
+
+  private static class ThrowingHashCodeCommitService
+      extends BaseCommitService<ThrowingHashCodeGroup> {
+
+    ThrowingHashCodeCommitService(Table table, int rewritesPerCommit, int timeoutInMS) {
+      super(table, rewritesPerCommit, timeoutInMS);
+    }
+
+    @Override
+    protected void commitOrClean(Set<ThrowingHashCodeGroup> batch) {}
+
+    @Override
+    protected void abortFileGroup(ThrowingHashCodeGroup group) {}
+  }
+
+  private static class ThrowingHashCodeGroup {
+    @Override
+    public int hashCode() {
+      throw new IllegalStateException("Cannot hash file group");
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return this == other;
+    }
+  }
+
+  private static class TrackingCommitService extends BaseCommitService<Integer> {
+    private final CountDownLatch firstCommitStarted = new CountDownLatch(1);
+    private final CountDownLatch secondCommitStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseCommits = new CountDownLatch(1);
+    private final AtomicInteger activeCommits = new AtomicInteger(0);
+    private final AtomicInteger maxConcurrentCommits = new AtomicInteger(0);
+
+    TrackingCommitService(Table table) {
+      this(table, 1);
+    }
+
+    TrackingCommitService(Table table, int rewritesPerCommit) {
+      super(table, rewritesPerCommit, 10000);
+    }
+
+    @Override
+    protected void commitOrClean(Set<Integer> batch) {
+      int active = activeCommits.incrementAndGet();
+      maxConcurrentCommits.accumulateAndGet(active, Math::max);
+      if (batch.contains(0)) {
+        firstCommitStarted.countDown();
+      } else {
+        secondCommitStarted.countDown();
+      }
+
+      try {
+        await(releaseCommits);
+      } finally {
+        activeCommits.decrementAndGet();
+      }
+    }
+
+    @Override
+    protected void abortFileGroup(Integer group) {}
+  }
+
+  private static class HandoffCommitService extends BaseCommitService<Integer> {
+    private final CountDownLatch firstCommitStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseFirstCommit = new CountDownLatch(1);
+    private final CountDownLatch ownerObservedEmptyQueue = new CountDownLatch(1);
+    private final CountDownLatch releaseOwner = new CountDownLatch(1);
+    private final CountDownLatch secondCommitStarted = new CountDownLatch(1);
+    private final AtomicBoolean pauseOwner = new AtomicBoolean(false);
+    private final AtomicBoolean ownerPaused = new AtomicBoolean(false);
+    private volatile Thread ownerThread = null;
+
+    HandoffCommitService(Table table) {
+      super(table, 1, 10000);
+    }
+
+    @Override
+    protected void commitOrClean(Set<Integer> batch) {
+      if (batch.contains(0)) {
+        ownerThread = Thread.currentThread();
+        firstCommitStarted.countDown();
+        await(releaseFirstCommit);
+        pauseOwner.set(true);
+      } else {
+        secondCommitStarted.countDown();
+      }
+    }
+
+    @Override
+    protected void abortFileGroup(Integer group) {}
+
+    @Override
+    boolean canCreateCommitGroup() {
+      boolean canCreate = super.canCreateCommitGroup();
+      if (!canCreate
+          && pauseOwner.get()
+          && Thread.currentThread().equals(ownerThread)
+          && ownerPaused.compareAndSet(false, true)) {
+        ownerObservedEmptyQueue.countDown();
+        await(releaseOwner);
+      }
+
+      return canCreate;
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void closeQuietly(BaseCommitService<?> commitService) {
+    try {
+      commitService.close();
+    } catch (RuntimeException ignored) {
+      // The original test failure should not be replaced by a cleanup failure.
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -324,6 +324,11 @@ public class TestCommitService extends TestBase {
     public boolean equals(Object other) {
       return this == other;
     }
+
+    @Override
+    public String toString() {
+      return "BlockingHashCodeGroup";
+    }
   }
 
   private static class ThrowingHashCodeCommitService

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -360,11 +360,7 @@ public class TestCommitService extends TestBase {
     private final AtomicInteger maxConcurrentCommits = new AtomicInteger(0);
 
     TrackingCommitService(Table table) {
-      this(table, 1);
-    }
-
-    TrackingCommitService(Table table, int rewritesPerCommit) {
-      super(table, rewritesPerCommit, 10000);
+      super(table, 1, 10000);
     }
 
     @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1428,16 +1428,13 @@ public class TestRewriteDataFilesAction extends TestBase {
             // Since we can have at most one commit per file group and there are only 10 file
             // groups, actual number of commits is 10
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "20")
-            // Setting max-failed-commits to 1 to tolerate random commit failure
-            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
-    rewrite.execute();
+            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "0");
+    Result result = rewrite.execute();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    assertThat(table.snapshots())
-        .as("Table did not have the expected number of snapshots")
-        // To tolerate 1 random commit failure
-        .hasSizeGreaterThanOrEqualTo(10);
+    assertThat(result.rewriteResults()).as("Should have 10 file groups").hasSize(10);
+    shouldHaveSnapshots(table, 11);
     shouldHaveNoOrphans(table);
     shouldHaveACleanCache(table);
   }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1429,16 +1429,13 @@ public class TestRewriteDataFilesAction extends TestBase {
             // Since we can have at most one commit per file group and there are only 10 file
             // groups, actual number of commits is 10
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "20")
-            // Setting max-failed-commits to 1 to tolerate random commit failure
-            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
-    rewrite.execute();
+            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "0");
+    Result result = rewrite.execute();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    assertThat(table.snapshots())
-        .as("Table did not have the expected number of snapshots")
-        // To tolerate 1 random commit failure
-        .hasSizeGreaterThanOrEqualTo(10);
+    assertThat(result.rewriteResults()).as("Should have 10 file groups").hasSize(10);
+    shouldHaveSnapshots(table, 11);
     shouldHaveNoOrphans(table);
     shouldHaveACleanCache(table);
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1429,16 +1429,13 @@ public class TestRewriteDataFilesAction extends TestBase {
             // Since we can have at most one commit per file group and there are only 10 file
             // groups, actual number of commits is 10
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "20")
-            // Setting max-failed-commits to 1 to tolerate random commit failure
-            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
-    rewrite.execute();
+            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "0");
+    Result result = rewrite.execute();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    assertThat(table.snapshots())
-        .as("Table did not have the expected number of snapshots")
-        // To tolerate 1 random commit failure
-        .hasSizeGreaterThanOrEqualTo(10);
+    assertThat(result.rewriteResults()).as("Should have 10 file groups").hasSize(10);
+    shouldHaveSnapshots(table, 11);
     shouldHaveNoOrphans(table);
     shouldHaveACleanCache(table);
   }

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1429,16 +1429,13 @@ public class TestRewriteDataFilesAction extends TestBase {
             // Since we can have at most one commit per file group and there are only 10 file
             // groups, actual number of commits is 10
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "20")
-            // Setting max-failed-commits to 1 to tolerate random commit failure
-            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
-    rewrite.execute();
+            .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "0");
+    Result result = rewrite.execute();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    assertThat(table.snapshots())
-        .as("Table did not have the expected number of snapshots")
-        // To tolerate 1 random commit failure
-        .hasSizeGreaterThanOrEqualTo(10);
+    assertThat(result.rewriteResults()).as("Should have 10 file groups").hasSize(10);
+    shouldHaveSnapshots(table, 11);
     shouldHaveNoOrphans(table);
     shouldHaveACleanCache(table);
   }


### PR DESCRIPTION
Relates to apache/iceberg#9521, and https://github.com/apache/iceberg/issues/17989#issuecomment-5564823202.

## Before this PR

`BaseCommitService.offer` is called by each file-group worker when its rewrite finishes. It extracts a batch of completed groups under `synchronized (completedRewrites)`, then commits that batch after releasing the monitor:

```java
synchronized (completedRewrites) {
  if (canCreateCommitGroup()) {
    batch = ...;
  }
}

if (batch != null) {
  commitOrClean(batch);
}
```

The queue is protected, but the table commit is not. With `max-concurrent-file-group-rewrites > 1`, workers from the same `rewrite_data_files` action can issue concurrent commits to the same table. Iceberg's optimistic commit protocol makes those commits conflict, retry, and back off even when there is no external writer. If a worker exhausts `commit.retry.num-retries`, `commitOrClean` deletes its newly written files and drops the completed group.

There is also a bookkeeping window after a batch leaves `completedRewrites` and before its token enters `inProgressCommits`. During that window, close-time accounting can observe neither queued nor active work.

The performance workload uses Spark 4.1 on `local[*]`, a local Hadoop catalog, JDK 21, and 32 cores. Each JMH single-shot iteration rebuilds a table with 100,000 rows in 20 files, rewrites 10 two-file groups with partial progress enabled and one group per commit, and verifies that all groups committed and the table has 11 snapshots. The timing run uses 20 commit retries so conflicts appear as latency rather than lost work.

## After this PR

One offering thread takes non-blocking drain ownership with `ReentrantLock.tryLock()` and commits every ready batch serially. A competing offer leaves its group queued and returns instead of waiting for the active commit. The owner rechecks eligibility after releasing the lock so a group offered during handoff is not stranded.

Batch extraction and in-progress publication now happen in the same queue critical section, while commit and cleanup remain outside it. This keeps close-time accounting live and allows timeout cleanup to abort queued groups during a slow commit. Non-positive batch sizes are rejected so the drain loop always makes progress. External writers are unchanged and still use Iceberg's existing optimistic retry behavior.

On the workload above, serializing commits removes the retry backoff caused by self-conflict:

| `max-concurrent-file-group-rewrites` | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1 | 1.643 s ± 0.105 | 1.605 s ± 0.120 | no measurable difference |
| 4 | 5.541 s ± 2.148 | 1.180 s ± 0.105 | 4.7× faster |
| 8 | 6.524 s ± 0.675 | 1.141 s ± 0.054 | 5.7× faster |

The values are mean ± 99.9% confidence interval in seconds per operation. The one-worker control is unchanged. These are end-to-end results for this local Hadoop catalog workload; its lock-manager retry contributes to the measured before latency, so the multiplier is not catalog-independent.

A second run sets `commit.retry.num-retries=0`, making every self-conflict an immediately observable failed commit. Across 10 trials with 4 rewrite workers:

| | Before | After |
| --- | ---: | ---: |
| Groups committed per run | 3–4 of 10 | 10 of 10 |
| Runs that lost groups | 10 of 10 | 0 of 10 |
| Mean groups lost per run | 6.8 | 0 |

No self-conflict was observed after serialization in those trials.

## AI Tooling

This PR was written by Codex but reviewed by me.
