### PR TITLE
Flink: Fix microsecond truncation for timestamps in arrays and maps

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
@@ -277,18 +277,16 @@ public class StructRowData implements RowData {
       case DECIMAL:
         return value;
       case TIMESTAMP:
-        long timeMillis;
+        long micros;
         if (value instanceof LocalDateTime localDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamp(localDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamp(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamptz(offsetDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamptz(offsetDateTime);
         } else {
-          timeMillis = Math.floorDiv((Long) value, 1000L);
+          micros = (Long) value;
         }
         return TimestampData.fromEpochMillis(
-            timeMillis,
-            (int) Math.floorMod(value instanceof Long ? (Long) value : timeMillis * 1000L, 1000L)
-                * 1000);
+            Math.floorDiv(micros, 1000L), (int) Math.floorMod(micros, 1000L) * 1000);
       case TIMESTAMP_NANO:
         long nanoLong;
         if (value instanceof LocalDateTime localDateTime) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
@@ -18,10 +18,17 @@
  */
 package org.apache.iceberg.flink.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
 import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestStructRowData {
@@ -96,5 +103,23 @@ public class TestStructRowData {
   @Test
   public void testMapOfStruct() {
     testConverter(new DataGenerators.MapOfStruct());
+  }
+
+  @Test
+  public void testArrayOfTimestampRetainsMicros() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "array_of_ts",
+                Types.ListType.ofRequired(101, Types.TimestampType.withoutZone())));
+    LocalDateTime afterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456000);
+    LocalDateTime beforeEpoch = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654000);
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("array_of_ts", Arrays.asList(afterEpoch, beforeEpoch));
+
+    ArrayData actual = new StructRowData(schema.asStruct()).setStruct(record).getArray(0);
+    assertThat(actual.getTimestamp(0, 6).toLocalDateTime()).isEqualTo(afterEpoch);
+    assertThat(actual.getTimestamp(1, 6).toLocalDateTime()).isEqualTo(beforeEpoch);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
@@ -283,18 +283,16 @@ public class StructRowData implements RowData {
       case DECIMAL:
         return value;
       case TIMESTAMP:
-        long timeMillis;
+        long micros;
         if (value instanceof LocalDateTime localDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamp(localDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamp(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamptz(offsetDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamptz(offsetDateTime);
         } else {
-          timeMillis = Math.floorDiv((Long) value, 1000L);
+          micros = (Long) value;
         }
         return TimestampData.fromEpochMillis(
-            timeMillis,
-            (int) Math.floorMod(value instanceof Long ? (Long) value : timeMillis * 1000L, 1000L)
-                * 1000);
+            Math.floorDiv(micros, 1000L), (int) Math.floorMod(micros, 1000L) * 1000);
       case TIMESTAMP_NANO:
         long nanoLong;
         if (value instanceof LocalDateTime localDateTime) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
@@ -18,10 +18,17 @@
  */
 package org.apache.iceberg.flink.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
 import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestStructRowData {
@@ -96,5 +103,23 @@ public class TestStructRowData {
   @Test
   public void testMapOfStruct() {
     testConverter(new DataGenerators.MapOfStruct());
+  }
+
+  @Test
+  public void testArrayOfTimestampRetainsMicros() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "array_of_ts",
+                Types.ListType.ofRequired(101, Types.TimestampType.withoutZone())));
+    LocalDateTime afterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456000);
+    LocalDateTime beforeEpoch = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654000);
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("array_of_ts", Arrays.asList(afterEpoch, beforeEpoch));
+
+    ArrayData actual = new StructRowData(schema.asStruct()).setStruct(record).getArray(0);
+    assertThat(actual.getTimestamp(0, 6).toLocalDateTime()).isEqualTo(afterEpoch);
+    assertThat(actual.getTimestamp(1, 6).toLocalDateTime()).isEqualTo(beforeEpoch);
   }
 }

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
@@ -283,18 +283,16 @@ public class StructRowData implements RowData {
       case DECIMAL:
         return value;
       case TIMESTAMP:
-        long timeMillis;
+        long micros;
         if (value instanceof LocalDateTime localDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamp(localDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamp(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamptz(offsetDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamptz(offsetDateTime);
         } else {
-          timeMillis = Math.floorDiv((Long) value, 1000L);
+          micros = (Long) value;
         }
         return TimestampData.fromEpochMillis(
-            timeMillis,
-            (int) Math.floorMod(value instanceof Long ? (Long) value : timeMillis * 1000L, 1000L)
-                * 1000);
+            Math.floorDiv(micros, 1000L), (int) Math.floorMod(micros, 1000L) * 1000);
       case TIMESTAMP_NANO:
         long nanoLong;
         if (value instanceof LocalDateTime localDateTime) {

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
@@ -18,10 +18,17 @@
  */
 package org.apache.iceberg.flink.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
 import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestStructRowData {
@@ -96,5 +103,23 @@ public class TestStructRowData {
   @Test
   public void testMapOfStruct() {
     testConverter(new DataGenerators.MapOfStruct());
+  }
+
+  @Test
+  public void testArrayOfTimestampRetainsMicros() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "array_of_ts",
+                Types.ListType.ofRequired(101, Types.TimestampType.withoutZone())));
+    LocalDateTime afterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456000);
+    LocalDateTime beforeEpoch = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654000);
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("array_of_ts", Arrays.asList(afterEpoch, beforeEpoch));
+
+    ArrayData actual = new StructRowData(schema.asStruct()).setStruct(record).getArray(0);
+    assertThat(actual.getTimestamp(0, 6).toLocalDateTime()).isEqualTo(afterEpoch);
+    assertThat(actual.getTimestamp(1, 6).toLocalDateTime()).isEqualTo(beforeEpoch);
   }
 }

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/StructRowData.java
@@ -283,18 +283,16 @@ public class StructRowData implements RowData {
       case DECIMAL:
         return value;
       case TIMESTAMP:
-        long timeMillis;
+        long micros;
         if (value instanceof LocalDateTime localDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamp(localDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamp(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
-          timeMillis = DateTimeUtil.microsFromTimestamptz(offsetDateTime) / 1000L;
+          micros = DateTimeUtil.microsFromTimestamptz(offsetDateTime);
         } else {
-          timeMillis = Math.floorDiv((Long) value, 1000L);
+          micros = (Long) value;
         }
         return TimestampData.fromEpochMillis(
-            timeMillis,
-            (int) Math.floorMod(value instanceof Long ? (Long) value : timeMillis * 1000L, 1000L)
-                * 1000);
+            Math.floorDiv(micros, 1000L), (int) Math.floorMod(micros, 1000L) * 1000);
       case TIMESTAMP_NANO:
         long nanoLong;
         if (value instanceof LocalDateTime localDateTime) {

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/data/TestStructRowData.java
@@ -18,10 +18,17 @@
  */
 package org.apache.iceberg.flink.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
 import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestStructRowData {
@@ -96,5 +103,23 @@ public class TestStructRowData {
   @Test
   public void testMapOfStruct() {
     testConverter(new DataGenerators.MapOfStruct());
+  }
+
+  @Test
+  public void testArrayOfTimestampRetainsMicros() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "array_of_ts",
+                Types.ListType.ofRequired(101, Types.TimestampType.withoutZone())));
+    LocalDateTime afterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456000);
+    LocalDateTime beforeEpoch = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654000);
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("array_of_ts", Arrays.asList(afterEpoch, beforeEpoch));
+
+    ArrayData actual = new StructRowData(schema.asStruct()).setStruct(record).getArray(0);
+    assertThat(actual.getTimestamp(0, 6).toLocalDateTime()).isEqualTo(afterEpoch);
+    assertThat(actual.getTimestamp(1, 6).toLocalDateTime()).isEqualTo(beforeEpoch);
   }
 }


### PR DESCRIPTION
The nano-of-millisecond argument in `StructRowData.convertValue` is `floorMod(timeMillis * 1000, 1000) * 1000`, always 0 since `timeMillis` is already millis. A `timestamp` in an array or map loses sub-millisecond precision: `12:00:00.123456` reads back as `12:00:00.123`. Normalized to micros first, like `TIMESTAMP_NANO` below it.

### Testing

`iceberg-flink-{1.20,2.1,2.2,2.3}:test --tests TestStructRowData`

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Ducc
- Human Oversight: fully reviewed
- Prompt Summary: Fix microsecond truncation for nested timestamps.
