### PR TITLE
Docs: Add Spark 4.2 to the engine support matrix and site variables

### DIFF
--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -76,6 +76,7 @@ Each engine version undergoes the following lifecycle stages:
 | 3.5        | Maintained         | 1.4.0                   | {{ icebergVersion }}   | [iceberg-spark-runtime-3.5_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.5_2.12-{{ icebergVersion }}.jar), [iceberg-spark-runtime-3.5_2.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.13/{{ icebergVersion }}/iceberg-spark-runtime-3.5_2.13-{{ icebergVersion }}.jar) |
 | 4.0        | Maintained         | 1.10.0                  | {{ icebergVersion }}   | [iceberg-spark-runtime-4.0_2.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-4.0_2.13/{{ icebergVersion }}/iceberg-spark-runtime-4.0_2.13-{{ icebergVersion }}.jar) |
 | 4.1        | Maintained         | 1.11.0                  | {{ icebergVersion }}   | [iceberg-spark-runtime-4.1_2.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-4.1_2.13/{{ icebergVersion }}/iceberg-spark-runtime-4.1_2.13-{{ icebergVersion }}.jar) |
+| 4.2        | Maintained         | 1.12.0                  | {{ icebergVersion }}   | [iceberg-spark-runtime-4.2_2.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-4.2_2.13/{{ icebergVersion }}/iceberg-spark-runtime-4.2_2.13-{{ icebergVersion }}.jar) |
 
 <!-- markdown-link-check-enable -->
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -115,7 +115,7 @@ extra:
   nessieVersion: '0.105.3'
   flinkVersion: '2.3.0'
   flinkVersionMajor: '2.3'
-  sparkVersionMajor: '4.1_2.13'
+  sparkVersionMajor: '4.2_2.13'
   slackInviteUrl: &slackInviteUrl 'https://s.apache.org/iceberg-slack'
   social:
     - icon: fontawesome/regular/comments


### PR DESCRIPTION
Follow-up to #14984, which added Spark 4.2 support.

- Add Spark 4.2 as `Maintained` in the engine support matrix, initial support 1.12.0
- Bump `sparkVersionMajor` to `4.2_2.13` to match `defaultSparkVersions` on main

The runtime-jar links use the `{{ icebergVersion }}` template and resolve once 1.12.0 is released, same as the Flink 2.2/2.3 rows in #17869.

### Testing

`cd site && make build`

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Ducc
- Human Oversight: fully reviewed
- Prompt Summary: Add Spark 4.2 to the site engine support matrix.
