### PR TITLE
Docs: Note that table encryption coverage is still incomplete

### DIFF
--- a/docs/docs/encryption.md
+++ b/docs/docs/encryption.md
@@ -26,6 +26,10 @@ The `metadata.json` file does not contain data or stats, and is therefore not en
 
 Currently, encryption is supported in the Hive and REST catalogs for tables with Parquet and Avro data formats.
 
+!!! warning
+    Coverage across engines and operations is still incomplete, so evaluate table encryption
+    carefully before relying on it in production.
+
 Two parameters are required to activate encryption of a table:
 
 1. Catalog property that specifies the KMS ("key management service"). It can be either `encryption.kms-type` for pre-defined KMS clients (`aws`, `azure` or `gcp`) or `encryption.kms-impl` with the client class path for custom KMS clients.

--- a/docs/docs/encryption.md
+++ b/docs/docs/encryption.md
@@ -27,8 +27,7 @@ The `metadata.json` file does not contain data or stats, and is therefore not en
 Currently, encryption is supported in the Hive and REST catalogs for tables with Parquet and Avro data formats.
 
 !!! warning
-    Coverage across engines and operations is still incomplete, so evaluate table encryption
-    carefully before relying on it in production.
+    Coverage across engines and operations is still incomplete, so evaluate table encryption carefully before relying on it in production.
 
 Two parameters are required to activate encryption of a table:
 


### PR DESCRIPTION
I was recently auditing the state encryption for the upcoming release - and given that encryption has some gaps across engines and operations within those engines (e.g. https://github.com/apache/iceberg/issues/17991, https://github.com/apache/iceberg/issues/17995, also I think that Flink's per-checkpoint manifests are plaintext currently), I suspected it could be worth documenting that so these gaps are not construed as security oversights, and folks are aware of them:

<img width="809" height="408" alt="image" src="https://github.com/user-attachments/assets/fa2ecca6-dd1e-4520-8e34-b2134e20f612" />