### PR TITLE
Spark: Reject table statistics for encrypted tables

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.ImmutableComputeTableStats;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
@@ -87,6 +88,11 @@ public class ComputeTableStatsSparkAction extends BaseSparkAction<ComputeTableSt
 
   @Override
   public Result execute() {
+    Preconditions.checkArgument(
+        !(table.encryption() instanceof StandardEncryptionManager),
+        "Cannot compute table statistics for an encrypted table: %s",
+        table.name());
+
     if (snapshot == null) {
       LOG.info("No snapshot to compute stats for table {}", table.name());
       return EMPTY_RESULT;

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.ImmutableComputeTableStats;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
@@ -87,6 +88,11 @@ public class ComputeTableStatsSparkAction extends BaseSparkAction<ComputeTableSt
 
   @Override
   public Result execute() {
+    Preconditions.checkArgument(
+        !(table.encryption() instanceof StandardEncryptionManager),
+        "Cannot compute table statistics for an encrypted table: %s",
+        table.name());
+
     if (snapshot == null) {
       LOG.info("No snapshot to compute stats for table {}", table.name());
       return EMPTY_RESULT;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -63,6 +65,8 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
+  private static final String EMPTY_TABLE = "empty_table";
+
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -95,6 +99,7 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -363,6 +368,33 @@ public class TestTableEncryption extends CatalogTestBase {
     assertThat(catalog.tableExists(tableIdent)).as("Table should not exist").isFalse();
     assertThat(dataFiles)
         .allSatisfy(filePath -> assertThat(localInput(filePath).exists()).isFalse());
+  }
+
+  @TestTemplate
+  public void testComputeTableStats() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
+  }
+
+  @TestTemplate
+  public void testComputeTableStatsWithoutSnapshot() {
+    sql(
+        "CREATE TABLE %s (id bigint) USING iceberg "
+            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
+        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table =
+        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
+    assertThat(table.currentSnapshot()).isNull();
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
   }
 
   private void checkMetadataFileEncryption(InputFile file) throws IOException {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -65,8 +64,6 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
-  private static final String EMPTY_TABLE = "empty_table";
-
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -99,7 +96,6 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
-    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -374,23 +370,6 @@ public class TestTableEncryption extends CatalogTestBase {
   public void testComputeTableStats() {
     validationCatalog.initialize(catalogName, catalogConfig);
     Table table = validationCatalog.loadTable(tableIdent);
-
-    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
-  }
-
-  @TestTemplate
-  public void testComputeTableStatsWithoutSnapshot() {
-    sql(
-        "CREATE TABLE %s (id bigint) USING iceberg "
-            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
-        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
-
-    validationCatalog.initialize(catalogName, catalogConfig);
-    Table table =
-        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
-    assertThat(table.currentSnapshot()).isNull();
 
     assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.ImmutableComputeTableStats;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
@@ -87,6 +88,11 @@ public class ComputeTableStatsSparkAction extends BaseSparkAction<ComputeTableSt
 
   @Override
   public Result execute() {
+    Preconditions.checkArgument(
+        !(table.encryption() instanceof StandardEncryptionManager),
+        "Cannot compute table statistics for an encrypted table: %s",
+        table.name());
+
     if (snapshot == null) {
       LOG.info("No snapshot to compute stats for table {}", table.name());
       return EMPTY_RESULT;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -63,6 +65,8 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
+  private static final String EMPTY_TABLE = "empty_table";
+
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -95,6 +99,7 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -363,6 +368,33 @@ public class TestTableEncryption extends CatalogTestBase {
     assertThat(catalog.tableExists(tableIdent)).as("Table should not exist").isFalse();
     assertThat(dataFiles)
         .allSatisfy(filePath -> assertThat(localInput(filePath).exists()).isFalse());
+  }
+
+  @TestTemplate
+  public void testComputeTableStats() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
+  }
+
+  @TestTemplate
+  public void testComputeTableStatsWithoutSnapshot() {
+    sql(
+        "CREATE TABLE %s (id bigint) USING iceberg "
+            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
+        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table =
+        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
+    assertThat(table.currentSnapshot()).isNull();
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
   }
 
   private void checkMetadataFileEncryption(InputFile file) throws IOException {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -65,8 +64,6 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
-  private static final String EMPTY_TABLE = "empty_table";
-
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -99,7 +96,6 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
-    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -374,23 +370,6 @@ public class TestTableEncryption extends CatalogTestBase {
   public void testComputeTableStats() {
     validationCatalog.initialize(catalogName, catalogConfig);
     Table table = validationCatalog.loadTable(tableIdent);
-
-    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
-  }
-
-  @TestTemplate
-  public void testComputeTableStatsWithoutSnapshot() {
-    sql(
-        "CREATE TABLE %s (id bigint) USING iceberg "
-            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
-        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
-
-    validationCatalog.initialize(catalogName, catalogConfig);
-    Table table =
-        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
-    assertThat(table.currentSnapshot()).isNull();
 
     assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableStatsSparkAction.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.ImmutableComputeTableStats;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
@@ -87,6 +88,11 @@ public class ComputeTableStatsSparkAction extends BaseSparkAction<ComputeTableSt
 
   @Override
   public Result execute() {
+    Preconditions.checkArgument(
+        !(table.encryption() instanceof StandardEncryptionManager),
+        "Cannot compute table statistics for an encrypted table: %s",
+        table.name());
+
     if (snapshot == null) {
       LOG.info("No snapshot to compute stats for table {}", table.name());
       return EMPTY_RESULT;

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -65,8 +64,6 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
-  private static final String EMPTY_TABLE = "empty_table";
-
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -99,7 +96,6 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
-    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -376,23 +372,6 @@ public class TestTableEncryption extends CatalogTestBase {
   public void testComputeTableStats() {
     validationCatalog.initialize(catalogName, catalogConfig);
     Table table = validationCatalog.loadTable(tableIdent);
-
-    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
-  }
-
-  @TestTemplate
-  public void testComputeTableStatsWithoutSnapshot() {
-    sql(
-        "CREATE TABLE %s (id bigint) USING iceberg "
-            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
-        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
-
-    validationCatalog.initialize(catalogName, catalogConfig);
-    Table table =
-        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
-    assertThat(table.currentSnapshot()).isNull();
 
     assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
@@ -54,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -63,6 +65,8 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.internal.util.collections.Iterables;
 
 public class TestTableEncryption extends CatalogTestBase {
+  private static final String EMPTY_TABLE = "empty_table";
+
   private static Map<String, String> appendCatalogEncryptionProperties(Map<String, String> props) {
     Map<String, String> newProps = Maps.newHashMap();
     newProps.putAll(props);
@@ -95,6 +99,7 @@ public class TestTableEncryption extends CatalogTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s", tableName(EMPTY_TABLE));
   }
 
   @TestTemplate
@@ -365,6 +370,33 @@ public class TestTableEncryption extends CatalogTestBase {
     assertThat(catalog.tableExists(tableIdent)).as("Table should not exist").isFalse();
     assertThat(dataFiles)
         .allSatisfy(filePath -> assertThat(localInput(filePath).exists()).isFalse());
+  }
+
+  @TestTemplate
+  public void testComputeTableStats() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
+  }
+
+  @TestTemplate
+  public void testComputeTableStatsWithoutSnapshot() {
+    sql(
+        "CREATE TABLE %s (id bigint) USING iceberg "
+            + "TBLPROPERTIES ('encryption.key-id'='%s', 'format-version'='3')",
+        tableName(EMPTY_TABLE), UnitestKMS.MASTER_KEY_NAME1);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table =
+        validationCatalog.loadTable(TableIdentifier.of(tableIdent.namespace(), EMPTY_TABLE));
+    assertThat(table.currentSnapshot()).isNull();
+
+    assertThatThrownBy(() -> SparkActions.get().computeTableStats(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot compute table statistics for an encrypted table: " + table.name());
   }
 
   private void checkMetadataFileEncryption(InputFile file) throws IOException {


### PR DESCRIPTION
See https://github.com/apache/iceberg/issues/17995 (and https://github.com/apache/iceberg/pull/17993 which is accompanying)