### PR TITLE
ORC: Fix filter pushdown on tables with a variant column

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -58,7 +58,13 @@ class ExpressionToSearchArgument
   // these Iceberg types
   private static final Set<TypeID> UNSUPPORTED_TYPES =
       ImmutableSet.of(
-          TypeID.BINARY, TypeID.FIXED, TypeID.UUID, TypeID.STRUCT, TypeID.MAP, TypeID.LIST);
+          TypeID.BINARY,
+          TypeID.FIXED,
+          TypeID.UUID,
+          TypeID.STRUCT,
+          TypeID.MAP,
+          TypeID.LIST,
+          TypeID.VARIANT);
 
   private final SearchArgument.Builder builder;
   private final Map<Integer, String> idToColumnName;

--- a/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
@@ -127,6 +127,11 @@ class IdToOrcName extends TypeUtil.SchemaVisitor<Map<Integer, String>> {
   }
 
   @Override
+  public Map<Integer, String> variant(Types.VariantType variant) {
+    return idToName;
+  }
+
+  @Override
   public Map<Integer, String> primitive(Type.PrimitiveType primitive) {
     return idToName;
   }

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -226,13 +226,21 @@ public class TestExpressionToSearchArgument {
     Schema schema =
         new Schema(
             required(1, "long", Types.LongType.get()),
+            // use an optional field for the isNull check because Iceberg itself resolves it for
+            // required fields
             optional(2, "variant", Types.VariantType.get()));
 
-    // predicates on other columns are still pushed down when the schema contains a variant column
-    Expression expr = equal("long", 1);
+    // predicates on other columns are still pushed down when the schema contains a variant column,
+    // while predicates on the variant itself resolve to YES_NO_NULL
+    Expression expr = and(equal("long", 1), isNull("variant"));
     Expression boundFilter = Binder.bind(schema.asStruct(), expr, true);
     SearchArgument expected =
-        SearchArgumentFactory.newBuilder().startAnd().equals("`long`", Type.LONG, 1L).end().build();
+        SearchArgumentFactory.newBuilder()
+            .startAnd()
+            .equals("`long`", Type.LONG, 1L)
+            .literal(TruthValue.YES_NO_NULL)
+            .end()
+            .build();
 
     SearchArgument actual =
         ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -222,6 +222,24 @@ public class TestExpressionToSearchArgument {
   }
 
   @Test
+  public void testVariantType() {
+    Schema schema =
+        new Schema(
+            required(1, "long", Types.LongType.get()),
+            optional(2, "variant", Types.VariantType.get()));
+
+    // predicates on other columns are still pushed down when the schema contains a variant column
+    Expression expr = equal("long", 1);
+    Expression boundFilter = Binder.bind(schema.asStruct(), expr, true);
+    SearchArgument expected =
+        SearchArgumentFactory.newBuilder().startAnd().equals("`long`", Type.LONG, 1L).end().build();
+
+    SearchArgument actual =
+        ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));
+    assertThat(actual.toString()).isEqualTo(expected.toString());
+  }
+
+  @Test
   public void testNestedPrimitives() {
     Schema schema =
         new Schema(


### PR DESCRIPTION
Reading an ORC table whose schema contains a variant column fails with `UnsupportedOperationException: Unsupported type: variant` once a filter is pushed down: `IdToOrcName` does not override `variant`, so the `TypeUtil.SchemaVisitor` base implementation throws while resolving column names.

### Testing

`./gradlew :iceberg-orc:test` — 66 tests, 0 failures. Reverting the override fails the new test.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Ducc
- Human Oversight: fully reviewed
- Prompt Summary: Fix the missing variant override that breaks ORC filter pushdown.
