### PR TITLE
Kafka Connect: Add a converter from equality deletes to deletion vectors

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/EqualityDeleteConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/EqualityDeleteConverter.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.DeleteWriteResult;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.StructLikeSet;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves equality delete files against the rows of a table and writes the matching row positions
+ * as deletion vectors, so the equality delete files never have to be committed.
+ *
+ * <p>An equality delete written by the sink deletes every row of an earlier commit whose identifier
+ * fields equal one of the deleted keys. The converter reads the keys, groups them by equality
+ * fields and partition, and asks a {@link KeyPositionResolver} for the rows that hold them. The
+ * default resolver, {@link ScanKeyPositionResolver}, scans the data files that the column
+ * statistics cannot rule out; an index-backed resolver can be plugged in instead. A data file that
+ * already has a deletion vector gets a merged one; the replaced vector is reported in {@link
+ * Result#rewrittenDvFiles()} and must be removed by the commit.
+ *
+ * <p>The positions are only valid for the snapshot they were resolved against, see {@link
+ * Result#baseSnapshotId()}. The commit that adds the deletion vectors has to validate that no
+ * conflicting data or delete files were added since then and re-run the conversion otherwise.
+ * {@link Result#conflictFilter()} narrows that validation to the deleted keys.
+ *
+ * <p>Requires format version 3.
+ */
+public class EqualityDeleteConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityDeleteConverter.class);
+
+  private final Table table;
+  private final String branch;
+  private final KeyPositionResolver resolver;
+  private final DeleteLoader deleteLoader;
+  private final AtomicInteger scannedDataFiles = new AtomicInteger();
+
+  /**
+   * Creates a converter that finds the rows by scanning data files.
+   *
+   * @param table the table to resolve the deletes against
+   * @param branch the branch that is written, or null for the main branch
+   */
+  public EqualityDeleteConverter(Table table, String branch) {
+    this(table, branch, new ScanKeyPositionResolver(table));
+  }
+
+  EqualityDeleteConverter(Table table, String branch, KeyPositionResolver resolver) {
+    this.table = table;
+    this.branch = branch;
+    this.resolver = resolver;
+    this.deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+  }
+
+  /**
+   * Converts the given equality delete files into deletion vectors on the current snapshot of the
+   * branch. The table is expected to be refreshed by the caller.
+   */
+  public Result convert(List<DeleteFile> eqDeleteFiles) {
+    Snapshot base = branch == null ? table.currentSnapshot() : table.snapshot(branch);
+    if (base == null) {
+      // there are no rows an equality delete could remove
+      LOG.info(
+          "Table {} has no snapshot on branch {}, {} equality delete file(s) match no rows",
+          table.name(),
+          branch == null ? "main" : branch,
+          eqDeleteFiles.size());
+      return Result.empty();
+    }
+
+    Map<DeleteGroup, List<DeleteFile>> groups = groupDeleteFiles(eqDeleteFiles);
+
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(table, 1, System.currentTimeMillis())
+            .defaultSpec(table.spec())
+            .operationId(UUID.randomUUID().toString())
+            .format(FileFormat.PUFFIN)
+            .build();
+    // deletion vectors already attached to a matched data file, folded into the new vector
+    Map<String, PositionDeleteIndex> previousDeletes = Maps.newHashMap();
+    BaseDVFileWriter dvWriter = new BaseDVFileWriter(fileFactory, previousDeletes::get);
+
+    Expression conflictFilter = Expressions.alwaysFalse();
+    int comparisonsPerFile = KeyFilters.comparisonsPerFile(base);
+    long matchedRows = 0L;
+    long deletedKeys = 0L;
+    scannedDataFiles.set(0);
+
+    long start = System.currentTimeMillis();
+    try {
+      for (Map.Entry<DeleteGroup, List<DeleteFile>> entry : groups.entrySet()) {
+        DeleteGroup group = entry.getKey();
+        Schema keySchema = keySchema(group.equalityFieldIds());
+        StructLikeSet keys = deleteLoader.loadEqualityDeletes(entry.getValue(), keySchema);
+        if (keys.isEmpty()) {
+          continue;
+        }
+
+        deletedKeys += keys.size();
+        conflictFilter =
+            Expressions.or(
+                conflictFilter,
+                Expressions.and(
+                    KeyFilters.partitionFilter(table.schema(), group.spec(), group.partition()),
+                    KeyFilters.keyFilter(keySchema, keys, comparisonsPerFile)));
+
+        KeyPositionResolver.Resolution resolution =
+            resolver.resolve(base, keySchema, keys, group.spec(), group.partition());
+        scannedDataFiles.addAndGet(resolution.scannedDataFiles());
+
+        for (KeyPositionResolver.FileMatches matches : resolution.matches()) {
+          if (matches.existingDeletes() != null) {
+            previousDeletes.put(matches.path(), matches.existingDeletes());
+          }
+
+          long[] count = new long[1];
+          matches.forEachPosition(
+              pos -> {
+                dvWriter.delete(matches.path(), pos, matches.spec(), matches.partition());
+                count[0]++;
+              });
+          matchedRows += count[0];
+        }
+      }
+
+      dvWriter.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    DeleteWriteResult writeResult = dvWriter.result();
+    LOG.info(
+        "Converted {} equality delete file(s) with {} key(s) into {} deletion vector(s) covering {} row(s) "
+            + "of table {} at snapshot {}, scanned {} data file(s) in {} ms",
+        eqDeleteFiles.size(),
+        deletedKeys,
+        writeResult.deleteFiles().size(),
+        matchedRows,
+        table.name(),
+        base.snapshotId(),
+        scannedDataFiles.get(),
+        System.currentTimeMillis() - start);
+
+    return new Result(
+        base.snapshotId(),
+        writeResult.deleteFiles(),
+        writeResult.rewrittenDeleteFiles(),
+        conflictFilter);
+  }
+
+  @VisibleForTesting
+  int scannedDataFiles() {
+    return scannedDataFiles.get();
+  }
+
+  /**
+   * Groups the delete files by equality field set and partition. A partitioned equality delete only
+   * applies to its own partition, and a smaller key set per group prunes better.
+   */
+  private Map<DeleteGroup, List<DeleteFile>> groupDeleteFiles(List<DeleteFile> eqDeleteFiles) {
+    Map<DeleteGroup, List<DeleteFile>> groups = Maps.newLinkedHashMap();
+    for (DeleteFile deleteFile : eqDeleteFiles) {
+      Preconditions.checkArgument(
+          deleteFile.content() == FileContent.EQUALITY_DELETES,
+          "Not an equality delete file: %s",
+          deleteFile.location());
+      PartitionSpec spec = table.specs().get(deleteFile.specId());
+      Preconditions.checkArgument(
+          spec != null,
+          "Unknown partition spec %s for %s",
+          deleteFile.specId(),
+          deleteFile.location());
+      DeleteGroup group =
+          new DeleteGroup(
+              ImmutableSet.copyOf(deleteFile.equalityFieldIds()), spec, deleteFile.partition());
+      groups.computeIfAbsent(group, key -> Lists.newArrayList()).add(deleteFile);
+    }
+
+    return groups;
+  }
+
+  private Schema keySchema(Set<Integer> equalityFieldIds) {
+    Schema keySchema = TypeUtil.select(table.schema(), equalityFieldIds);
+    Preconditions.checkArgument(
+        TypeUtil.getProjectedIds(keySchema).containsAll(equalityFieldIds),
+        "Equality field IDs %s are not all present in table schema %s",
+        equalityFieldIds,
+        table.schema());
+    return keySchema;
+  }
+
+  /** Outcome of a conversion, to be committed together with the data files of the batch. */
+  public static class Result {
+    private static final Result EMPTY =
+        new Result(null, ImmutableList.of(), ImmutableList.of(), Expressions.alwaysFalse());
+
+    private final Long baseSnapshotId;
+    private final List<DeleteFile> dvFiles;
+    private final List<DeleteFile> rewrittenDvFiles;
+    private final Expression conflictFilter;
+
+    Result(
+        Long baseSnapshotId,
+        List<DeleteFile> dvFiles,
+        List<DeleteFile> rewrittenDvFiles,
+        Expression conflictFilter) {
+      this.baseSnapshotId = baseSnapshotId;
+      this.dvFiles = ImmutableList.copyOf(dvFiles);
+      this.rewrittenDvFiles = ImmutableList.copyOf(rewrittenDvFiles);
+      this.conflictFilter = conflictFilter;
+    }
+
+    static Result empty() {
+      return EMPTY;
+    }
+
+    /** Snapshot the positions were resolved against, or null when the branch had no snapshot. */
+    public Long baseSnapshotId() {
+      return baseSnapshotId;
+    }
+
+    /** Deletion vectors to add. */
+    public List<DeleteFile> dvFiles() {
+      return dvFiles;
+    }
+
+    /** Deletion vectors that were merged into a new one and must be removed. */
+    public List<DeleteFile> rewrittenDvFiles() {
+      return rewrittenDvFiles;
+    }
+
+    /**
+     * Row filter covering every deleted key, for detecting data or delete files that were added
+     * concurrently for those keys.
+     */
+    public Expression conflictFilter() {
+      return conflictFilter;
+    }
+  }
+
+  /** Equality delete files that share the equality fields and the partition. */
+  private static class DeleteGroup {
+    private final Set<Integer> equalityFieldIds;
+    private final PartitionSpec spec;
+    private final StructLikeWrapper partition;
+
+    DeleteGroup(Set<Integer> equalityFieldIds, PartitionSpec spec, StructLike partition) {
+      this.equalityFieldIds = equalityFieldIds;
+      this.spec = spec;
+      this.partition = StructLikeWrapper.forType(spec.partitionType()).set(partition);
+    }
+
+    Set<Integer> equalityFieldIds() {
+      return equalityFieldIds;
+    }
+
+    PartitionSpec spec() {
+      return spec;
+    }
+
+    StructLike partition() {
+      return partition.get();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      } else if (!(other instanceof DeleteGroup)) {
+        return false;
+      }
+
+      DeleteGroup that = (DeleteGroup) other;
+      return equalityFieldIds.equals(that.equalityFieldIds)
+          && spec.specId() == that.spec.specId()
+          && partition.equals(that.partition);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(equalityFieldIds, spec.specId(), partition);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/KeyFilters.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/KeyFilters.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.ToDoubleFunction;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.UnboundTerm;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.UnknownTransform;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+
+/**
+ * Row filters built from the keys of equality delete files.
+ *
+ * <p>The filters are inclusive: every row with a deleted key satisfies them, and rows without a
+ * deleted key may satisfy them too. {@link ScanKeyPositionResolver} uses them to prune the data
+ * files it has to read; {@link EqualityDeleteConverter} uses them to detect files that another
+ * writer added concurrently for the deleted keys.
+ */
+final class KeyFilters {
+
+  // metrics evaluators stop pruning with an IN list above this many values, so keys are matched
+  // with several lists of at most this size
+  @VisibleForTesting static final int IN_PREDICATE_LIMIT = 200;
+
+  // The filters are evaluated once per data file entry during planning, so their size is chosen
+  // from the table's data file count: a budget of comparisons for the whole plan, divided by the
+  // number of data files. The budget is what a fixed cap of 100 value ranges (200 comparisons per
+  // file) would spend on a table with one million data files, so such a table keeps that cost
+  // and smaller tables get a finer filter. The lower bound is that same cap and applies when the
+  // count is missing; the upper bound limits what the filter costs when every file is read
+  // anyway, e.g. keys spread over a small table, where a finer filter only adds evaluation time.
+  @VisibleForTesting static final long COMPARISON_BUDGET = 200_000_000L;
+  @VisibleForTesting static final int MIN_COMPARISONS_PER_FILE = 200;
+  @VisibleForTesting static final int MAX_COMPARISONS_PER_FILE = 1_000;
+
+  private KeyFilters() {}
+
+  /**
+   * Pins the partition of an equality delete file. Every partition field is expressed through its
+   * transform, e.g. {@code bucket(16, id) = 3}, so the scan planner prunes to the partition even
+   * when the key filter is a range that a transform like bucket cannot project. Identity fields
+   * reference the column directly. Void fields carry no information and unknown transforms cannot
+   * be evaluated, so both are skipped.
+   */
+  @SuppressWarnings("unchecked")
+  static Expression partitionFilter(Schema tableSchema, PartitionSpec spec, StructLike partition) {
+    Expression filter = Expressions.alwaysTrue();
+    List<PartitionField> fields = spec.fields();
+    for (int pos = 0; pos < fields.size(); pos++) {
+      PartitionField field = fields.get(pos);
+      Transform<?, ?> transform = field.transform();
+      if (transform.isVoid() || transform instanceof UnknownTransform) {
+        continue;
+      }
+
+      String column = tableSchema.findColumnName(field.sourceId());
+      UnboundTerm<Object> term =
+          transform.isIdentity()
+              ? Expressions.ref(column)
+              : Expressions.transform(column, (Transform<?, Object>) transform);
+      Object value = partition.get(pos, Object.class);
+      filter =
+          Expressions.and(
+              filter, value == null ? Expressions.isNull(term) : Expressions.equal(term, value));
+    }
+
+    return filter;
+  }
+
+  /**
+   * Comparisons the key filter may cost per data file entry when planning against the snapshot:
+   * {@link #COMPARISON_BUDGET} divided by the snapshot's {@code total-data-files}, kept between
+   * {@link #MIN_COMPARISONS_PER_FILE} and {@link #MAX_COMPARISONS_PER_FILE}. A snapshot without the
+   * count gets the minimum.
+   */
+  static int comparisonsPerFile(Snapshot snapshot) {
+    String value = snapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP);
+    if (value == null) {
+      return MIN_COMPARISONS_PER_FILE;
+    }
+
+    long dataFiles;
+    try {
+      dataFiles = Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      return MIN_COMPARISONS_PER_FILE;
+    }
+
+    if (dataFiles <= 0) {
+      return MAX_COMPARISONS_PER_FILE;
+    }
+
+    long perFile = COMPARISON_BUDGET / dataFiles;
+    return (int) Math.max(MIN_COMPARISONS_PER_FILE, Math.min(MAX_COMPARISONS_PER_FILE, perFile));
+  }
+
+  /**
+   * Filter for the deleted keys within a budget of comparisons per data file entry.
+   *
+   * <p>While the keys fit the budget they are matched with {@code IN} lists, {@link
+   * #IN_PREDICATE_LIMIT} keys per list and one list per key column, which matches exactly the files
+   * that hold a deleted key. A list costs one comparison per value, so the keys fit when their
+   * number times the number of key columns is within the budget. Above that the keys are matched
+   * with value ranges on the leading key column, two comparisons each, split at the largest gaps; a
+   * range may also cover files without a deleted key.
+   */
+  static Expression keyFilter(Schema keySchema, StructLikeSet keys, int comparisonsPerFile) {
+    long listComparisons = (long) keys.size() * primitiveColumns(keySchema);
+    if (listComparisons <= comparisonsPerFile) {
+      return listFilter(keySchema, keys);
+    }
+
+    return rangeFilter(keySchema, keys, Math.max(1, comparisonsPerFile / 2));
+  }
+
+  private static int primitiveColumns(Schema keySchema) {
+    int count = 0;
+    for (Types.NestedField column : keySchema.columns()) {
+      if (column.type().isPrimitiveType()) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  /** {@code IN} lists of at most {@link #IN_PREDICATE_LIMIT} keys each, joined with {@code OR}. */
+  private static Expression listFilter(Schema keySchema, StructLikeSet keys) {
+    List<StructLike> keyList = Lists.newArrayList(keys);
+    Expression filter = Expressions.alwaysFalse();
+    for (int from = 0; from < keyList.size(); from += IN_PREDICATE_LIMIT) {
+      List<StructLike> chunk =
+          keyList.subList(from, Math.min(from + IN_PREDICATE_LIMIT, keyList.size()));
+      filter = Expressions.or(filter, inFilter(keySchema, chunk));
+    }
+
+    return filter;
+  }
+
+  /** One {@code IN} list per key column over the given keys. */
+  private static Expression inFilter(Schema keySchema, Iterable<StructLike> keys) {
+    Expression filter = Expressions.alwaysTrue();
+    List<Types.NestedField> columns = keySchema.columns();
+    for (int pos = 0; pos < columns.size(); pos++) {
+      Types.NestedField column = columns.get(pos);
+      if (!column.type().isPrimitiveType()) {
+        // no pruning on a nested key column
+        continue;
+      }
+
+      Set<Object> values = Sets.newHashSet();
+      boolean hasNull = false;
+      for (StructLike key : keys) {
+        Object value = key.get(pos, Object.class);
+        if (value == null) {
+          hasNull = true;
+        } else {
+          values.add(value);
+        }
+      }
+
+      Expression columnFilter =
+          values.isEmpty() ? Expressions.alwaysFalse() : Expressions.in(column.name(), values);
+      if (hasNull) {
+        columnFilter = Expressions.or(columnFilter, Expressions.isNull(column.name()));
+      }
+
+      filter = Expressions.and(filter, columnFilter);
+    }
+
+    return filter;
+  }
+
+  /**
+   * Sorts the values of the leading key column and splits them into at most {@code maxRanges}
+   * ranges. Numeric and temporal keys are split at the largest gaps, so a cluster of hot keys and a
+   * few scattered keys each get a tight range; other types are split into ranges with an equal
+   * number of keys.
+   */
+  @SuppressWarnings("unchecked")
+  private static Expression rangeFilter(Schema keySchema, StructLikeSet keys, int maxRanges) {
+    Types.NestedField lead = null;
+    int leadPos = -1;
+    List<Types.NestedField> columns = keySchema.columns();
+    for (int pos = 0; pos < columns.size(); pos++) {
+      if (columns.get(pos).type().isPrimitiveType()) {
+        lead = columns.get(pos);
+        leadPos = pos;
+        break;
+      }
+    }
+
+    if (lead == null) {
+      return Expressions.alwaysTrue();
+    }
+
+    List<Object> values = Lists.newArrayListWithCapacity(keys.size());
+    boolean hasNull = false;
+    for (StructLike key : keys) {
+      Object value = key.get(leadPos, Object.class);
+      if (value == null) {
+        hasNull = true;
+      } else {
+        values.add(value);
+      }
+    }
+
+    Expression filter = Expressions.alwaysFalse();
+    if (!values.isEmpty()) {
+      Comparator<Object> comparator =
+          (Comparator<Object>) Comparators.forType(lead.type().asPrimitiveType());
+      values.sort(comparator);
+      for (int[] range : splitIntoRanges(values, numericConverter(lead.type()), maxRanges)) {
+        Object min = values.get(range[0]);
+        Object max = values.get(range[1]);
+        filter =
+            Expressions.or(
+                filter,
+                Expressions.and(
+                    Expressions.greaterThanOrEqual(lead.name(), min),
+                    Expressions.lessThanOrEqual(lead.name(), max)));
+      }
+    }
+
+    if (hasNull) {
+      filter = Expressions.or(filter, Expressions.isNull(lead.name()));
+    }
+
+    return filter;
+  }
+
+  /**
+   * Returns index ranges [first, last] over the sorted values, at most {@code maxRanges} of them.
+   * With a numeric converter the ranges are separated at the largest gaps between neighboring
+   * values, and only at gaps that leave out at least one value; otherwise the values are split into
+   * ranges of equal size.
+   */
+  @VisibleForTesting
+  static List<int[]> splitIntoRanges(
+      List<Object> sortedValues, ToDoubleFunction<Object> numeric, int maxRanges) {
+    int size = sortedValues.size();
+    int rangeCount = Math.min(maxRanges, size);
+    List<Integer> splits = Lists.newArrayListWithCapacity(rangeCount);
+
+    if (numeric != null) {
+      // a split after index i separates values i and i + 1. Only a gap wide enough to leave out a
+      // value can exclude a data file, so adjacent integers are never split; of the remaining gaps
+      // the widest are kept. Contiguous keys therefore form a single range however many they are.
+      double minGap = isIntegral(sortedValues.get(0)) ? 1.0 : 0.0;
+      List<Integer> byGap = Lists.newArrayList();
+      for (int i = 0; i < size - 1; i++) {
+        double gap =
+            numeric.applyAsDouble(sortedValues.get(i + 1))
+                - numeric.applyAsDouble(sortedValues.get(i));
+        if (gap > minGap) {
+          byGap.add(i);
+        }
+      }
+
+      byGap.sort(
+          Comparator.comparingDouble(
+                  (Integer i) ->
+                      numeric.applyAsDouble(sortedValues.get(i + 1))
+                          - numeric.applyAsDouble(sortedValues.get(i)))
+              .reversed());
+      splits.addAll(byGap.subList(0, Math.min(rangeCount - 1, byGap.size())));
+    } else {
+      for (int i = 1; i < rangeCount; i++) {
+        splits.add((int) ((long) i * size / rangeCount) - 1);
+      }
+    }
+
+    splits.sort(Comparator.naturalOrder());
+
+    List<int[]> ranges = Lists.newArrayListWithCapacity(rangeCount);
+    int first = 0;
+    for (int split : splits) {
+      ranges.add(new int[] {first, split});
+      first = split + 1;
+    }
+
+    ranges.add(new int[] {first, size - 1});
+    return ranges;
+  }
+
+  private static boolean isIntegral(Object value) {
+    return value instanceof Long || value instanceof Integer;
+  }
+
+  /** Converts internal key representations to a number for gap comparison, or null. */
+  private static ToDoubleFunction<Object> numericConverter(Type type) {
+    switch (type.typeId()) {
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+        return value -> ((Number) value).doubleValue();
+      case DECIMAL:
+        return value -> ((BigDecimal) value).doubleValue();
+      default:
+        return null;
+    }
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/KeyPositionResolver.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/KeyPositionResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.LongConsumer;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.util.StructLikeSet;
+
+/**
+ * Finds the rows of a table snapshot whose identifier values are in a set of deleted keys.
+ *
+ * <p>{@link EqualityDeleteConverter} asks a resolver for the position of every row an equality
+ * delete would remove and writes those positions as deletion vectors. Implementations differ in how
+ * they locate the rows. The default {@link ScanKeyPositionResolver} reads the data files that the
+ * column statistics cannot rule out; an implementation backed by an index can look the keys up
+ * without touching data files.
+ */
+public interface KeyPositionResolver {
+
+  /**
+   * Resolves the keys of one group of equality delete files.
+   *
+   * @param base snapshot whose rows are resolved
+   * @param keySchema the identifier columns, a projection of the table schema
+   * @param keys deleted keys in the internal representation of {@code keySchema}, as produced by
+   *     {@link org.apache.iceberg.data.InternalRecordWrapper}
+   * @param deleteSpec partition spec of the equality delete files
+   * @param deletePartition partition of the equality delete files; the rows of other partitions are
+   *     not affected by the deletes
+   * @return the matched rows, grouped by data file
+   */
+  Resolution resolve(
+      Snapshot base,
+      Schema keySchema,
+      StructLikeSet keys,
+      PartitionSpec deleteSpec,
+      StructLike deletePartition)
+      throws IOException;
+
+  /** Rows matched by one resolution. */
+  interface Resolution {
+    Collection<FileMatches> matches();
+
+    /** Number of data files the resolver read to find the matches. */
+    int scannedDataFiles();
+  }
+
+  /** Matched rows of one data file. */
+  interface FileMatches {
+    String path();
+
+    PartitionSpec spec();
+
+    StructLike partition();
+
+    /**
+     * Deletion vector already attached to the data file, or null. The converter folds it into the
+     * new vector because a data file can only have one.
+     */
+    PositionDeleteIndex existingDeletes();
+
+    void forEachPosition(LongConsumer consumer);
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/ScanKeyPositionResolver.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/ScanKeyPositionResolver.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.LongConsumer;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.ReadBuilder;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.StructLikeSet;
+import org.apache.iceberg.util.StructProjection;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+
+/**
+ * Resolves deleted keys by scanning data files. No state is kept between calls.
+ *
+ * <p>The candidate files are planned with the filters of {@link KeyFilters}: the partition of the
+ * equality delete files is pinned through its transform and the keys are matched with {@code IN}
+ * lists while they fit the comparison budget the table's data file count allows, with value ranges
+ * split at the largest gaps of the leading key column above that. Only the key columns and the row
+ * position of the candidate files are read, in parallel, and a row is matched by comparing its key
+ * with the deleted set. A cluster of hot keys and a few scattered keys therefore cost the files
+ * that hold them; keys spread evenly over a large table still match most files of the partition.
+ *
+ * <p>Data files that carry position delete files instead of deletion vectors are rejected, because
+ * a deletion vector replaces all position deletes of its data file.
+ */
+class ScanKeyPositionResolver implements KeyPositionResolver {
+
+  private final Table table;
+  private final DeleteLoader deleteLoader;
+
+  ScanKeyPositionResolver(Table table) {
+    this.table = table;
+    this.deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+  }
+
+  @Override
+  public Resolution resolve(
+      Snapshot base,
+      Schema keySchema,
+      StructLikeSet keys,
+      PartitionSpec deleteSpec,
+      StructLike deletePartition)
+      throws IOException {
+    // the plan filter carries the partition pin and the key filter; only the key filter is passed
+    // to the file readers, whose row group filters evaluate column references,
+    // not partition transforms
+    Expression keyFilter =
+        KeyFilters.keyFilter(keySchema, keys, KeyFilters.comparisonsPerFile(base));
+    Expression planFilter =
+        Expressions.and(
+            KeyFilters.partitionFilter(table.schema(), deleteSpec, deletePartition), keyFilter);
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> planned =
+        table
+            .newScan()
+            .useSnapshot(base.snapshotId())
+            .filter(planFilter)
+            .ignoreResiduals()
+            .planFiles()) {
+      tasks = Lists.newArrayList(planned);
+    }
+
+    Map<String, FileMatches> matches = Maps.newConcurrentMap();
+    Tasks.foreach(tasks)
+        .executeWith(ThreadPools.getWorkerPool())
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .run(task -> match(task, keySchema, keys, keyFilter, matches), IOException.class);
+
+    return new ScanResolution(matches.values(), tasks.size());
+  }
+
+  /** Reads the key columns and row positions of one data file and records the matching rows. */
+  private void match(
+      FileScanTask task,
+      Schema keySchema,
+      StructLikeSet keys,
+      Expression keyFilter,
+      Map<String, FileMatches> matches)
+      throws IOException {
+    DataFile file = task.file();
+
+    List<DeleteFile> dvs = Lists.newArrayList();
+    for (DeleteFile delete : task.deletes()) {
+      if (ContentFileUtil.isDV(delete)) {
+        dvs.add(delete);
+      } else if (delete.content() == FileContent.POSITION_DELETES) {
+        throw new IllegalStateException(
+            String.format(
+                "Data file %s has position delete file %s, rewrite position deletes into deletion "
+                    + "vectors before enabling equality delete conversion",
+                file.location(), delete.location()));
+      }
+      // an attached equality delete stays in the table and is still applied by readers
+    }
+
+    PositionDeleteIndex existing =
+        dvs.isEmpty() ? null : deleteLoader.loadPositionDeletes(dvs, file.location());
+
+    Schema readSchema =
+        new Schema(
+            ImmutableList.<Types.NestedField>builder()
+                .addAll(keySchema.columns())
+                .add(MetadataColumns.ROW_POSITION)
+                .build());
+    Accessor<StructLike> posAccessor =
+        readSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
+    StructProjection keyProjection = StructProjection.create(readSchema, keySchema);
+    InternalRecordWrapper keyWrapper = new InternalRecordWrapper(keySchema.asStruct());
+
+    InputFile input = table.io().newInputFile(file);
+    ReadBuilder<Record, Schema> reader =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    Positions positions = new Positions();
+    try (CloseableIterable<Record> records =
+        reader.project(readSchema).filter(keyFilter).reuseContainers().build()) {
+      for (Record record : records) {
+        long pos = (long) posAccessor.get(record);
+        if (existing != null && existing.isDeleted(pos)) {
+          continue;
+        }
+
+        if (keys.contains(keyWrapper.wrap(keyProjection.wrap(record)))) {
+          positions.add(pos);
+        }
+      }
+    }
+
+    if (!positions.isEmpty()) {
+      matches.put(
+          file.location(),
+          new ScanFileMatches(file.location(), task.spec(), file.partition(), existing, positions));
+    }
+  }
+
+  private static class ScanResolution implements Resolution {
+    private final Collection<FileMatches> matches;
+    private final int scannedDataFiles;
+
+    ScanResolution(Collection<FileMatches> matches, int scannedDataFiles) {
+      this.matches = matches;
+      this.scannedDataFiles = scannedDataFiles;
+    }
+
+    @Override
+    public Collection<FileMatches> matches() {
+      return matches;
+    }
+
+    @Override
+    public int scannedDataFiles() {
+      return scannedDataFiles;
+    }
+  }
+
+  private static class ScanFileMatches implements FileMatches {
+    private final String path;
+    private final PartitionSpec spec;
+    private final StructLike partition;
+    private final PositionDeleteIndex existingDeletes;
+    private final Positions positions;
+
+    ScanFileMatches(
+        String path,
+        PartitionSpec spec,
+        StructLike partition,
+        PositionDeleteIndex existingDeletes,
+        Positions positions) {
+      this.path = path;
+      this.spec = spec;
+      this.partition = partition;
+      this.existingDeletes = existingDeletes;
+      this.positions = positions;
+    }
+
+    @Override
+    public String path() {
+      return path;
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return spec;
+    }
+
+    @Override
+    public StructLike partition() {
+      return partition;
+    }
+
+    @Override
+    public PositionDeleteIndex existingDeletes() {
+      return existingDeletes;
+    }
+
+    @Override
+    public void forEachPosition(LongConsumer consumer) {
+      positions.forEach(consumer);
+    }
+  }
+
+  /** Growable list of row positions without boxing. */
+  private static class Positions {
+    private long[] values = new long[64];
+    private int size = 0;
+
+    void add(long value) {
+      if (size == values.length) {
+        long[] grown = new long[values.length * 2];
+        System.arraycopy(values, 0, grown, 0, size);
+        this.values = grown;
+      }
+
+      values[size] = value;
+      size++;
+    }
+
+    boolean isEmpty() {
+      return size == 0;
+    }
+
+    void forEach(LongConsumer consumer) {
+      for (int i = 0; i < size; i++) {
+        consumer.accept(values[i]);
+      }
+    }
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestEqualityDeleteConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestEqualityDeleteConverter.java
@@ -1,0 +1,683 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericFileWriterFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.FileWriterFactory;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestEqualityDeleteConverter {
+
+  private static final Namespace NAMESPACE = Namespace.of("db");
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(NAMESPACE, "tbl");
+  private static final Schema SCHEMA =
+      new Schema(
+          ImmutableList.of(
+              Types.NestedField.required(1, "id", Types.LongType.get()),
+              Types.NestedField.required(2, "category", Types.StringType.get()),
+              Types.NestedField.optional(3, "data", Types.StringType.get())),
+          ImmutableSet.of(1));
+
+  /** The change of one row, as a CDC writer would produce it. */
+  private enum Op {
+    INSERT,
+    UPDATE,
+    DELETE
+  }
+
+  private InMemoryCatalog catalog;
+  private List<Integer> equalityFieldIds;
+
+  @BeforeEach
+  public void before() {
+    catalog = new InMemoryCatalog();
+    catalog.initialize("test_catalog", ImmutableMap.of());
+    catalog.createNamespace(NAMESPACE);
+    equalityFieldIds = ImmutableList.copyOf(SCHEMA.identifierFieldIds());
+  }
+
+  @AfterEach
+  public void after() throws IOException {
+    catalog.close();
+  }
+
+  @Test
+  public void testConvertsDeletesOfEarlierCommits() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+    WriteResult first =
+        write(
+            table,
+            insert(1L, "a", "v1"),
+            insert(2L, "a", "v1"),
+            insert(3L, "a", "v1"),
+            insert(4L, "a", "v1"),
+            insert(5L, "a", "v1"));
+    commit(table, first.dataFiles(), first.deleteFiles(), ImmutableList.of());
+    DataFile firstDataFile = first.dataFiles()[0];
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+
+    WriteResult second = write(table, delete(2L, "a"), update(4L, "a", "v2"));
+    assertThat(second.deleteFiles()).hasSize(1);
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    assertThat(result.baseSnapshotId()).isEqualTo(firstSnapshotId);
+    assertThat(result.rewrittenDvFiles()).isEmpty();
+    assertThat(result.dvFiles()).hasSize(1);
+    DeleteFile dv = result.dvFiles().get(0);
+    assertThat(ContentFileUtil.isDV(dv)).isTrue();
+    assertThat(dv.referencedDataFile()).isEqualTo(firstDataFile.location());
+    assertThat(dv.recordCount()).isEqualTo(2L);
+    assertThat(converter.scannedDataFiles()).isEqualTo(1);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).containsExactlyInAnyOrder("1|a|v1", "3|a|v1", "4|a|v2", "5|a|v1");
+
+    // a second conversion for the same data file merges the existing deletion vector
+    WriteResult third = write(table, delete(1L, "a"));
+    result = converter.convert(Arrays.asList(third.deleteFiles()));
+
+    assertThat(result.dvFiles()).hasSize(1);
+    assertThat(result.dvFiles().get(0).referencedDataFile()).isEqualTo(firstDataFile.location());
+    assertThat(result.dvFiles().get(0).recordCount()).isEqualTo(3L);
+    assertThat(result.rewrittenDvFiles()).hasSize(1);
+    assertThat(result.rewrittenDvFiles().get(0).location()).isEqualTo(dv.location());
+    assertThat(result.rewrittenDvFiles().get(0).contentOffset()).isEqualTo(dv.contentOffset());
+    // the data file written by the second batch only holds id 4 and is pruned by its column bounds
+    assertThat(converter.scannedDataFiles()).isEqualTo(1);
+
+    commit(table, third.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).containsExactlyInAnyOrder("3|a|v1", "4|a|v2", "5|a|v1");
+  }
+
+  @Test
+  public void testPartitionPruning() throws IOException {
+    Table table = createTable(PartitionSpec.builderFor(SCHEMA).identity("category").build());
+    // the partition column has to be part of the key for the delete to land in its partition
+    equalityFieldIds = ImmutableList.of(1, 2);
+
+    WriteResult first =
+        write(
+            table,
+            insert(1L, "a", "v1"),
+            insert(2L, "a", "v1"),
+            insert(3L, "b", "v1"),
+            insert(4L, "b", "v1"));
+    assertThat(first.dataFiles()).hasSize(2);
+    commit(table, first.dataFiles(), first.deleteFiles(), ImmutableList.of());
+
+    WriteResult second = write(table, delete(1L, "a"));
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    // only the data file of partition a is a candidate
+    assertThat(converter.scannedDataFiles()).isEqualTo(1);
+    assertThat(result.dvFiles()).hasSize(1);
+    assertThat(result.dvFiles().get(0).recordCount()).isEqualTo(1L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).containsExactlyInAnyOrder("2|a|v1", "3|b|v1", "4|b|v1");
+  }
+
+  @Test
+  public void testManyKeys() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+
+    List<Object[]> inserts = Lists.newArrayList();
+    for (long id = 1; id <= 300; id++) {
+      inserts.add(insert(id, "a", "v1"));
+    }
+    WriteResult first = write(table, inserts.toArray(new Object[0][]));
+    commit(table, first.dataFiles(), first.deleteFiles(), ImmutableList.of());
+
+    List<Object[]> deletes = Lists.newArrayList();
+    for (long id = 1; id <= 250; id++) {
+      deletes.add(delete(id, "a"));
+    }
+    WriteResult second = write(table, deletes.toArray(new Object[0][]));
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    assertThat(result.dvFiles()).hasSize(1);
+    assertThat(result.dvFiles().get(0).recordCount()).isEqualTo(250L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    Set<String> rows = readRows(table);
+    assertThat(rows).hasSize(50);
+    assertThat(rows).contains("251|a|v1", "300|a|v1");
+    assertThat(rows).doesNotContain("1|a|v1", "250|a|v1");
+  }
+
+  @Test
+  public void testClusteredKeysPruneToTheirFiles() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+
+    // 200 data files with 50 consecutive ids each
+    int fileCount = 200;
+    int rowsPerFile = 50;
+    List<DataFile> dataFiles = Lists.newArrayList();
+    for (int file = 0; file < fileCount; file++) {
+      List<Object[]> inserts = Lists.newArrayList();
+      for (int row = 0; row < rowsPerFile; row++) {
+        inserts.add(insert((long) file * rowsPerFile + row, "a", "v1"));
+      }
+      WriteResult result = write(table, inserts.toArray(new Object[0][]));
+      assertThat(result.dataFiles()).hasSize(1);
+      dataFiles.add(result.dataFiles()[0]);
+    }
+    commit(table, dataFiles.toArray(new DataFile[0]), new DeleteFile[0], ImmutableList.of());
+
+    // 295 hot keys in the last six files and five keys scattered over the table
+    List<Object[]> deletes = Lists.newArrayList();
+    for (long id = 9700; id < 9995; id++) {
+      deletes.add(delete(id, "a"));
+    }
+    for (long id : new long[] {5, 1005, 3005, 6005, 8005}) {
+      deletes.add(delete(id, "a"));
+    }
+    WriteResult second = write(table, deletes.toArray(new Object[0][]));
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    // more keys than one IN list holds, so the keys are matched with several lists: the hot
+    // range covers six files and every scattered key stays in its own file
+    assertThat(deletes).hasSizeGreaterThan(KeyFilters.IN_PREDICATE_LIMIT);
+    assertThat(converter.scannedDataFiles()).isEqualTo(11);
+    assertThat(result.dvFiles()).hasSize(11);
+    assertThat(result.dvFiles().stream().mapToLong(DeleteFile::recordCount).sum()).isEqualTo(300L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).hasSize(fileCount * rowsPerFile - 300);
+  }
+
+  @Test
+  public void testPartitionIsPinnedWithManyKeys() throws IOException {
+    Table table = createTable(PartitionSpec.builderFor(SCHEMA).identity("category").build());
+    // the partition column has to be part of the key for the delete to land in its partition
+    equalityFieldIds = ImmutableList.of(1, 2);
+
+    // three files of 100 ids in each of the partitions a and b, ids overlap across partitions
+    List<DataFile> dataFiles = Lists.newArrayList();
+    for (String category : new String[] {"a", "b"}) {
+      for (int file = 0; file < 3; file++) {
+        List<Object[]> inserts = Lists.newArrayList();
+        for (int row = 0; row < 100; row++) {
+          inserts.add(insert((long) file * 100 + row, category, "v1"));
+        }
+        WriteResult result = write(table, inserts.toArray(new Object[0][]));
+        dataFiles.add(result.dataFiles()[0]);
+      }
+    }
+    commit(table, dataFiles.toArray(new DataFile[0]), new DeleteFile[0], ImmutableList.of());
+
+    List<Object[]> deletes = Lists.newArrayList();
+    for (long id = 0; id < 250; id++) {
+      deletes.add(delete(id, "a"));
+    }
+    WriteResult second = write(table, deletes.toArray(new Object[0][]));
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    // the id filter alone covers files of both partitions, the partition pins it to a
+    assertThat(converter.scannedDataFiles()).isEqualTo(3);
+    assertThat(result.dvFiles()).hasSize(3);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    Set<String> rows = readRows(table);
+    assertThat(rows).hasSize(350);
+    assertThat(rows).contains("0|b|v1", "250|a|v1").doesNotContain("0|a|v1", "249|a|v1");
+  }
+
+  @Test
+  public void testTransformPartitionIsPinnedWithManyKeys() throws IOException {
+    Table table = createTable(PartitionSpec.builderFor(SCHEMA).bucket("id", 4).build());
+
+    // three batches, each writes one file per bucket
+    List<DataFile> dataFiles = Lists.newArrayList();
+    for (int batch = 0; batch < 3; batch++) {
+      List<Object[]> inserts = Lists.newArrayList();
+      for (long id = batch * 1000L; id < (batch + 1) * 1000L; id++) {
+        inserts.add(insert(id, "a", "v1"));
+      }
+      WriteResult result = write(table, inserts.toArray(new Object[0][]));
+      assertThat(result.dataFiles()).hasSize(4);
+      dataFiles.addAll(Arrays.asList(result.dataFiles()));
+    }
+    commit(table, dataFiles.toArray(new DataFile[0]), new DeleteFile[0], ImmutableList.of());
+
+    // more keys than the IN limit, all of them in bucket 0 and spread over all three batches
+    Function<Object, Integer> bucket = Transforms.bucket(4).bind(Types.LongType.get());
+    List<Long> bucketZeroIds = Lists.newArrayList();
+    for (long id = 0; id < 3000; id++) {
+      if (bucket.apply(id) == 0) {
+        bucketZeroIds.add(id);
+      }
+    }
+    List<Object[]> deletes = Lists.newArrayList();
+    for (int i = 0; i < 250; i++) {
+      deletes.add(delete(bucketZeroIds.get(i * bucketZeroIds.size() / 250), "a"));
+    }
+    WriteResult second = write(table, deletes.toArray(new Object[0][]));
+    assertThat(second.deleteFiles()).hasSize(1);
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    // the pinned bucket keeps only the three files of bucket 0
+    assertThat(converter.scannedDataFiles()).isEqualTo(3);
+    assertThat(result.dvFiles()).hasSize(3);
+    assertThat(result.dvFiles().stream().mapToLong(DeleteFile::recordCount).sum()).isEqualTo(250L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).hasSize(3000 - 250);
+  }
+
+  @Test
+  public void testScatteredKeysAreMatchedWithLists() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+
+    // 200 data files with 50 consecutive ids each
+    int fileCount = 200;
+    int rowsPerFile = 50;
+    List<DataFile> dataFiles = Lists.newArrayList();
+    for (int file = 0; file < fileCount; file++) {
+      List<Object[]> inserts = Lists.newArrayList();
+      for (int row = 0; row < rowsPerFile; row++) {
+        inserts.add(insert((long) file * rowsPerFile + row, "a", "v1"));
+      }
+      dataFiles.add(write(table, inserts.toArray(new Object[0][])).dataFiles()[0]);
+    }
+    commit(table, dataFiles.toArray(new DataFile[0]), new DeleteFile[0], ImmutableList.of());
+
+    // 300 hot keys in the last six files plus one key in each of the first 150 files: more
+    // scattered keys than value ranges could isolate, so the keys are matched with IN lists
+    List<Object[]> deletes = Lists.newArrayList();
+    for (long id = 9700; id < 10000; id++) {
+      deletes.add(delete(id, "a"));
+    }
+    for (int file = 0; file < 150; file++) {
+      deletes.add(delete((long) file * rowsPerFile + 7, "a"));
+    }
+    WriteResult second = write(table, deletes.toArray(new Object[0][]));
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    // exactly the files that hold a deleted key are read: 6 hot files and 150 scattered files
+    assertThat(converter.scannedDataFiles()).isEqualTo(156);
+    assertThat(result.dvFiles()).hasSize(156);
+    assertThat(result.dvFiles().stream().mapToLong(DeleteFile::recordCount).sum()).isEqualTo(450L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).hasSize(fileCount * rowsPerFile - 450);
+  }
+
+  @Test
+  public void testCustomResolver() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+    WriteResult first = write(table, insert(1L, "a", "v1"), insert(2L, "a", "v1"));
+    commit(table, first.dataFiles(), first.deleteFiles(), ImmutableList.of());
+    DataFile dataFile = first.dataFiles()[0];
+
+    WriteResult second = write(table, delete(2L, "a"));
+
+    // a resolver that knows the position of the row without reading the data file
+    KeyPositionResolver resolver =
+        (base, keySchema, keys, deleteSpec, deletePartition) -> {
+          assertThat(keys).hasSize(1);
+          KeyPositionResolver.FileMatches matches =
+              new KeyPositionResolver.FileMatches() {
+                @Override
+                public String path() {
+                  return dataFile.location();
+                }
+
+                @Override
+                public PartitionSpec spec() {
+                  return table.spec();
+                }
+
+                @Override
+                public StructLike partition() {
+                  return dataFile.partition();
+                }
+
+                @Override
+                public PositionDeleteIndex existingDeletes() {
+                  return null;
+                }
+
+                @Override
+                public void forEachPosition(LongConsumer consumer) {
+                  consumer.accept(1L);
+                }
+              };
+          return new KeyPositionResolver.Resolution() {
+            @Override
+            public Collection<KeyPositionResolver.FileMatches> matches() {
+              return ImmutableList.of(matches);
+            }
+
+            @Override
+            public int scannedDataFiles() {
+              return 0;
+            }
+          };
+        };
+
+    EqualityDeleteConverter converter = new EqualityDeleteConverter(table, null, resolver);
+    EqualityDeleteConverter.Result result = converter.convert(Arrays.asList(second.deleteFiles()));
+
+    assertThat(converter.scannedDataFiles()).isEqualTo(0);
+    assertThat(result.dvFiles()).hasSize(1);
+    assertThat(result.dvFiles().get(0).referencedDataFile()).isEqualTo(dataFile.location());
+    assertThat(result.dvFiles().get(0).recordCount()).isEqualTo(1L);
+
+    commit(table, second.dataFiles(), result.dvFiles(), result.rewrittenDvFiles());
+    assertThat(readRows(table)).containsExactly("1|a|v1");
+  }
+
+  @Test
+  public void testSplitIntoRanges() {
+    // 200 consecutive values and a cluster of 100 far away
+    List<Object> values = Lists.newArrayList();
+    for (long value = 0; value < 200; value++) {
+      values.add(value);
+    }
+    for (long value = 1000; value < 1100; value++) {
+      values.add(value);
+    }
+
+    // adjacent integers are never split, so the only split is the gap between 199 and 1000
+    List<int[]> ranges =
+        KeyFilters.splitIntoRanges(values, value -> ((Number) value).doubleValue(), 100);
+    assertThat(ranges).hasSize(2);
+    assertThat(ranges.get(0)).containsExactly(0, 199);
+    assertThat(ranges.get(1)).containsExactly(200, 299);
+
+    // with scattered values every gap qualifies and the range count is capped
+    List<Object> scattered = Lists.newArrayList();
+    for (long value = 0; value < 300; value++) {
+      scattered.add(value * 10);
+    }
+    List<int[]> capped =
+        KeyFilters.splitIntoRanges(scattered, value -> ((Number) value).doubleValue(), 100);
+    assertThat(capped).hasSize(100);
+    assertThat(capped.get(0)[0]).isEqualTo(0);
+    assertThat(capped.get(capped.size() - 1)[1]).isEqualTo(scattered.size() - 1);
+    for (int i = 1; i < capped.size(); i++) {
+      assertThat(capped.get(i)[0]).isEqualTo(capped.get(i - 1)[1] + 1);
+    }
+
+    // without a numeric converter the values are split into ranges of equal size
+    List<int[]> equalRanges = KeyFilters.splitIntoRanges(values, null, 100);
+    assertThat(equalRanges).hasSize(100);
+    assertThat(equalRanges).allMatch(range -> range[1] - range[0] + 1 == 3);
+
+    // fewer values than ranges: one range per value
+    List<int[]> single = KeyFilters.splitIntoRanges(values.subList(0, 5), null, 100);
+    assertThat(single).hasSize(5);
+    assertThat(single).allMatch(range -> range[0] == range[1]);
+  }
+
+  @Test
+  public void testConvertOnBranch() throws IOException {
+    Table table = createTable(PartitionSpec.unpartitioned());
+    WriteResult first = write(table, insert(1L, "a", "v1"), insert(2L, "a", "v1"));
+    RowDelta rowDelta = table.newRowDelta().toBranch("staging");
+    Arrays.stream(first.dataFiles()).forEach(rowDelta::addRows);
+    rowDelta.commit();
+
+    WriteResult second = write(table, delete(1L, "a"));
+
+    // main has no snapshot, nothing to resolve against
+    EqualityDeleteConverter.Result onMain =
+        new EqualityDeleteConverter(table, null).convert(Arrays.asList(second.deleteFiles()));
+    assertThat(onMain.baseSnapshotId()).isNull();
+    assertThat(onMain.dvFiles()).isEmpty();
+
+    EqualityDeleteConverter.Result onBranch =
+        new EqualityDeleteConverter(table, "staging").convert(Arrays.asList(second.deleteFiles()));
+    assertThat(onBranch.baseSnapshotId()).isEqualTo(table.snapshot("staging").snapshotId());
+    assertThat(onBranch.dvFiles()).hasSize(1);
+    assertThat(onBranch.dvFiles().get(0).recordCount()).isEqualTo(1L);
+  }
+
+  @Test
+  public void testRejectsNonEqualityDeletes() {
+    Table table = createTable(PartitionSpec.unpartitioned());
+    WriteResult first = write(table, insert(1L, "a", "v1"));
+    commit(table, first.dataFiles(), first.deleteFiles(), ImmutableList.of());
+
+    DeleteFile dv =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withFormat(FileFormat.PUFFIN)
+            .withPath("/path/to/dv.puffin")
+            .withFileSizeInBytes(10L)
+            .withRecordCount(1L)
+            .withReferencedDataFile(first.dataFiles()[0].location())
+            .withContentOffset(4L)
+            .withContentSizeInBytes(6L)
+            .build();
+
+    assertThatThrownBy(() -> new EqualityDeleteConverter(table, null).convert(ImmutableList.of(dv)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Not an equality delete file: /path/to/dv.puffin");
+  }
+
+  private Table createTable(PartitionSpec spec) {
+    return catalog.createTable(
+        TABLE_IDENTIFIER, SCHEMA, spec, ImmutableMap.of("format-version", "3"));
+  }
+
+  private static Object[] insert(Long id, String category, String data) {
+    return new Object[] {Op.INSERT, row(id, category, data)};
+  }
+
+  private static Object[] update(Long id, String category, String data) {
+    return new Object[] {Op.UPDATE, row(id, category, data)};
+  }
+
+  private static Object[] delete(Long id, String category) {
+    return new Object[] {Op.DELETE, row(id, category, null)};
+  }
+
+  private static Record row(Long id, String category, String data) {
+    Record row = GenericRecord.create(SCHEMA);
+    row.setField("id", id);
+    row.setField("category", category);
+    row.setField("data", data);
+    return row;
+  }
+
+  /**
+   * Writes the changes the way a CDC writer does: inserts and the new version of updates go to a
+   * data file, updates and deletes write the key to an equality delete file, one file of each kind
+   * per partition.
+   */
+  private WriteResult write(Table table, Object[]... operations) {
+    Schema keySchema = TypeUtil.select(table.schema(), Sets.newHashSet(equalityFieldIds));
+    FileWriterFactory<Record> writerFactory =
+        new GenericFileWriterFactory.Builder(table)
+            .dataSchema(table.schema())
+            .dataFileFormat(FileFormat.PARQUET)
+            .deleteFileFormat(FileFormat.PARQUET)
+            .equalityFieldIds(equalityFieldIds.stream().mapToInt(Integer::intValue).toArray())
+            .equalityDeleteRowSchema(keySchema)
+            .build();
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(table, 1, System.nanoTime())
+            .format(FileFormat.PARQUET)
+            .build();
+    PartitionKey partitionKey = new PartitionKey(table.spec(), table.schema());
+    InternalRecordWrapper wrapper = new InternalRecordWrapper(table.schema().asStruct());
+
+    Map<String, StructLike> partitions = Maps.newHashMap();
+    Map<String, DataWriter<Record>> dataWriters = Maps.newHashMap();
+    Map<String, EqualityDeleteWriter<Record>> deleteWriters = Maps.newHashMap();
+    WriteResult.Builder result = WriteResult.builder();
+    try {
+      for (Object[] operation : operations) {
+        Record row = (Record) operation[1];
+        StructLike partition = null;
+        String path = "";
+        if (table.spec().isPartitioned()) {
+          partitionKey.partition(wrapper.wrap(row));
+          partition = partitionKey.copy();
+          path = partitionKey.toPath();
+        }
+        partitions.put(path, partition);
+
+        Op op = (Op) operation[0];
+        if (op != Op.INSERT) {
+          Record key = GenericRecord.create(keySchema);
+          for (Types.NestedField field : keySchema.columns()) {
+            key.setField(field.name(), row.getField(field.name()));
+          }
+          deleteWriters
+              .computeIfAbsent(
+                  path,
+                  ignored ->
+                      writerFactory.newEqualityDeleteWriter(
+                          fileFactory.newOutputFile(table.spec(), partitions.get(ignored)),
+                          table.spec(),
+                          partitions.get(ignored)))
+              .write(key);
+        }
+        if (op != Op.DELETE) {
+          dataWriters
+              .computeIfAbsent(
+                  path,
+                  ignored ->
+                      writerFactory.newDataWriter(
+                          fileFactory.newOutputFile(table.spec(), partitions.get(ignored)),
+                          table.spec(),
+                          partitions.get(ignored)))
+              .write(row);
+        }
+      }
+
+      for (DataWriter<Record> writer : dataWriters.values()) {
+        writer.close();
+        result.addDataFiles(writer.toDataFile());
+      }
+      for (EqualityDeleteWriter<Record> writer : deleteWriters.values()) {
+        writer.close();
+        result.addDeleteFiles(writer.toDeleteFile());
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return result.build();
+  }
+
+  private static void commit(
+      Table table,
+      DataFile[] dataFiles,
+      Iterable<DeleteFile> addedDeletes,
+      Iterable<DeleteFile> removedDeletes) {
+    RowDelta rowDelta = table.newRowDelta();
+    if (table.currentSnapshot() != null) {
+      // replacing a deletion vector requires the starting snapshot, like the coordinator sets it
+      rowDelta.validateFromSnapshot(table.currentSnapshot().snapshotId());
+    }
+    Arrays.stream(dataFiles).forEach(rowDelta::addRows);
+    addedDeletes.forEach(rowDelta::addDeletes);
+    removedDeletes.forEach(rowDelta::removeDeletes);
+    rowDelta.commit();
+  }
+
+  private static void commit(
+      Table table,
+      DataFile[] dataFiles,
+      DeleteFile[] addedDeletes,
+      Iterable<DeleteFile> removedDeletes) {
+    commit(table, dataFiles, Arrays.asList(addedDeletes), removedDeletes);
+  }
+
+  private static Set<String> readRows(Table table) {
+    Set<String> rows = Sets.newHashSet();
+    try (CloseableIterable<Record> records = IcebergGenerics.read(table).build()) {
+      for (Record record : records) {
+        rows.add(
+            record.getField("id")
+                + "|"
+                + record.getField("category")
+                + "|"
+                + record.getField("data"));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return rows;
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestKeyFilters.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestKeyFilters.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.jupiter.api.Test;
+
+public class TestKeyFilters {
+
+  private static final Schema KEY_SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+  private static final Schema TWO_COLUMN_KEY_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.required(2, "tenant", Types.LongType.get()));
+
+  @Test
+  public void testComparisonsPerFileFollowsDataFileCount() {
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("1000000"))).isEqualTo(200);
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("400000"))).isEqualTo(500);
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("200000"))).isEqualTo(1000);
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("2000"))).isEqualTo(1000);
+    // without a usable count the filter stays as small as for the largest table
+    assertThat(KeyFilters.comparisonsPerFile(snapshot(null))).isEqualTo(200);
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("not a number"))).isEqualTo(200);
+    // an empty table can afford the largest filter
+    assertThat(KeyFilters.comparisonsPerFile(snapshot("0"))).isEqualTo(1000);
+  }
+
+  @Test
+  public void testListsSelectOnlyFilesHoldingKeys() {
+    // 300 hot keys and 150 scattered keys, one every 50 ids
+    StructLikeSet keys = StructLikeSet.create(KEY_SCHEMA.asStruct());
+    for (long id = 9700; id < 10000; id++) {
+      keys.add(key(id));
+    }
+    for (long file = 0; file < 150; file++) {
+      keys.add(key(file * 50 + 7));
+    }
+
+    Expression lists = KeyFilters.keyFilter(KEY_SCHEMA, keys, 2000);
+    assertThat(lists.toString()).contains(" in (").doesNotContain(" <= ");
+
+    // a file between two scattered keys holds no key and is pruned by the lists
+    assertThat(mightMatch(lists, 20, 39)).isFalse();
+    // files holding a scattered key or the hot keys are kept
+    assertThat(mightMatch(lists, 0, 49)).isTrue();
+    assertThat(mightMatch(lists, 9750, 9799)).isTrue();
+    // files past the last key are pruned
+    assertThat(mightMatch(lists, 10000, 10049)).isFalse();
+  }
+
+  @Test
+  public void testRangesAboveTheBudget() {
+    StructLikeSet keys = StructLikeSet.create(KEY_SCHEMA.asStruct());
+    for (long id = 9700; id < 10000; id++) {
+      keys.add(key(id));
+    }
+    for (long file = 0; file < 150; file++) {
+      keys.add(key(file * 50 + 7));
+    }
+
+    // a budget of 200 comparisons allows 100 ranges, fewer than the 151 clusters of keys
+    Expression ranges = KeyFilters.keyFilter(KEY_SCHEMA, keys, 200);
+    assertThat(ranges.toString()).contains(" <= ").doesNotContain(" in (");
+
+    // the hot cluster and files far from any key are handled like the lists do
+    assertThat(mightMatch(ranges, 9750, 9799)).isTrue();
+    assertThat(mightMatch(ranges, 10000, 10049)).isFalse();
+    // but some scattered keys share a range, so a file between them cannot be pruned everywhere
+    int keptFilesWithoutKeys = 0;
+    for (long file = 0; file < 150; file++) {
+      long first = file * 50 + 20;
+      if (mightMatch(ranges, first, first + 19)) {
+        keptFilesWithoutKeys++;
+      }
+    }
+    assertThat(keptFilesWithoutKeys).isGreaterThan(0);
+  }
+
+  @Test
+  public void testEveryKeyColumnCountsTowardsTheBudget() {
+    StructLikeSet keys = StructLikeSet.create(TWO_COLUMN_KEY_SCHEMA.asStruct());
+    for (long id = 0; id < 150; id++) {
+      Record key = GenericRecord.create(TWO_COLUMN_KEY_SCHEMA);
+      key.set(0, id);
+      key.set(1, id % 4);
+      keys.add(key);
+    }
+
+    // 150 keys x 2 columns = 300 comparisons: within a budget of 300, above a budget of 299
+    assertThat(KeyFilters.keyFilter(TWO_COLUMN_KEY_SCHEMA, keys, 300).toString()).contains(" in (");
+    assertThat(KeyFilters.keyFilter(TWO_COLUMN_KEY_SCHEMA, keys, 299).toString()).contains(" <= ");
+  }
+
+  private static Snapshot snapshot(String totalDataFiles) {
+    Snapshot snapshot = mock(Snapshot.class);
+    Map<String, String> summary =
+        totalDataFiles == null
+            ? ImmutableMap.of()
+            : ImmutableMap.of("total-data-files", totalDataFiles);
+    when(snapshot.summary()).thenReturn(summary);
+    return snapshot;
+  }
+
+  private static Record key(long id) {
+    Record key = GenericRecord.create(KEY_SCHEMA);
+    key.set(0, id);
+    return key;
+  }
+
+  /** Evaluates the filter against a data file whose id column spans [lower, upper]. */
+  private static boolean mightMatch(Expression filter, long lower, long upper) {
+    ByteBuffer lowerBound = Conversions.toByteBuffer(Types.LongType.get(), lower);
+    ByteBuffer upperBound = Conversions.toByteBuffer(Types.LongType.get(), upper);
+    long rows = upper - lower + 1;
+    DataFile file =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/data/" + lower + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(1)
+            .withMetrics(
+                new Metrics(
+                    rows,
+                    ImmutableMap.of(1, rows),
+                    ImmutableMap.of(1, rows),
+                    ImmutableMap.of(1, 0L),
+                    null,
+                    ImmutableMap.of(1, lowerBound),
+                    ImmutableMap.of(1, upperBound)))
+            .build();
+    return new InclusiveMetricsEvaluator(KEY_SCHEMA, filter).eval(file);
+  }
+}


### PR DESCRIPTION
This is inspired by Flink's `ConvertEqualityDeletes` maintenance action (#15996) and
follows the same approach: resolve the keys of equality deletes to row positions and
commit deletion vectors instead, built on the same core pieces (`BaseDeleteLoader`,
`BaseDVFileWriter`, `RowDelta` validations). The difference is where it runs. Flink
converts already committed deletes of a staging branch in a separate topology with a
keyed-state index; the Kafka Connect sink converts the deletes of the current commit
inside its coordinator, before they are committed, with a stateless pruned scan.

Part 1 of 4 in a series that adds CDC writes to the Kafka Connect sink without exposing
equality deletes on the table. Each part is a separate PR, opened after the previous one
is merged:

- [x] **Part 1 (this PR)**: `EqualityDeleteConverter`, a library class that resolves
      equality deletes to deletion vectors. No callers yet, no behavior change.
- [ ] **Part 2**: coordinator wiring. `iceberg.tables.convert-equality-deletes-enabled`,
      conversion inside the commit with validation, retries and fallback, runtime
      dependency for Parquet reads, docs.
- [ ] **Part 3**: delta writer. `iceberg.tables.cdc-field` and
      `iceberg.tables.upsert-mode-enabled`, inserts as data files, updates and deletes as
      equality deletes (deletion vectors within a batch).
- [ ] **Part 4**: integration tests for partitioned tables, keys split over tasks,
      schema evolution and concurrent writers, plus an opt-in soak test.

### Why

Equality deletes committed by a streaming sink are applied by every reader to every older
data file until compaction runs, which is what blocked #14797. The sink has one process,
the coordinator, that sees every delete file of a commit before the commit exists, so the
equality deletes can be resolved to row positions right there and committed as deletion
vectors instead. No branch, no index state, no maintenance job, and the main branch never
carries an equality delete. This PR adds the class that does the resolving; the
coordinator that calls it is the next PR.

```mermaid
flowchart LR
    W["Worker<br/>delta writer (PR 3)"] -->|"data files +<br/>equality delete files"| C["Coordinator (PR 2)"]
    C -->|"equality delete files"| X["EqualityDeleteConverter<br/>(this PR)"]
    X -->|"Result: deletion vectors,<br/>rewritten vectors, base snapshot,<br/>conflict filter"| C
    C -->|"RowDelta: data files + vectors"| T[("Iceberg table, v3<br/>no equality deletes")]
```

### What this PR adds

| Class | Role |
|---|---|
| `EqualityDeleteConverter` (public) | Entry point. Groups the delete files, loads their keys, asks a resolver for positions, writes the vectors, returns a `Result`. |
| `KeyPositionResolver` (interface) | "Given a set of deleted keys, which rows of the base snapshot hold them?" Returns matches per data file, including the vector already attached to that file. |
| `ScanKeyPositionResolver` (default) | Answers by planning the snapshot with pruning filters and reading only the key columns and `_pos` of the candidate files. Keeps no state. |
| `KeyFilters` | Builds the pruning filters: partition pin through transforms, `IN` lists or value ranges within a comparison budget. |

```mermaid
classDiagram
    class EqualityDeleteConverter {
        +EqualityDeleteConverter(Table, String branch)
        +convert(List~DeleteFile~ eqDeleteFiles) Result
    }
    class Result {
        +baseSnapshotId() Long
        +dvFiles() List~DeleteFile~
        +rewrittenDvFiles() List~DeleteFile~
        +conflictFilter() Expression
    }
    class KeyPositionResolver {
        <<interface>>
        +resolve(Snapshot base, Schema keySchema, StructLikeSet keys, PartitionSpec deleteSpec, StructLike deletePartition) Resolution
    }
    class FileMatches {
        <<interface>>
        +path() String
        +spec() PartitionSpec
        +partition() StructLike
        +existingDeletes() PositionDeleteIndex
        +forEachPosition(LongConsumer)
    }
    class ScanKeyPositionResolver
    class KeyFilters {
        +partitionFilter(Schema, PartitionSpec, StructLike) Expression
        +comparisonsPerFile(Snapshot) int
        +keyFilter(Schema keySchema, StructLikeSet keys, int comparisonsPerFile) Expression
    }
    EqualityDeleteConverter --> KeyPositionResolver : resolve()
    EqualityDeleteConverter --> Result : returns
    EqualityDeleteConverter ..> KeyFilters : conflict filter
    KeyPositionResolver --> FileMatches : returns per data file
    ScanKeyPositionResolver ..|> KeyPositionResolver
    ScanKeyPositionResolver ..> KeyFilters : plan + read filters
```

### How a conversion runs

```mermaid
sequenceDiagram
    participant Caller
    participant Conv as EqualityDeleteConverter
    participant Loader as BaseDeleteLoader (core)
    participant Res as KeyPositionResolver
    participant DV as BaseDVFileWriter (core)

    Caller->>Conv: convert(eqDeleteFiles)
    Conv->>Conv: base = snapshot of branch (none: Result.empty())
    Conv->>Conv: group files by (equality field ids, spec, partition)
    loop each group
        Conv->>Loader: loadEqualityDeletes(files, keySchema)
        Loader-->>Conv: StructLikeSet keys
        Conv->>Conv: conflictFilter OR= partitionFilter AND keyFilter
        Conv->>Res: resolve(base, keySchema, keys, spec, partition)
        Res-->>Conv: FileMatches per data file
        Conv->>DV: delete(path, pos, spec, partition) for every position
    end
    Conv->>DV: close()
    Note over DV: merges the vector a data file already has,<br/>writes one Puffin file
    DV-->>Conv: DeleteWriteResult (new vectors, rewritten vectors)
    Conv-->>Caller: Result(baseSnapshotId, dvFiles, rewrittenDvFiles, conflictFilter)
```

The `Result` maps one-to-one onto the `RowDelta` the next PR will build:

| `Result` | `RowDelta` |
|---|---|
| `baseSnapshotId()` | `validateFromSnapshot(id)` (also required to replace a vector) |
| `dvFiles()` | `addDeletes(dv)` |
| `rewrittenDvFiles()` | `removeDeletes(dv)` (a data file may have only one vector) |
| `conflictFilter()` | `conflictDetectionFilter(expr)` + `validateNoConflictingDataFiles()` / `validateNoConflictingDeleteFiles()` |

### How positions are found (`ScanKeyPositionResolver`)

Four stages narrow the work. The first three only decide which files and row groups are
opened; the last one decides correctness. Stages 1 and 2 happen inside `planFiles`, stage 3
inside the file reader, stage 4 in the resolver's own loop.

```mermaid
flowchart TD
    K["deleted keys of one group"] --> F["KeyFilters<br/>planFilter = partitionFilter AND keyFilter"]
    F --> P1["1. manifest level (planFiles)<br/>partition summaries of each manifest<br/>vs. the partition pin"]
    P1 --> P2["2. file level (planFiles)<br/>partition value and column bounds<br/>of each data file entry vs. planFilter"]
    P2 -->|"candidate FileScanTasks, read in parallel"| P3["3. row group level (file reader)<br/>project key columns + _pos,<br/>filter(keyFilter) skips row groups by their statistics"]
    P3 --> P4["4. row level (resolver)<br/>skip positions the file's existing deletion vector covers,<br/>then keys.contains(row key): exact"]
    P4 --> O["FileMatches: path, spec, partition,<br/>existing vector, positions"]
```

Only `keyFilter` is passed to the file readers: Parquet row-group filters evaluate column
references, not partition transforms. Data files that carry v2 position delete files are
rejected with an `IllegalStateException` asking to rewrite them into deletion vectors
first, because a data file can have only one vector and no position delete files next to
it. Equality delete files already attached to a candidate are left alone; their rows may
land in the new vector too, which is harmless.

### How the filters are built (`KeyFilters`)

The filters are inclusive: a file that holds a deleted key always stays a candidate, a file
without one may. Their size is bounded because the plan filter is evaluated once per data
file entry.

```mermaid
flowchart TD
    S["snapshot summary<br/>total-data-files = F"] --> C["budget C = 200,000,000 / F<br/>clamped to [200, 1000] comparisons per file<br/>(missing count: 200)"]
    C --> D{"keys x primitive key columns <= C ?"}
    D -->|yes| L["IN lists<br/>chunks of 200 values (evaluator limit), one list per key column,<br/>chunks OR-ed: exact, only files holding a key"]
    D -->|no| G["value ranges on the leading key column<br/>at most C / 2 ranges, split at the largest gaps<br/>(integers: only gaps that skip a value):<br/>inclusive, may keep files without a key"]
    PF["partitionFilter<br/>every partition field pinned through its transform,<br/>e.g. bucket(4, id) = 3; void / unknown transforms skipped"] --> A["planFilter = partitionFilter AND keyFilter"]
    L --> A
    G --> A
```

Why 200,000,000: a fixed cap of 100 ranges would cost 200 comparisons per file, or 200M
on a table with one million data files. The budget keeps that cost for such tables and
lets smaller tables use a finer filter. On a 2,000-file benchmark table, 2,000 deleted
keys of which 10% were scattered opened 1,109 files with a fixed cap of 100 ranges and
202 with the budget, the files that actually hold a key.

### Notes for reviewers

- `KeyPositionResolver` is an interface so an index-backed resolver can replace the scan
  once the secondary index spec (#16961) lands; the constructor that accepts one is
  package-private for now.
- `KeyFilters.IN_PREDICATE_LIMIT` (200) mirrors the private constant in
  `InclusiveEvalVisitor`; above it an `IN` list is not evaluated against file bounds.
- Format version 3 only. The class keeps no state between calls; `scannedDataFiles()` is
  a test hook reporting the files read by the last conversion.

### Testing

- `TestEqualityDeleteConverter` (11), against a real v3 table (`InMemoryCatalog`), read
  back with `IcebergGenerics`: deletes of earlier commits become vectors and a second
  conversion merges the existing vector and reports it as rewritten; partition pruning;
  identity and `bucket` partitions pinned with more keys than one `IN` list holds
  (12 files → 3); clustered plus scattered keys open exactly the files that hold them
  (200 files → 11, and → 156); a custom resolver; conversion on a branch; rejection of
  non-equality delete files.
- `TestKeyFilters` (4), against file statistics with `InclusiveMetricsEvaluator`: the
  budget for every `total-data-files` case; `IN` lists exclude exactly the files without
  keys; ranges above the budget keep some files without keys (documented); every key
  column counts towards the budget.
- `./gradlew -DkafkaVersions=3 :iceberg-kafka-connect:iceberg-kafka-connect:check` passes
  (148 tests, checkstyle, spotless).