### PR TITLE
Spark: Reject `rewrite_table_path` for encrypted tables

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.actions.RewriteTablePath;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.CloseableIterable;
@@ -191,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    Preconditions.checkArgument(
+        !(table.io() instanceof EncryptingFileIO),
+        "Cannot rewrite table paths for encrypted tables");
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -192,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    // Reject encrypted tables because this action does not propagate encryption metadata for
+    // rewritten files through manifests, manifest lists, snapshots, and table metadata.
+    // TODO: Add encrypted table support.
     Preconditions.checkArgument(
         !(table.io() instanceof EncryptingFileIO),
         "Cannot rewrite table paths for encrypted tables");

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.actions.RewriteTablePath;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.CloseableIterable;
@@ -191,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    Preconditions.checkArgument(
+        !(table.io() instanceof EncryptingFileIO),
+        "Cannot rewrite table paths for encrypted tables");
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -192,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    // Reject encrypted tables because this action does not propagate encryption metadata for
+    // rewritten files through manifests, manifest lists, snapshots, and table metadata.
+    // TODO: Add encrypted table support.
     Preconditions.checkArgument(
         !(table.io() instanceof EncryptingFileIO),
         "Cannot rewrite table paths for encrypted tables");

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -103,6 +104,24 @@ public class TestTableEncryption extends CatalogTestBase {
         ImmutableList.of(row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN));
 
     assertEquals("Should return all expected rows", expected, sql("SELECT * FROM %s", tableName));
+  }
+
+  @TestTemplate
+  public void testRejectsRewriteTablePath() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    File stagingDir = temp.resolve("rewrite-table-path-staging").toFile();
+
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .rewriteTablePath(table)
+                    .rewriteLocationPrefix(table.location(), table.location() + "-rewritten")
+                    .stagingLocation(stagingDir.getAbsolutePath())
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot rewrite table paths for encrypted tables");
+    assertThat(stagingDir).doesNotExist();
   }
 
   private static List<DataFile> currentDataFiles(Table table) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.actions.RewriteTablePath;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.CloseableIterable;
@@ -191,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    Preconditions.checkArgument(
+        !(table.io() instanceof EncryptingFileIO),
+        "Cannot rewrite table paths for encrypted tables");
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -192,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    // Reject encrypted tables because this action does not propagate encryption metadata for
+    // rewritten files through manifests, manifest lists, snapshots, and table metadata.
+    // TODO: Add encrypted table support.
     Preconditions.checkArgument(
         !(table.io() instanceof EncryptingFileIO),
         "Cannot rewrite table paths for encrypted tables");

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -103,6 +104,24 @@ public class TestTableEncryption extends CatalogTestBase {
         ImmutableList.of(row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN));
 
     assertEquals("Should return all expected rows", expected, sql("SELECT * FROM %s", tableName));
+  }
+
+  @TestTemplate
+  public void testRejectsRewriteTablePath() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    File stagingDir = temp.resolve("rewrite-table-path-staging").toFile();
+
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .rewriteTablePath(table)
+                    .rewriteLocationPrefix(table.location(), table.location() + "-rewritten")
+                    .stagingLocation(stagingDir.getAbsolutePath())
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot rewrite table paths for encrypted tables");
+    assertThat(stagingDir).doesNotExist();
   }
 
   private static List<DataFile> currentDataFiles(Table table) {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.actions.RewriteTablePath;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.CloseableIterable;
@@ -191,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    Preconditions.checkArgument(
+        !(table.io() instanceof EncryptingFileIO),
+        "Cannot rewrite table paths for encrypted tables");
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -192,6 +192,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         !sourcePrefix.equals(targetPrefix),
         "Source prefix cannot be the same as target prefix (%s)",
         sourcePrefix);
+    // Reject encrypted tables because this action does not propagate encryption metadata for
+    // rewritten files through manifests, manifest lists, snapshots, and table metadata.
+    // TODO: Add encrypted table support.
     Preconditions.checkArgument(
         !(table.io() instanceof EncryptingFileIO),
         "Cannot rewrite table paths for encrypted tables");

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -103,6 +104,24 @@ public class TestTableEncryption extends CatalogTestBase {
         ImmutableList.of(row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN));
 
     assertEquals("Should return all expected rows", expected, sql("SELECT * FROM %s", tableName));
+  }
+
+  @TestTemplate
+  public void testRejectsRewriteTablePath() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    File stagingDir = temp.resolve("rewrite-table-path-staging").toFile();
+
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .rewriteTablePath(table)
+                    .rewriteLocationPrefix(table.location(), table.location() + "-rewritten")
+                    .stagingLocation(stagingDir.getAbsolutePath())
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot rewrite table paths for encrypted tables");
+    assertThat(stagingDir).doesNotExist();
   }
 
   private static List<DataFile> currentDataFiles(Table table) {


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/17992 by having `rewrite_table_path ` throw on encrypted tables.

For an encrypted source table the rewrite completes and produces a target that cannot be read. Instead, we now reject encrypted tables in `validateInputs()`.