### PR TITLE
Spark: Fix concurrent runtime filtering on shared scan for COW UPDATE with subquery

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -124,9 +124,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  // synchronized on the same monitor as tasks()/taskGroups()/resetTasks() so the non-atomic
-  // check-then-act runtime filtering cannot interleave with a concurrent filter() call on a
-  // scan instance shared across query stages.
+  // serialize concurrent filter() calls on a shared scan
   public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilterExpr = convertRuntimeFilters(predicates);
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -124,7 +124,10 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  public void filter(Predicate[] predicates) {
+  // synchronized on the same monitor as tasks()/taskGroups()/resetTasks() so the non-atomic
+  // check-then-act runtime filtering cannot interleave with a concurrent filter() call on a
+  // scan instance shared across query stages.
+  public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilterExpr = convertRuntimeFilters(predicates);
 
     if (runtimeFilterExpr != Expressions.alwaysTrue()) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -118,11 +118,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  // synchronized on the same monitor as tasks()/taskGroups()/resetTasks() so the non-atomic
-  // check-then-act (publish filteredLocations, stream tasks(), then resetTasks()) cannot interleave
-  // with a concurrent filter() call. UPDATE ... WHERE EXISTS(<subquery>) is rewritten as a UNION
-  // whose branches share this scan and Spark may invoke filter() concurrently on the shared
-  // instance.
+  // serialize concurrent filter() calls on a scan shared across UNION branches
   public synchronized void filter(Predicate[] predicates) {
     Preconditions.checkState(
         Objects.equals(snapshotId(), currentSnapshotId()),

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -118,7 +118,12 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  public void filter(Predicate[] predicates) {
+  // synchronized on the same monitor as tasks()/taskGroups()/resetTasks() so the non-atomic
+  // check-then-act (publish filteredLocations, stream tasks(), then resetTasks()) cannot interleave
+  // with a concurrent filter() call. UPDATE ... WHERE EXISTS(<subquery>) is rewritten as a UNION
+  // whose branches share this scan and Spark may invoke filter() concurrently on the shared
+  // instance.
+  public synchronized void filter(Predicate[] predicates) {
     Preconditions.checkState(
         Objects.equals(snapshotId(), currentSnapshotId()),
         "Runtime file filtering is not possible: the table has been concurrently modified. "

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -243,7 +243,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
   // only task groups can be reset while resetting tasks
   // the set of scanned specs and grouping key type must never change
-  protected void resetTasks(List<T> filteredTasks) {
+  protected synchronized void resetTasks(List<T> filteredTasks) {
     this.taskGroups = null;
     this.tasks = filteredTasks;
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
+ *
+ * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
+ * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
+ * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
+ * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
+ * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
+ * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
+ * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
+ * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
+ * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
+ *
+ * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
+ * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
+ * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
+ * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
+ * observes the full set.
+ */
+public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
+
+  private static final int FILE_COUNT = 10;
+  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
+  private static final long LATCH_TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
+        tableName);
+
+    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
+    // the single-file set the runtime filter should produce
+    for (int i = 0; i < FILE_COUNT; i++) {
+      sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
+    }
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    CountDownLatch enteredResetTasks = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+
+    // memoize the full planning-time task set and task groups exactly as query planning would
+    List<FileScanTask> plannedTasks = scan.tasks();
+    scan.taskGroups();
+    assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
+
+    // `_file IN (<one location>)` runtime predicate, matching what Spark passes for a COW filter
+    String targetLocation = plannedTasks.get(0).file().location();
+    Predicate[] predicates = {filePathInPredicate(targetLocation)};
+
+    AtomicReference<Throwable> winnerFailure = new AtomicReference<>();
+    AtomicReference<Throwable> loserFailure = new AtomicReference<>();
+    AtomicInteger observedTaskCount = new AtomicInteger(-1);
+    AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
+
+    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
+    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    Thread winner =
+        new Thread(
+            () -> {
+              try {
+                scan.filter(predicates);
+              } catch (Throwable t) {
+                winnerFailure.set(t);
+                enteredResetTasks.countDown();
+              }
+            },
+            "cow-filter-winner");
+
+    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
+    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
+    // the shared task set - which must already be narrowed.
+    Thread loser =
+        new Thread(
+            () -> {
+              try {
+                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("winner should have entered resetTasks")
+                    .isTrue();
+                scan.filter(predicates);
+                observedTaskCount.set(scan.tasks().size());
+                observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
+              } catch (Throwable t) {
+                loserFailure.set(t);
+              }
+            },
+            "cow-filter-loser");
+
+    winner.start();
+    loser.start();
+    winner.join(JOIN_TIMEOUT_MILLIS);
+    loser.join(JOIN_TIMEOUT_MILLIS);
+
+    if (winnerFailure.get() != null) {
+      throw new AssertionError("winner branch failed", winnerFailure.get());
+    }
+    if (loserFailure.get() != null) {
+      throw new AssertionError("loser branch failed", loserFailure.get());
+    }
+
+    assertThat(observedTaskCount.get())
+        .as(
+            "the losing UNION branch must observe the narrowed single-file task set, never the "
+                + "full %s-file set (which would rewrite every file and duplicate rows, issue "
+                + "#18004)",
+            FILE_COUNT)
+        .isEqualTo(1);
+    assertThat(observedTaskGroupFileCount.get())
+        .as("task groups must reflect the narrowed single-file set")
+        .isEqualTo(1);
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
+  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  private InstrumentedCopyOnWriteScan newInstrumentedScan(
+      Table table, CountDownLatch enteredResetTasks) {
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Schema expectedSchema = table.schema();
+    Snapshot snapshot = table.currentSnapshot();
+
+    BatchScan batchScan =
+        table
+            .newBatchScan()
+            .useSnapshot(snapshot.snapshotId())
+            .ignoreResiduals()
+            .caseSensitive(readConf.caseSensitive())
+            .filter(Expressions.alwaysTrue())
+            .project(expectedSchema);
+
+    return new InstrumentedCopyOnWriteScan(
+        spark,
+        table,
+        batchScan,
+        snapshot,
+        readConf,
+        expectedSchema,
+        Lists.newArrayList(),
+        () -> null,
+        enteredResetTasks);
+  }
+
+  private static Predicate filePathInPredicate(String location) {
+    NamedReference fileRef = FieldReference.apply(MetadataColumns.FILE_PATH.name());
+    LiteralValue<UTF8String> literal =
+        new LiteralValue<>(UTF8String.fromString(location), DataTypes.StringType);
+    return new Predicate(
+        "IN", new org.apache.spark.sql.connector.expressions.Expression[] {fileRef, literal});
+  }
+
+  private static int countFiles(List<ScanTaskGroup<FileScanTask>> taskGroups) {
+    int count = 0;
+    for (ScanTaskGroup<FileScanTask> group : taskGroups) {
+      count += group.tasks().size();
+    }
+    return count;
+  }
+
+  /**
+   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
+   * real implementation) so the check-then-act window in {@code filter()} can be observed by
+   * another thread. The override is intentionally NOT synchronized: the only serialization under
+   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
+   * reproduces the race instead of being masked here.
+   */
+  private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
+    private final CountDownLatch enteredResetTasks;
+
+    InstrumentedCopyOnWriteScan(
+        SparkSession spark,
+        Table table,
+        BatchScan scan,
+        Snapshot snapshot,
+        SparkReadConf readConf,
+        Schema expectedSchema,
+        List<Expression> filters,
+        Supplier<ScanReport> scanReportSupplier,
+        CountDownLatch enteredResetTasks) {
+      super(spark, table, scan, snapshot, readConf, expectedSchema, filters, scanReportSupplier);
+      this.enteredResetTasks = enteredResetTasks;
+    }
+
+    @Override
+    protected void resetTasks(List<FileScanTask> filteredTasks) {
+      enteredResetTasks.countDown();
+      try {
+        Thread.sleep(PARK_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      super.resetTasks(filteredTasks);
+    }
+  }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -50,37 +50,21 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
-/**
- * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
- *
- * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
- * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
- * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
- * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
- * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
- * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
- * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
- * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
- * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
- *
- * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
- * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
- * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
- * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
- * observes the full set.
- */
+/** Regression test for the copy-on-write runtime-filter concurrency bug (issue #18004). */
 public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
 
   private static final int FILE_COUNT = 10;
-  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
-  private static final long LATCH_TIMEOUT_SECONDS = 30;
-  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
 
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
+  // A COW UPDATE with a subquery becomes a UNION whose branches share one scan, which Spark can
+  // filter() concurrently under AQE. Without synchronization a branch reads the full task set and
+  // rewrites every file, duplicating rows (#18004).
   @TestTemplate
   public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
     sql(
@@ -88,8 +72,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
         tableName);
 
-    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
-    // the single-file set the runtime filter should produce
+    // one single-row file per INSERT, so the narrowed set (1) is clearly distinct from the full set
     for (int i = 0; i < FILE_COUNT; i++) {
       sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
     }
@@ -97,9 +80,10 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     Table table = validationCatalog.loadTable(tableIdent);
 
     CountDownLatch enteredResetTasks = new CountDownLatch(1);
-    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+    CountDownLatch releaseWinner = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks, releaseWinner);
 
-    // memoize the full planning-time task set and task groups exactly as query planning would
+    // memoize the full task set and groups exactly as query planning would
     List<FileScanTask> plannedTasks = scan.tasks();
     scan.taskGroups();
     assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
@@ -113,8 +97,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     AtomicInteger observedTaskCount = new AtomicInteger(-1);
     AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
 
-    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
-    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    // winner: narrows the scan, then parks in resetTasks while holding the scan monitor
     Thread winner =
         new Thread(
             () -> {
@@ -122,21 +105,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
                 scan.filter(predicates);
               } catch (Throwable t) {
                 winnerFailure.set(t);
-                enteredResetTasks.countDown();
               }
             },
             "cow-filter-winner");
 
-    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
-    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
-    // the shared task set - which must already be narrowed.
+    // loser: runs filter() (short-circuits) then reads the shared task set, which must be narrowed
     Thread loser =
         new Thread(
             () -> {
               try {
-                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                    .as("winner should have entered resetTasks")
-                    .isTrue();
                 scan.filter(predicates);
                 observedTaskCount.set(scan.tasks().size());
                 observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
@@ -147,7 +124,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             "cow-filter-loser");
 
     winner.start();
+    assertThat(enteredResetTasks.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .as("winner should have entered resetTasks")
+        .isTrue();
+
     loser.start();
+    // release the winner once the loser has blocked on the monitor or finished its stale read
+    awaitLoserSettled(loser, observedTaskCount);
+    releaseWinner.countDown();
+
     winner.join(JOIN_TIMEOUT_MILLIS);
     loser.join(JOIN_TIMEOUT_MILLIS);
 
@@ -170,10 +155,25 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         .isEqualTo(1);
   }
 
-  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
-  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  // waits until the loser can progress no further before releasing the winner: either blocked on
+  // the scan monitor (synchronized filter()) or already done recording its task count
+  private static void awaitLoserSettled(Thread loser, AtomicInteger observedTaskCount)
+      throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+    while (System.nanoTime() < deadlineNanos) {
+      Thread.State state = loser.getState();
+      if (state == Thread.State.BLOCKED
+          || state == Thread.State.TERMINATED
+          || observedTaskCount.get() != -1) {
+        return;
+      }
+      Thread.sleep(1);
+    }
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan but returns an instrumented subclass
   private InstrumentedCopyOnWriteScan newInstrumentedScan(
-      Table table, CountDownLatch enteredResetTasks) {
+      Table table, CountDownLatch enteredResetTasks, CountDownLatch releaseWinner) {
     SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
     Schema expectedSchema = table.schema();
     Snapshot snapshot = table.currentSnapshot();
@@ -196,7 +196,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         expectedSchema,
         Lists.newArrayList(),
         () -> null,
-        enteredResetTasks);
+        enteredResetTasks,
+        releaseWinner);
   }
 
   private static Predicate filePathInPredicate(String location) {
@@ -215,15 +216,11 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     return count;
   }
 
-  /**
-   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
-   * real implementation) so the check-then-act window in {@code filter()} can be observed by
-   * another thread. The override is intentionally NOT synchronized: the only serialization under
-   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
-   * reproduces the race instead of being masked here.
-   */
+  // parks inside resetTasks to hold the filter() window open for another thread. Intentionally NOT
+  // synchronized so the only serialization under test comes from SparkCopyOnWriteScan#filter.
   private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
     private final CountDownLatch enteredResetTasks;
+    private final CountDownLatch releaseWinner;
 
     InstrumentedCopyOnWriteScan(
         SparkSession spark,
@@ -234,16 +231,18 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         Schema expectedSchema,
         List<Expression> filters,
         Supplier<ScanReport> scanReportSupplier,
-        CountDownLatch enteredResetTasks) {
+        CountDownLatch enteredResetTasks,
+        CountDownLatch releaseWinner) {
       super(spark, table, scan, snapshot, readConf, expectedSchema, filters, scanReportSupplier);
       this.enteredResetTasks = enteredResetTasks;
+      this.releaseWinner = releaseWinner;
     }
 
     @Override
     protected void resetTasks(List<FileScanTask> filteredTasks) {
       enteredResetTasks.countDown();
       try {
-        Thread.sleep(PARK_MILLIS);
+        releaseWinner.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -124,7 +124,10 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  public void filter(Predicate[] predicates) {
+  // synchronized on the scan monitor (same monitor as tasks()/taskGroups()/resetTasks) so the
+  // non-atomic narrow-tasks -> resetTasks sequence is not observed half-applied when a shared scan
+  // instance receives concurrent runtime-filter callbacks.
+  public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilterExpr = convertRuntimeFilters(predicates);
 
     if (runtimeFilterExpr != Expressions.alwaysTrue()) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -124,9 +124,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  // synchronized on the scan monitor (same monitor as tasks()/taskGroups()/resetTasks) so the
-  // non-atomic narrow-tasks -> resetTasks sequence is not observed half-applied when a shared scan
-  // instance receives concurrent runtime-filter callbacks.
+  // serialize concurrent filter() calls on a shared scan
   public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilterExpr = convertRuntimeFilters(predicates);
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -103,10 +103,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  // synchronized on the scan monitor (same monitor as tasks()/taskGroups()/resetTasks) so the
-  // non-atomic check-then-act (publish filteredLocations -> narrow tasks -> resetTasks) is not
-  // observed half-applied by a concurrent branch. A COW UPDATE with a subquery is rewritten as a
-  // UNION whose two branches share this one scan and, under AQE, prepare their stages concurrently.
+  // serialize concurrent filter() calls on a scan shared across UNION branches
   public synchronized void filter(Predicate[] predicates) {
     Preconditions.checkState(
         Objects.equals(snapshotId(), currentSnapshotId()),

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -103,7 +103,11 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  public void filter(Predicate[] predicates) {
+  // synchronized on the scan monitor (same monitor as tasks()/taskGroups()/resetTasks) so the
+  // non-atomic check-then-act (publish filteredLocations -> narrow tasks -> resetTasks) is not
+  // observed half-applied by a concurrent branch. A COW UPDATE with a subquery is rewritten as a
+  // UNION whose two branches share this one scan and, under AQE, prepare their stages concurrently.
+  public synchronized void filter(Predicate[] predicates) {
     Preconditions.checkState(
         Objects.equals(snapshotId(), currentSnapshotId()),
         "Runtime file filtering is not possible: the table has been concurrently modified. "

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -243,7 +243,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
   // only task groups can be reset while resetting tasks
   // the set of scanned specs and grouping key type must never change
-  protected void resetTasks(List<T> filteredTasks) {
+  protected synchronized void resetTasks(List<T> filteredTasks) {
     this.taskGroups = null;
     this.tasks = filteredTasks;
   }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
+ *
+ * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
+ * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
+ * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
+ * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
+ * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
+ * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
+ * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
+ * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
+ * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
+ *
+ * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
+ * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
+ * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
+ * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
+ * observes the full set.
+ */
+public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
+
+  private static final int FILE_COUNT = 10;
+  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
+  private static final long LATCH_TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
+        tableName);
+
+    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
+    // the single-file set the runtime filter should produce
+    for (int i = 0; i < FILE_COUNT; i++) {
+      sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
+    }
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    CountDownLatch enteredResetTasks = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+
+    // memoize the full planning-time task set and task groups exactly as query planning would
+    List<FileScanTask> plannedTasks = scan.tasks();
+    scan.taskGroups();
+    assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
+
+    // `_file IN (<one location>)` runtime predicate, matching what Spark passes for a COW filter
+    String targetLocation = plannedTasks.get(0).file().location();
+    Predicate[] predicates = {filePathInPredicate(targetLocation)};
+
+    AtomicReference<Throwable> winnerFailure = new AtomicReference<>();
+    AtomicReference<Throwable> loserFailure = new AtomicReference<>();
+    AtomicInteger observedTaskCount = new AtomicInteger(-1);
+    AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
+
+    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
+    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    Thread winner =
+        new Thread(
+            () -> {
+              try {
+                scan.filter(predicates);
+              } catch (Throwable t) {
+                winnerFailure.set(t);
+                enteredResetTasks.countDown();
+              }
+            },
+            "cow-filter-winner");
+
+    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
+    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
+    // the shared task set - which must already be narrowed.
+    Thread loser =
+        new Thread(
+            () -> {
+              try {
+                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("winner should have entered resetTasks")
+                    .isTrue();
+                scan.filter(predicates);
+                observedTaskCount.set(scan.tasks().size());
+                observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
+              } catch (Throwable t) {
+                loserFailure.set(t);
+              }
+            },
+            "cow-filter-loser");
+
+    winner.start();
+    loser.start();
+    winner.join(JOIN_TIMEOUT_MILLIS);
+    loser.join(JOIN_TIMEOUT_MILLIS);
+
+    if (winnerFailure.get() != null) {
+      throw new AssertionError("winner branch failed", winnerFailure.get());
+    }
+    if (loserFailure.get() != null) {
+      throw new AssertionError("loser branch failed", loserFailure.get());
+    }
+
+    assertThat(observedTaskCount.get())
+        .as(
+            "the losing UNION branch must observe the narrowed single-file task set, never the "
+                + "full %s-file set (which would rewrite every file and duplicate rows, issue "
+                + "#18004)",
+            FILE_COUNT)
+        .isEqualTo(1);
+    assertThat(observedTaskGroupFileCount.get())
+        .as("task groups must reflect the narrowed single-file set")
+        .isEqualTo(1);
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
+  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  private InstrumentedCopyOnWriteScan newInstrumentedScan(
+      Table table, CountDownLatch enteredResetTasks) {
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Schema expectedSchema = table.schema();
+    Snapshot snapshot = table.currentSnapshot();
+
+    BatchScan batchScan =
+        table
+            .newBatchScan()
+            .useSnapshot(snapshot.snapshotId())
+            .ignoreResiduals()
+            .caseSensitive(readConf.caseSensitive())
+            .filter(Expressions.alwaysTrue())
+            .project(expectedSchema);
+
+    return new InstrumentedCopyOnWriteScan(
+        spark,
+        table,
+        batchScan,
+        snapshot,
+        readConf,
+        expectedSchema,
+        Lists.newArrayList(),
+        () -> null,
+        enteredResetTasks);
+  }
+
+  private static Predicate filePathInPredicate(String location) {
+    NamedReference fileRef = FieldReference.apply(MetadataColumns.FILE_PATH.name());
+    LiteralValue<UTF8String> literal =
+        new LiteralValue<>(UTF8String.fromString(location), DataTypes.StringType);
+    return new Predicate(
+        "IN", new org.apache.spark.sql.connector.expressions.Expression[] {fileRef, literal});
+  }
+
+  private static int countFiles(List<ScanTaskGroup<FileScanTask>> taskGroups) {
+    int count = 0;
+    for (ScanTaskGroup<FileScanTask> group : taskGroups) {
+      count += group.tasks().size();
+    }
+    return count;
+  }
+
+  /**
+   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
+   * real implementation) so the check-then-act window in {@code filter()} can be observed by
+   * another thread. The override is intentionally NOT synchronized: the only serialization under
+   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
+   * reproduces the race instead of being masked here.
+   */
+  private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
+    private final CountDownLatch enteredResetTasks;
+
+    InstrumentedCopyOnWriteScan(
+        SparkSession spark,
+        Table table,
+        BatchScan scan,
+        Snapshot snapshot,
+        SparkReadConf readConf,
+        Schema expectedSchema,
+        List<Expression> filters,
+        Supplier<ScanReport> scanReportSupplier,
+        CountDownLatch enteredResetTasks) {
+      super(spark, table, scan, snapshot, readConf, expectedSchema, filters, scanReportSupplier);
+      this.enteredResetTasks = enteredResetTasks;
+    }
+
+    @Override
+    protected void resetTasks(List<FileScanTask> filteredTasks) {
+      enteredResetTasks.countDown();
+      try {
+        Thread.sleep(PARK_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      super.resetTasks(filteredTasks);
+    }
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -50,37 +50,21 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
-/**
- * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
- *
- * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
- * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
- * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
- * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
- * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
- * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
- * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
- * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
- * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
- *
- * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
- * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
- * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
- * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
- * observes the full set.
- */
+/** Regression test for the copy-on-write runtime-filter concurrency bug (issue #18004). */
 public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
 
   private static final int FILE_COUNT = 10;
-  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
-  private static final long LATCH_TIMEOUT_SECONDS = 30;
-  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
 
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
+  // A COW UPDATE with a subquery becomes a UNION whose branches share one scan, which Spark can
+  // filter() concurrently under AQE. Without synchronization a branch reads the full task set and
+  // rewrites every file, duplicating rows (#18004).
   @TestTemplate
   public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
     sql(
@@ -88,8 +72,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
         tableName);
 
-    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
-    // the single-file set the runtime filter should produce
+    // one single-row file per INSERT, so the narrowed set (1) is clearly distinct from the full set
     for (int i = 0; i < FILE_COUNT; i++) {
       sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
     }
@@ -97,9 +80,10 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     Table table = validationCatalog.loadTable(tableIdent);
 
     CountDownLatch enteredResetTasks = new CountDownLatch(1);
-    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+    CountDownLatch releaseWinner = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks, releaseWinner);
 
-    // memoize the full planning-time task set and task groups exactly as query planning would
+    // memoize the full task set and groups exactly as query planning would
     List<FileScanTask> plannedTasks = scan.tasks();
     scan.taskGroups();
     assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
@@ -113,8 +97,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     AtomicInteger observedTaskCount = new AtomicInteger(-1);
     AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
 
-    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
-    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    // winner: narrows the scan, then parks in resetTasks while holding the scan monitor
     Thread winner =
         new Thread(
             () -> {
@@ -122,21 +105,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
                 scan.filter(predicates);
               } catch (Throwable t) {
                 winnerFailure.set(t);
-                enteredResetTasks.countDown();
               }
             },
             "cow-filter-winner");
 
-    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
-    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
-    // the shared task set - which must already be narrowed.
+    // loser: runs filter() (short-circuits) then reads the shared task set, which must be narrowed
     Thread loser =
         new Thread(
             () -> {
               try {
-                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                    .as("winner should have entered resetTasks")
-                    .isTrue();
                 scan.filter(predicates);
                 observedTaskCount.set(scan.tasks().size());
                 observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
@@ -147,7 +124,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             "cow-filter-loser");
 
     winner.start();
+    assertThat(enteredResetTasks.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .as("winner should have entered resetTasks")
+        .isTrue();
+
     loser.start();
+    // release the winner once the loser has blocked on the monitor or finished its stale read
+    awaitLoserSettled(loser, observedTaskCount);
+    releaseWinner.countDown();
+
     winner.join(JOIN_TIMEOUT_MILLIS);
     loser.join(JOIN_TIMEOUT_MILLIS);
 
@@ -170,10 +155,25 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         .isEqualTo(1);
   }
 
-  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
-  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  // waits until the loser can progress no further before releasing the winner: either blocked on
+  // the scan monitor (synchronized filter()) or already done recording its task count
+  private static void awaitLoserSettled(Thread loser, AtomicInteger observedTaskCount)
+      throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+    while (System.nanoTime() < deadlineNanos) {
+      Thread.State state = loser.getState();
+      if (state == Thread.State.BLOCKED
+          || state == Thread.State.TERMINATED
+          || observedTaskCount.get() != -1) {
+        return;
+      }
+      Thread.sleep(1);
+    }
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan but returns an instrumented subclass
   private InstrumentedCopyOnWriteScan newInstrumentedScan(
-      Table table, CountDownLatch enteredResetTasks) {
+      Table table, CountDownLatch enteredResetTasks, CountDownLatch releaseWinner) {
     SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
     Schema expectedSchema = table.schema();
     Snapshot snapshot = table.currentSnapshot();
@@ -196,7 +196,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         expectedSchema,
         Lists.newArrayList(),
         () -> null,
-        enteredResetTasks);
+        enteredResetTasks,
+        releaseWinner);
   }
 
   private static Predicate filePathInPredicate(String location) {
@@ -215,15 +216,11 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     return count;
   }
 
-  /**
-   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
-   * real implementation) so the check-then-act window in {@code filter()} can be observed by
-   * another thread. The override is intentionally NOT synchronized: the only serialization under
-   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
-   * reproduces the race instead of being masked here.
-   */
+  // parks inside resetTasks to hold the filter() window open for another thread. Intentionally NOT
+  // synchronized so the only serialization under test comes from SparkCopyOnWriteScan#filter.
   private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
     private final CountDownLatch enteredResetTasks;
+    private final CountDownLatch releaseWinner;
 
     InstrumentedCopyOnWriteScan(
         SparkSession spark,
@@ -234,16 +231,18 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         Schema expectedSchema,
         List<Expression> filters,
         Supplier<ScanReport> scanReportSupplier,
-        CountDownLatch enteredResetTasks) {
+        CountDownLatch enteredResetTasks,
+        CountDownLatch releaseWinner) {
       super(spark, table, scan, snapshot, readConf, expectedSchema, filters, scanReportSupplier);
       this.enteredResetTasks = enteredResetTasks;
+      this.releaseWinner = releaseWinner;
     }
 
     @Override
     protected void resetTasks(List<FileScanTask> filteredTasks) {
       enteredResetTasks.countDown();
       try {
-        Thread.sleep(PARK_MILLIS);
+        releaseWinner.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -91,11 +91,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     return new NamedReference[] {SparkMetadataColumns.FILE_PATH.asRef()};
   }
 
-  // synchronized because Spark rewrites UPDATEs with subqueries as a UNION of two branches that
-  // share this scan; under AQE both branches may invoke filter() concurrently. The method is a
-  // non-atomic check-then-act over filteredLocations/tasks()/resetTasks(), so it must hold the
-  // same monitor as the tasks()/taskGroups()/resetTasks() accessors to avoid a losing branch
-  // observing the full (planning-time) task set and rewriting every file.
+  // serialize concurrent filter() calls on a scan shared across UNION branches
   @Override
   public synchronized void filter(Predicate[] predicates) {
     for (Predicate predicate : predicates) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -91,8 +91,13 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     return new NamedReference[] {SparkMetadataColumns.FILE_PATH.asRef()};
   }
 
+  // synchronized because Spark rewrites UPDATEs with subqueries as a UNION of two branches that
+  // share this scan; under AQE both branches may invoke filter() concurrently. The method is a
+  // non-atomic check-then-act over filteredLocations/tasks()/resetTasks(), so it must hold the
+  // same monitor as the tasks()/taskGroups()/resetTasks() accessors to avoid a losing branch
+  // observing the full (planning-time) task set and rewriting every file.
   @Override
-  public void filter(Predicate[] predicates) {
+  public synchronized void filter(Predicate[] predicates) {
     for (Predicate predicate : predicates) {
       // Spark can only pass IN predicates at the moment
       if (isFilePathInPredicate(predicate)) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -244,7 +244,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
   // only task groups can be reset while resetting tasks
   // the set of scanned specs and grouping key type must never change
-  protected void resetTasks(List<T> filteredTasks) {
+  protected synchronized void resetTasks(List<T> filteredTasks) {
     this.taskGroups = null;
     this.tasks = filteredTasks;
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -105,8 +105,11 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
         .toArray(NamedReference[]::new);
   }
 
+  // synchronized because this non-atomic check-then-act spans tasks() and resetTasks(); it must
+  // hold the same monitor as the tasks()/taskGroups()/resetTasks() accessors so concurrent runtime
+  // filtering (e.g. AQE preparing multiple stages) can never observe the full planning-time tasks.
   @Override
-  public void filter(Predicate[] predicates) {
+  public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilter = convertRuntimePredicates(predicates);
 
     if (runtimeFilter != Expressions.alwaysTrue()) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -105,9 +105,7 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
         .toArray(NamedReference[]::new);
   }
 
-  // synchronized because this non-atomic check-then-act spans tasks() and resetTasks(); it must
-  // hold the same monitor as the tasks()/taskGroups()/resetTasks() accessors so concurrent runtime
-  // filtering (e.g. AQE preparing multiple stages) can never observe the full planning-time tasks.
+  // serialize concurrent filter() calls on a shared scan
   @Override
   public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilter = convertRuntimePredicates(predicates);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -49,37 +49,21 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
-/**
- * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
- *
- * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
- * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
- * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
- * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
- * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
- * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
- * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
- * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
- * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
- *
- * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
- * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
- * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
- * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
- * observes the full set.
- */
+/** Regression test for the copy-on-write runtime-filter concurrency bug (issue #18004). */
 public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
 
   private static final int FILE_COUNT = 10;
-  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
-  private static final long LATCH_TIMEOUT_SECONDS = 30;
-  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
 
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
+  // A COW UPDATE with a subquery becomes a UNION whose branches share one scan, which Spark can
+  // filter() concurrently under AQE. Without synchronization a branch reads the full task set and
+  // rewrites every file, duplicating rows (#18004).
   @TestTemplate
   public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
     sql(
@@ -87,8 +71,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
         tableName);
 
-    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
-    // the single-file set the runtime filter should produce
+    // one single-row file per INSERT, so the narrowed set (1) is clearly distinct from the full set
     for (int i = 0; i < FILE_COUNT; i++) {
       sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
     }
@@ -96,9 +79,10 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     Table table = validationCatalog.loadTable(tableIdent);
 
     CountDownLatch enteredResetTasks = new CountDownLatch(1);
-    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+    CountDownLatch releaseWinner = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks, releaseWinner);
 
-    // memoize the full planning-time task set and task groups exactly as query planning would
+    // memoize the full task set and groups exactly as query planning would
     List<FileScanTask> plannedTasks = scan.tasks();
     scan.taskGroups();
     assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
@@ -112,8 +96,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     AtomicInteger observedTaskCount = new AtomicInteger(-1);
     AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
 
-    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
-    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    // winner: narrows the scan, then parks in resetTasks while holding the scan monitor
     Thread winner =
         new Thread(
             () -> {
@@ -121,21 +104,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
                 scan.filter(predicates);
               } catch (Throwable t) {
                 winnerFailure.set(t);
-                enteredResetTasks.countDown();
               }
             },
             "cow-filter-winner");
 
-    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
-    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
-    // the shared task set - which must already be narrowed.
+    // loser: runs filter() (short-circuits) then reads the shared task set, which must be narrowed
     Thread loser =
         new Thread(
             () -> {
               try {
-                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                    .as("winner should have entered resetTasks")
-                    .isTrue();
                 scan.filter(predicates);
                 observedTaskCount.set(scan.tasks().size());
                 observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
@@ -146,7 +123,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             "cow-filter-loser");
 
     winner.start();
+    assertThat(enteredResetTasks.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .as("winner should have entered resetTasks")
+        .isTrue();
+
     loser.start();
+    // release the winner once the loser has blocked on the monitor or finished its stale read
+    awaitLoserSettled(loser, observedTaskCount);
+    releaseWinner.countDown();
+
     winner.join(JOIN_TIMEOUT_MILLIS);
     loser.join(JOIN_TIMEOUT_MILLIS);
 
@@ -169,10 +154,25 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         .isEqualTo(1);
   }
 
-  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
-  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  // waits until the loser can progress no further before releasing the winner: either blocked on
+  // the scan monitor (synchronized filter()) or already done recording its task count
+  private static void awaitLoserSettled(Thread loser, AtomicInteger observedTaskCount)
+      throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+    while (System.nanoTime() < deadlineNanos) {
+      Thread.State state = loser.getState();
+      if (state == Thread.State.BLOCKED
+          || state == Thread.State.TERMINATED
+          || observedTaskCount.get() != -1) {
+        return;
+      }
+      Thread.sleep(1);
+    }
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan but returns an instrumented subclass
   private InstrumentedCopyOnWriteScan newInstrumentedScan(
-      Table table, CountDownLatch enteredResetTasks) {
+      Table table, CountDownLatch enteredResetTasks, CountDownLatch releaseWinner) {
     SparkReadConf readConf = new SparkReadConf(spark, table);
     Schema schema = table.schema();
     Snapshot snapshot = table.currentSnapshot();
@@ -197,7 +197,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         schema /* projection */,
         Lists.newArrayList(),
         () -> null,
-        enteredResetTasks);
+        enteredResetTasks,
+        releaseWinner);
   }
 
   private static Predicate filePathInPredicate(String location) {
@@ -216,15 +217,11 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     return count;
   }
 
-  /**
-   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
-   * real implementation) so the check-then-act window in {@code filter()} can be observed by
-   * another thread. The override is intentionally NOT synchronized: the only serialization under
-   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
-   * reproduces the race instead of being masked here.
-   */
+  // parks inside resetTasks to hold the filter() window open for another thread. Intentionally NOT
+  // synchronized so the only serialization under test comes from SparkCopyOnWriteScan#filter.
   private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
     private final CountDownLatch enteredResetTasks;
+    private final CountDownLatch releaseWinner;
 
     InstrumentedCopyOnWriteScan(
         SparkSession spark,
@@ -237,7 +234,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         Schema projection,
         List<Expression> filters,
         Supplier<ScanReport> scanReportSupplier,
-        CountDownLatch enteredResetTasks) {
+        CountDownLatch enteredResetTasks,
+        CountDownLatch releaseWinner) {
       super(
           spark,
           table,
@@ -250,13 +248,14 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
           filters,
           scanReportSupplier);
       this.enteredResetTasks = enteredResetTasks;
+      this.releaseWinner = releaseWinner;
     }
 
     @Override
     protected void resetTasks(List<FileScanTask> filteredTasks) {
       enteredResetTasks.countDown();
       try {
-        Thread.sleep(PARK_MILLIS);
+        releaseWinner.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
+ *
+ * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
+ * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
+ * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
+ * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
+ * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
+ * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
+ * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
+ * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
+ * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
+ *
+ * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
+ * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
+ * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
+ * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
+ * observes the full set.
+ */
+public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
+
+  private static final int FILE_COUNT = 10;
+  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
+  private static final long LATCH_TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
+        tableName);
+
+    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
+    // the single-file set the runtime filter should produce
+    for (int i = 0; i < FILE_COUNT; i++) {
+      sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
+    }
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    CountDownLatch enteredResetTasks = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+
+    // memoize the full planning-time task set and task groups exactly as query planning would
+    List<FileScanTask> plannedTasks = scan.tasks();
+    scan.taskGroups();
+    assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
+
+    // `_file IN (<one location>)` runtime predicate, matching what Spark passes for a COW filter
+    String targetLocation = plannedTasks.get(0).file().location();
+    Predicate[] predicates = {filePathInPredicate(targetLocation)};
+
+    AtomicReference<Throwable> winnerFailure = new AtomicReference<>();
+    AtomicReference<Throwable> loserFailure = new AtomicReference<>();
+    AtomicInteger observedTaskCount = new AtomicInteger(-1);
+    AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
+
+    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
+    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    Thread winner =
+        new Thread(
+            () -> {
+              try {
+                scan.filter(predicates);
+              } catch (Throwable t) {
+                winnerFailure.set(t);
+                enteredResetTasks.countDown();
+              }
+            },
+            "cow-filter-winner");
+
+    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
+    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
+    // the shared task set - which must already be narrowed.
+    Thread loser =
+        new Thread(
+            () -> {
+              try {
+                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("winner should have entered resetTasks")
+                    .isTrue();
+                scan.filter(predicates);
+                observedTaskCount.set(scan.tasks().size());
+                observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
+              } catch (Throwable t) {
+                loserFailure.set(t);
+              }
+            },
+            "cow-filter-loser");
+
+    winner.start();
+    loser.start();
+    winner.join(JOIN_TIMEOUT_MILLIS);
+    loser.join(JOIN_TIMEOUT_MILLIS);
+
+    if (winnerFailure.get() != null) {
+      throw new AssertionError("winner branch failed", winnerFailure.get());
+    }
+    if (loserFailure.get() != null) {
+      throw new AssertionError("loser branch failed", loserFailure.get());
+    }
+
+    assertThat(observedTaskCount.get())
+        .as(
+            "the losing UNION branch must observe the narrowed single-file task set, never the "
+                + "full %s-file set (which would rewrite every file and duplicate rows, issue "
+                + "#18004)",
+            FILE_COUNT)
+        .isEqualTo(1);
+    assertThat(observedTaskGroupFileCount.get())
+        .as("task groups must reflect the narrowed single-file set")
+        .isEqualTo(1);
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
+  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  private InstrumentedCopyOnWriteScan newInstrumentedScan(
+      Table table, CountDownLatch enteredResetTasks) {
+    SparkReadConf readConf = new SparkReadConf(spark, table);
+    Schema schema = table.schema();
+    Snapshot snapshot = table.currentSnapshot();
+
+    BatchScan batchScan =
+        table
+            .newBatchScan()
+            .useSnapshot(snapshot.snapshotId())
+            .ignoreResiduals()
+            .caseSensitive(readConf.caseSensitive())
+            .filter(Expressions.alwaysTrue())
+            .project(schema);
+
+    return new InstrumentedCopyOnWriteScan(
+        spark,
+        table,
+        schema,
+        snapshot,
+        null /* branch */,
+        batchScan,
+        readConf,
+        schema /* projection */,
+        Lists.newArrayList(),
+        () -> null,
+        enteredResetTasks);
+  }
+
+  private static Predicate filePathInPredicate(String location) {
+    NamedReference fileRef = FieldReference.apply(MetadataColumns.FILE_PATH.name());
+    LiteralValue<UTF8String> literal =
+        new LiteralValue<>(UTF8String.fromString(location), DataTypes.StringType);
+    return new Predicate(
+        "IN", new org.apache.spark.sql.connector.expressions.Expression[] {fileRef, literal});
+  }
+
+  private static int countFiles(List<ScanTaskGroup<FileScanTask>> taskGroups) {
+    int count = 0;
+    for (ScanTaskGroup<FileScanTask> group : taskGroups) {
+      count += group.tasks().size();
+    }
+    return count;
+  }
+
+  /**
+   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
+   * real implementation) so the check-then-act window in {@code filter()} can be observed by
+   * another thread. The override is intentionally NOT synchronized: the only serialization under
+   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
+   * reproduces the race instead of being masked here.
+   */
+  private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
+    private final CountDownLatch enteredResetTasks;
+
+    InstrumentedCopyOnWriteScan(
+        SparkSession spark,
+        Table table,
+        Schema schema,
+        Snapshot snapshot,
+        String branch,
+        BatchScan scan,
+        SparkReadConf readConf,
+        Schema projection,
+        List<Expression> filters,
+        Supplier<ScanReport> scanReportSupplier,
+        CountDownLatch enteredResetTasks) {
+      super(
+          spark,
+          table,
+          schema,
+          snapshot,
+          branch,
+          scan,
+          readConf,
+          projection,
+          filters,
+          scanReportSupplier);
+      this.enteredResetTasks = enteredResetTasks;
+    }
+
+    @Override
+    protected void resetTasks(List<FileScanTask> filteredTasks) {
+      enteredResetTasks.countDown();
+      try {
+        Thread.sleep(PARK_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      super.resetTasks(filteredTasks);
+    }
+  }
+}

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -91,11 +91,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     return new NamedReference[] {SparkMetadataColumns.FILE_PATH.asRef()};
   }
 
-  // synchronized because a single scan instance is shared across both branches of the UNION plan
-  // produced when rewriting UPDATEs with subqueries, so Spark may invoke this runtime file-filter
-  // callback concurrently; the check-then-act below (and its terminal resetTasks) must be atomic
-  // to keep every branch from observing the pre-narrowing (full) task set. filter() runs at
-  // planning time only, so synchronization adds no per-row cost.
+  // serialize concurrent filter() calls on a scan shared across UNION branches
   @Override
   public synchronized void filter(Predicate[] predicates) {
     for (Predicate predicate : predicates) {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -91,8 +91,13 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     return new NamedReference[] {SparkMetadataColumns.FILE_PATH.asRef()};
   }
 
+  // synchronized because a single scan instance is shared across both branches of the UNION plan
+  // produced when rewriting UPDATEs with subqueries, so Spark may invoke this runtime file-filter
+  // callback concurrently; the check-then-act below (and its terminal resetTasks) must be atomic
+  // to keep every branch from observing the pre-narrowing (full) task set. filter() runs at
+  // planning time only, so synchronization adds no per-row cost.
   @Override
-  public void filter(Predicate[] predicates) {
+  public synchronized void filter(Predicate[] predicates) {
     for (Predicate predicate : predicates) {
       // Spark can only pass IN predicates at the moment
       if (isFilePathInPredicate(predicate)) {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -244,7 +244,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
   // only task groups can be reset while resetting tasks
   // the set of scanned specs and grouping key type must never change
-  protected void resetTasks(List<T> filteredTasks) {
+  protected synchronized void resetTasks(List<T> filteredTasks) {
     this.taskGroups = null;
     this.tasks = filteredTasks;
   }

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -105,10 +105,7 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
         .toArray(NamedReference[]::new);
   }
 
-  // synchronized because a single scan instance may be shared and Spark can invoke this runtime
-  // filter callback concurrently; the check-then-act below (and its terminal resetTasks) must be
-  // atomic to keep concurrent callers from observing the pre-narrowing (full) task set. filter()
-  // runs at planning time only, so synchronization adds no per-row cost.
+  // serialize concurrent filter() calls on a shared scan
   @Override
   public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilter = convertRuntimePredicates(predicates);

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -105,8 +105,12 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
         .toArray(NamedReference[]::new);
   }
 
+  // synchronized because a single scan instance may be shared and Spark can invoke this runtime
+  // filter callback concurrently; the check-then-act below (and its terminal resetTasks) must be
+  // atomic to keep concurrent callers from observing the pre-narrowing (full) task set. filter()
+  // runs at planning time only, so synchronization adds no per-row cost.
   @Override
-  public void filter(Predicate[] predicates) {
+  public synchronized void filter(Predicate[] predicates) {
     Expression runtimeFilter = convertRuntimePredicates(predicates);
 
     if (runtimeFilter != Expressions.alwaysTrue()) {

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -49,37 +49,21 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
-/**
- * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
- *
- * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
- * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
- * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
- * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
- * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
- * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
- * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
- * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
- * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
- *
- * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
- * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
- * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
- * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
- * observes the full set.
- */
+/** Regression test for the copy-on-write runtime-filter concurrency bug (issue #18004). */
 public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
 
   private static final int FILE_COUNT = 10;
-  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
-  private static final long LATCH_TIMEOUT_SECONDS = 30;
-  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
 
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
+  // A COW UPDATE with a subquery becomes a UNION whose branches share one scan, which Spark can
+  // filter() concurrently under AQE. Without synchronization a branch reads the full task set and
+  // rewrites every file, duplicating rows (#18004).
   @TestTemplate
   public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
     sql(
@@ -87,8 +71,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
         tableName);
 
-    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
-    // the single-file set the runtime filter should produce
+    // one single-row file per INSERT, so the narrowed set (1) is clearly distinct from the full set
     for (int i = 0; i < FILE_COUNT; i++) {
       sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
     }
@@ -96,9 +79,10 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     Table table = validationCatalog.loadTable(tableIdent);
 
     CountDownLatch enteredResetTasks = new CountDownLatch(1);
-    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+    CountDownLatch releaseWinner = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks, releaseWinner);
 
-    // memoize the full planning-time task set and task groups exactly as query planning would
+    // memoize the full task set and groups exactly as query planning would
     List<FileScanTask> plannedTasks = scan.tasks();
     scan.taskGroups();
     assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
@@ -112,8 +96,7 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     AtomicInteger observedTaskCount = new AtomicInteger(-1);
     AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
 
-    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
-    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    // winner: narrows the scan, then parks in resetTasks while holding the scan monitor
     Thread winner =
         new Thread(
             () -> {
@@ -121,21 +104,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
                 scan.filter(predicates);
               } catch (Throwable t) {
                 winnerFailure.set(t);
-                enteredResetTasks.countDown();
               }
             },
             "cow-filter-winner");
 
-    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
-    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
-    // the shared task set - which must already be narrowed.
+    // loser: runs filter() (short-circuits) then reads the shared task set, which must be narrowed
     Thread loser =
         new Thread(
             () -> {
               try {
-                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
-                    .as("winner should have entered resetTasks")
-                    .isTrue();
                 scan.filter(predicates);
                 observedTaskCount.set(scan.tasks().size());
                 observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
@@ -146,7 +123,15 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
             "cow-filter-loser");
 
     winner.start();
+    assertThat(enteredResetTasks.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        .as("winner should have entered resetTasks")
+        .isTrue();
+
     loser.start();
+    // release the winner once the loser has blocked on the monitor or finished its stale read
+    awaitLoserSettled(loser, observedTaskCount);
+    releaseWinner.countDown();
+
     winner.join(JOIN_TIMEOUT_MILLIS);
     loser.join(JOIN_TIMEOUT_MILLIS);
 
@@ -169,10 +154,25 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         .isEqualTo(1);
   }
 
-  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
-  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  // waits until the loser can progress no further before releasing the winner: either blocked on
+  // the scan monitor (synchronized filter()) or already done recording its task count
+  private static void awaitLoserSettled(Thread loser, AtomicInteger observedTaskCount)
+      throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+    while (System.nanoTime() < deadlineNanos) {
+      Thread.State state = loser.getState();
+      if (state == Thread.State.BLOCKED
+          || state == Thread.State.TERMINATED
+          || observedTaskCount.get() != -1) {
+        return;
+      }
+      Thread.sleep(1);
+    }
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan but returns an instrumented subclass
   private InstrumentedCopyOnWriteScan newInstrumentedScan(
-      Table table, CountDownLatch enteredResetTasks) {
+      Table table, CountDownLatch enteredResetTasks, CountDownLatch releaseWinner) {
     SparkReadConf readConf = new SparkReadConf(spark, table);
     Schema schema = table.schema();
     Snapshot snapshot = table.currentSnapshot();
@@ -197,7 +197,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         schema /* projection */,
         Lists.newArrayList(),
         () -> null,
-        enteredResetTasks);
+        enteredResetTasks,
+        releaseWinner);
   }
 
   private static Predicate filePathInPredicate(String location) {
@@ -216,15 +217,11 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
     return count;
   }
 
-  /**
-   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
-   * real implementation) so the check-then-act window in {@code filter()} can be observed by
-   * another thread. The override is intentionally NOT synchronized: the only serialization under
-   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
-   * reproduces the race instead of being masked here.
-   */
+  // parks inside resetTasks to hold the filter() window open for another thread. Intentionally NOT
+  // synchronized so the only serialization under test comes from SparkCopyOnWriteScan#filter.
   private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
     private final CountDownLatch enteredResetTasks;
+    private final CountDownLatch releaseWinner;
 
     InstrumentedCopyOnWriteScan(
         SparkSession spark,
@@ -237,7 +234,8 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
         Schema projection,
         List<Expression> filters,
         Supplier<ScanReport> scanReportSupplier,
-        CountDownLatch enteredResetTasks) {
+        CountDownLatch enteredResetTasks,
+        CountDownLatch releaseWinner) {
       super(
           spark,
           table,
@@ -250,13 +248,14 @@ public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
           filters,
           scanReportSupplier);
       this.enteredResetTasks = enteredResetTasks;
+      this.releaseWinner = releaseWinner;
     }
 
     @Override
     protected void resetTasks(List<FileScanTask> filteredTasks) {
       enteredResetTasks.countDown();
       try {
-        Thread.sleep(PARK_MILLIS);
+        releaseWinner.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCopyOnWriteScanConcurrency.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Reproduces the copy-on-write runtime-filter concurrency bug (issue #18004).
+ *
+ * <p>A COW {@code UPDATE ... WHERE EXISTS (<subquery>)} is rewritten as {@code Union(Filter(cond,
+ * S), Filter(NOT cond, S))} where BOTH branches share the same {@link SparkCopyOnWriteScan} {@code
+ * S}. Under AQE the two branch stages are prepared concurrently, so the {@link
+ * org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering#filter(Predicate[])} callback runs
+ * concurrently on the one shared scan. {@code filter()} is a non-atomic check-then-act: it
+ * publishes {@code filteredLocations} first, then narrows {@code tasks()}, and only at the very end
+ * calls {@code resetTasks(...)}. A losing branch that observes {@code filteredLocations} already
+ * set (so it skips narrowing) while the winner has not yet reached {@code resetTasks} would read
+ * the planning-time memoized FULL task set and scan every file, duplicating rows on commit.
+ *
+ * <p>This drives the race deterministically: a winner thread narrows the scan but parks inside an
+ * un-synchronized {@code resetTasks} override, while a loser thread runs {@code filter()} and reads
+ * the shared task set. With {@code filter()} synchronized the loser is serialized behind the winner
+ * and observes the narrowed single-file set; revert the {@code synchronized} keyword and it
+ * observes the full set.
+ */
+public class TestSparkCopyOnWriteScanConcurrency extends TestBaseWithCatalog {
+
+  private static final int FILE_COUNT = 10;
+  private static final long PARK_MILLIS = TimeUnit.SECONDS.toMillis(2);
+  private static final long LATCH_TIMEOUT_SECONDS = 30;
+  private static final long JOIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testConcurrentRuntimeFilteringNarrowsSharedScan() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ('write.update.mode'='copy-on-write')",
+        tableName);
+
+    // one single-row data file per INSERT, so the full task set is clearly distinguishable from
+    // the single-file set the runtime filter should produce
+    for (int i = 0; i < FILE_COUNT; i++) {
+      sql("INSERT INTO %s VALUES (%d, 'data-%d')", tableName, i, i);
+    }
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    CountDownLatch enteredResetTasks = new CountDownLatch(1);
+    InstrumentedCopyOnWriteScan scan = newInstrumentedScan(table, enteredResetTasks);
+
+    // memoize the full planning-time task set and task groups exactly as query planning would
+    List<FileScanTask> plannedTasks = scan.tasks();
+    scan.taskGroups();
+    assertThat(plannedTasks).as("expected one task per single-row file").hasSize(FILE_COUNT);
+
+    // `_file IN (<one location>)` runtime predicate, matching what Spark passes for a COW filter
+    String targetLocation = plannedTasks.get(0).file().location();
+    Predicate[] predicates = {filePathInPredicate(targetLocation)};
+
+    AtomicReference<Throwable> winnerFailure = new AtomicReference<>();
+    AtomicReference<Throwable> loserFailure = new AtomicReference<>();
+    AtomicInteger observedTaskCount = new AtomicInteger(-1);
+    AtomicInteger observedTaskGroupFileCount = new AtomicInteger(-1);
+
+    // winner: narrows the scan but parks inside resetTasks. It holds the scan monitor while it
+    // sleeps ONLY if filter() is synchronized; that is exactly the production behavior under test.
+    Thread winner =
+        new Thread(
+            () -> {
+              try {
+                scan.filter(predicates);
+              } catch (Throwable t) {
+                winnerFailure.set(t);
+                enteredResetTasks.countDown();
+              }
+            },
+            "cow-filter-winner");
+
+    // loser: proceeds only once the winner has published filteredLocations and entered resetTasks.
+    // Its own filter() short-circuits (the guard fails for the same single location), then it reads
+    // the shared task set - which must already be narrowed.
+    Thread loser =
+        new Thread(
+            () -> {
+              try {
+                assertThat(enteredResetTasks.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("winner should have entered resetTasks")
+                    .isTrue();
+                scan.filter(predicates);
+                observedTaskCount.set(scan.tasks().size());
+                observedTaskGroupFileCount.set(countFiles(scan.taskGroups()));
+              } catch (Throwable t) {
+                loserFailure.set(t);
+              }
+            },
+            "cow-filter-loser");
+
+    winner.start();
+    loser.start();
+    winner.join(JOIN_TIMEOUT_MILLIS);
+    loser.join(JOIN_TIMEOUT_MILLIS);
+
+    if (winnerFailure.get() != null) {
+      throw new AssertionError("winner branch failed", winnerFailure.get());
+    }
+    if (loserFailure.get() != null) {
+      throw new AssertionError("loser branch failed", loserFailure.get());
+    }
+
+    assertThat(observedTaskCount.get())
+        .as(
+            "the losing UNION branch must observe the narrowed single-file task set, never the "
+                + "full %s-file set (which would rewrite every file and duplicate rows, issue "
+                + "#18004)",
+            FILE_COUNT)
+        .isEqualTo(1);
+    assertThat(observedTaskGroupFileCount.get())
+        .as("task groups must reflect the narrowed single-file set")
+        .isEqualTo(1);
+  }
+
+  // mirrors SparkScanBuilder#buildCopyOnWriteScan (non-null snapshot path) but returns an
+  // instrumented subclass so the race window inside resetTasks can be controlled deterministically
+  private InstrumentedCopyOnWriteScan newInstrumentedScan(
+      Table table, CountDownLatch enteredResetTasks) {
+    SparkReadConf readConf = new SparkReadConf(spark, table);
+    Schema schema = table.schema();
+    Snapshot snapshot = table.currentSnapshot();
+
+    BatchScan batchScan =
+        table
+            .newBatchScan()
+            .useSnapshot(snapshot.snapshotId())
+            .ignoreResiduals()
+            .caseSensitive(readConf.caseSensitive())
+            .filter(Expressions.alwaysTrue())
+            .project(schema);
+
+    return new InstrumentedCopyOnWriteScan(
+        spark,
+        table,
+        schema,
+        snapshot,
+        null /* branch */,
+        batchScan,
+        readConf,
+        schema /* projection */,
+        Lists.newArrayList(),
+        () -> null,
+        enteredResetTasks);
+  }
+
+  private static Predicate filePathInPredicate(String location) {
+    NamedReference fileRef = FieldReference.apply(MetadataColumns.FILE_PATH.name());
+    LiteralValue<UTF8String> literal =
+        new LiteralValue<>(UTF8String.fromString(location), DataTypes.StringType);
+    return new Predicate(
+        "IN", new org.apache.spark.sql.connector.expressions.Expression[] {fileRef, literal});
+  }
+
+  private static int countFiles(List<ScanTaskGroup<FileScanTask>> taskGroups) {
+    int count = 0;
+    for (ScanTaskGroup<FileScanTask> group : taskGroups) {
+      count += group.tasks().size();
+    }
+    return count;
+  }
+
+  /**
+   * A {@link SparkCopyOnWriteScan} that parks inside {@code resetTasks} (before delegating to the
+   * real implementation) so the check-then-act window in {@code filter()} can be observed by
+   * another thread. The override is intentionally NOT synchronized: the only serialization under
+   * test must come from {@code SparkCopyOnWriteScan#filter}, so reverting that fix reliably
+   * reproduces the race instead of being masked here.
+   */
+  private static class InstrumentedCopyOnWriteScan extends SparkCopyOnWriteScan {
+    private final CountDownLatch enteredResetTasks;
+
+    InstrumentedCopyOnWriteScan(
+        SparkSession spark,
+        Table table,
+        Schema schema,
+        Snapshot snapshot,
+        String branch,
+        BatchScan scan,
+        SparkReadConf readConf,
+        Schema projection,
+        List<Expression> filters,
+        Supplier<ScanReport> scanReportSupplier,
+        CountDownLatch enteredResetTasks) {
+      super(
+          spark,
+          table,
+          schema,
+          snapshot,
+          branch,
+          scan,
+          readConf,
+          projection,
+          filters,
+          scanReportSupplier);
+      this.enteredResetTasks = enteredResetTasks;
+    }
+
+    @Override
+    protected void resetTasks(List<FileScanTask> filteredTasks) {
+      enteredResetTasks.countDown();
+      try {
+        Thread.sleep(PARK_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      super.resetTasks(filteredTasks);
+    }
+  }
+}


### PR DESCRIPTION
A copy-on-write `UPDATE ... WHERE ... IN/EXISTS (<subquery>)` is rewritten by Spark into a UNION whose two branches share the same Iceberg scan. Under AQE, Spark runs the `filter(Predicate[])` runtime-filter callback on that shared scan from multiple threads at once. That filter wasn't thread-safe, so one thread could end up scanning all files instead of just the filtered ones — duplicating rows.

Fix: make the runtime filter methods `synchronized` so the filtering happens atomically. It only runs during planning, so there's no per-row cost. 