### PR TITLE
Spark: Encrypt manifests written by `rewrite_manifests`

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -50,10 +50,10 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -591,8 +591,9 @@ public class RewriteManifestsSparkAction
     }
 
     private EncryptedOutputFile newOutputFile() {
-      return EncryptingFileIO.combine(table().io(), table().encryption())
-          .newEncryptingOutputFile(newManifestLocation());
+      Table table = table();
+      OutputFile rawOutputFile = table.io().newOutputFile(newManifestLocation());
+      return table.encryption().encrypt(rawOutputFile);
     }
 
     private String newManifestLocation() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -49,10 +49,11 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -589,8 +590,9 @@ public class RewriteManifestsSparkAction
       return table().specs().get(specId);
     }
 
-    private OutputFile newOutputFile() {
-      return table().io().newOutputFile(newManifestLocation());
+    private EncryptedOutputFile newOutputFile() {
+      return EncryptingFileIO.combine(table().io(), table().encryption())
+          .newEncryptingOutputFile(newManifestLocation());
     }
 
     private String newManifestLocation() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.encryption.Ciphers;
+import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+// TODO: Port the remaining TestTableEncryption and TestCTASEncryption tests from Spark 4.0.
+class TestTableEncryption extends CatalogTestBase {
+  private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
+    Map<String, String> newProps = new HashMap<>(props);
+    newProps.put(CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
+    return newProps;
+  }
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        appendCatalogEncryptionProperties(SparkCatalogConfig.HIVE.properties())
+      }
+    };
+  }
+
+  @BeforeEach
+  void createTables() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string, float float) USING iceberg "
+            + "TBLPROPERTIES ( "
+            + "'encryption.key-id'='%s', 'format-version'='3')",
+        tableName, UnitestKMS.MASTER_KEY_NAME1);
+
+    sql("INSERT INTO %s VALUES (1, 'a', 1.0), (2, 'b', 2.0), (3, 'c', float('NaN'))", tableName);
+  }
+
+  @AfterEach
+  void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  void rewriteManifestsOnEncryptedTables() throws IOException {
+    // A second append ensures there is more than one manifest to rewrite.
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    RewriteManifests.Result result = SparkActions.get().rewriteManifests(table).execute();
+
+    assertThat(result.rewrittenManifests()).hasSizeGreaterThan(1);
+    assertThat(result.addedManifests()).isNotEmpty();
+
+    for (ManifestFile manifest : result.addedManifests()) {
+      assertThat(manifest.keyMetadata()).isNotNull();
+      checkMetadataFileEncryption(localInput(manifest.path()));
+    }
+
+    // The action commits through a separate catalog instance.
+    sql("REFRESH TABLE %s", tableName);
+
+    List<Object[]> expected =
+        List.of(
+            row(1L, "a", 1.0F),
+            row(2L, "b", 2.0F),
+            row(3L, "c", Float.NaN),
+            row(4L, "d", 4.0F),
+            row(5L, "e", 5.0F),
+            row(6L, "f", Float.NaN));
+
+    assertEquals(
+        "Should return all expected rows",
+        expected,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  private void checkMetadataFileEncryption(InputFile file) throws IOException {
+    byte[] expectedMagic = Ciphers.GCM_STREAM_MAGIC_STRING.getBytes(StandardCharsets.UTF_8);
+    try (SeekableInputStream stream = file.newStream()) {
+      assertThat(stream.readNBytes(expectedMagic.length)).isEqualTo(expectedMagic);
+    }
+  }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
@@ -35,6 +34,7 @@ import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.actions.SparkActions;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.TestTemplate;
 // TODO: Port the remaining TestTableEncryption and TestCTASEncryption tests from Spark 4.0.
 class TestTableEncryption extends CatalogTestBase {
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
-    Map<String, String> newProps = new HashMap<>(props);
+    Map<String, String> newProps = Maps.newHashMap(props);
     newProps.put(CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
     return newProps;
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -50,10 +50,10 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -591,8 +591,9 @@ public class RewriteManifestsSparkAction
     }
 
     private EncryptedOutputFile newOutputFile() {
-      return EncryptingFileIO.combine(table().io(), table().encryption())
-          .newEncryptingOutputFile(newManifestLocation());
+      Table table = table();
+      OutputFile rawOutputFile = table.io().newOutputFile(newManifestLocation());
+      return table.encryption().encrypt(rawOutputFile);
     }
 
     private String newManifestLocation() {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -49,10 +49,11 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -589,8 +590,9 @@ public class RewriteManifestsSparkAction
       return table().specs().get(specId);
     }
 
-    private OutputFile newOutputFile() {
-      return table().io().newOutputFile(newManifestLocation());
+    private EncryptedOutputFile newOutputFile() {
+      return EncryptingFileIO.combine(table().io(), table().encryption())
+          .newEncryptingOutputFile(newManifestLocation());
     }
 
     private String newManifestLocation() {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -368,6 +368,9 @@ public class TestTableEncryption extends CatalogTestBase {
       checkMetadataFileEncryption(localInput(manifest.path()));
     }
 
+    // The action commits through a separate catalog instance.
+    sql("REFRESH TABLE %s", tableName);
+
     List<Object[]> expected =
         ImmutableList.of(
             row(1L, "a", 1.0F),

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -350,7 +350,7 @@ public class TestTableEncryption extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsEncryption() throws IOException {
+  public void rewriteManifestsOnEncryptedTables() throws IOException {
     // append a second time, so that there is more than one manifest to rewrite
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -38,12 +38,14 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -344,6 +347,40 @@ public class TestTableEncryption extends CatalogTestBase {
     if (!foundManifestListFile) {
       throw new RuntimeException("No manifest list files found for table " + tableName);
     }
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsEncryption() throws IOException {
+    // append a second time, so that there is more than one manifest to rewrite
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    RewriteManifests.Result result = SparkActions.get().rewriteManifests(table).execute();
+
+    // guard against the action short-circuiting
+    assertThat(result.rewrittenManifests()).hasSizeGreaterThan(1);
+    assertThat(result.addedManifests()).isNotEmpty();
+
+    for (ManifestFile manifest : result.addedManifests()) {
+      assertThat(manifest.keyMetadata()).isNotNull();
+      checkMetadataFileEncryption(localInput(manifest.path()));
+    }
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(1L, "a", 1.0F),
+            row(2L, "b", 2.0F),
+            row(3L, "c", Float.NaN),
+            row(4L, "d", 4.0F),
+            row(5L, "e", 5.0F),
+            row(6L, "f", Float.NaN));
+
+    assertEquals(
+        "Should return all expected rows",
+        expected,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -50,10 +50,10 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -591,8 +591,9 @@ public class RewriteManifestsSparkAction
     }
 
     private EncryptedOutputFile newOutputFile() {
-      return EncryptingFileIO.combine(table().io(), table().encryption())
-          .newEncryptingOutputFile(newManifestLocation());
+      Table table = table();
+      OutputFile rawOutputFile = table.io().newOutputFile(newManifestLocation());
+      return table.encryption().encrypt(rawOutputFile);
     }
 
     private String newManifestLocation() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -49,10 +49,11 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -589,8 +590,9 @@ public class RewriteManifestsSparkAction
       return table().specs().get(specId);
     }
 
-    private OutputFile newOutputFile() {
-      return table().io().newOutputFile(newManifestLocation());
+    private EncryptedOutputFile newOutputFile() {
+      return EncryptingFileIO.combine(table().io(), table().encryption())
+          .newEncryptingOutputFile(newManifestLocation());
     }
 
     private String newManifestLocation() {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -368,6 +368,9 @@ public class TestTableEncryption extends CatalogTestBase {
       checkMetadataFileEncryption(localInput(manifest.path()));
     }
 
+    // The action commits through a separate catalog instance.
+    sql("REFRESH TABLE %s", tableName);
+
     List<Object[]> expected =
         ImmutableList.of(
             row(1L, "a", 1.0F),

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -350,7 +350,7 @@ public class TestTableEncryption extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsEncryption() throws IOException {
+  public void rewriteManifestsOnEncryptedTables() throws IOException {
     // append a second time, so that there is more than one manifest to rewrite
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -38,12 +38,14 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -344,6 +347,40 @@ public class TestTableEncryption extends CatalogTestBase {
     if (!foundManifestListFile) {
       throw new RuntimeException("No manifest list files found for table " + tableName);
     }
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsEncryption() throws IOException {
+    // append a second time, so that there is more than one manifest to rewrite
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    RewriteManifests.Result result = SparkActions.get().rewriteManifests(table).execute();
+
+    // guard against the action short-circuiting
+    assertThat(result.rewrittenManifests()).hasSizeGreaterThan(1);
+    assertThat(result.addedManifests()).isNotEmpty();
+
+    for (ManifestFile manifest : result.addedManifests()) {
+      assertThat(manifest.keyMetadata()).isNotNull();
+      checkMetadataFileEncryption(localInput(manifest.path()));
+    }
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(1L, "a", 1.0F),
+            row(2L, "b", 2.0F),
+            row(3L, "c", Float.NaN),
+            row(4L, "d", 4.0F),
+            row(5L, "e", 5.0F),
+            row(6L, "f", Float.NaN));
+
+    assertEquals(
+        "Should return all expected rows",
+        expected,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -50,10 +50,10 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -591,8 +591,9 @@ public class RewriteManifestsSparkAction
     }
 
     private EncryptedOutputFile newOutputFile() {
-      return EncryptingFileIO.combine(table().io(), table().encryption())
-          .newEncryptingOutputFile(newManifestLocation());
+      Table table = table();
+      OutputFile rawOutputFile = table.io().newOutputFile(newManifestLocation());
+      return table.encryption().encrypt(rawOutputFile);
     }
 
     private String newManifestLocation() {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -49,10 +49,11 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -589,8 +590,9 @@ public class RewriteManifestsSparkAction
       return table().specs().get(specId);
     }
 
-    private OutputFile newOutputFile() {
-      return table().io().newOutputFile(newManifestLocation());
+    private EncryptedOutputFile newOutputFile() {
+      return EncryptingFileIO.combine(table().io(), table().encryption())
+          .newEncryptingOutputFile(newManifestLocation());
     }
 
     private String newManifestLocation() {

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -38,12 +38,14 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -346,6 +349,40 @@ public class TestTableEncryption extends CatalogTestBase {
     if (!foundManifestListFile) {
       throw new RuntimeException("No manifest list files found for table " + tableName);
     }
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsEncryption() throws IOException {
+    // append a second time, so that there is more than one manifest to rewrite
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    RewriteManifests.Result result = SparkActions.get().rewriteManifests(table).execute();
+
+    // guard against the action short-circuiting
+    assertThat(result.rewrittenManifests()).hasSizeGreaterThan(1);
+    assertThat(result.addedManifests()).isNotEmpty();
+
+    for (ManifestFile manifest : result.addedManifests()) {
+      assertThat(manifest.keyMetadata()).isNotNull();
+      checkMetadataFileEncryption(localInput(manifest.path()));
+    }
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(1L, "a", 1.0F),
+            row(2L, "b", 2.0F),
+            row(3L, "c", Float.NaN),
+            row(4L, "d", 4.0F),
+            row(5L, "e", 5.0F),
+            row(6L, "f", Float.NaN));
+
+    assertEquals(
+        "Should return all expected rows",
+        expected,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @TestTemplate

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -352,7 +352,7 @@ public class TestTableEncryption extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsEncryption() throws IOException {
+  public void rewriteManifestsOnEncryptedTables() throws IOException {
     // append a second time, so that there is more than one manifest to rewrite
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0), (6, 'f', float('NaN'))", tableName);
 

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -370,6 +370,9 @@ public class TestTableEncryption extends CatalogTestBase {
       checkMetadataFileEncryption(localInput(manifest.path()));
     }
 
+    // The action commits through a separate catalog instance.
+    sql("REFRESH TABLE %s", tableName);
+
     List<Object[]> expected =
         ImmutableList.of(
             row(1L, "a", 1.0F),


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/17991.

`RewriteManifestsSparkAction` created its replacement-manifest output with `table().io().newOutputFile(...)`, which returns a plain `OutputFile`, so overload resolution selected the plaintext `ManifestFiles.write` and `writeDeleteManifest` variants. 

We now obtain an `EncryptedOutputFile` from the table's encryption manager instead, matching `SnapshotProducer.newManifestOutputFile()`. Behaviour is unchanged for tables without encryption.