### PR TITLE
Kafka Connect: Read the control topic from earliest in the coordinator

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -100,6 +100,27 @@ By default the connector will attempt to use Kafka client config from the worker
 the control topic. If that config cannot be read for some reason, Kafka client settings
 can be set explicitly using `iceberg.kafka.*` properties.
 
+#### Control-topic recovery
+
+The coordinator uses a persistent consumer group and defaults to `auto.offset.reset=earliest`.
+When a partition has no committed offset or its offset is out of range, the coordinator reads
+from the earliest retained offset. This lets a replacement coordinator recover file announcements
+that its predecessor consumed but did not commit to Iceberg. Valid committed offsets take precedence
+over the reset policy. Worker control-topic consumers use transient groups and default to `latest`.
+An explicit `iceberg.kafka.auto.offset.reset` overrides both defaults; setting it to `latest`
+disables recovery of earlier announcements when a coordinator partition needs an offset reset.
+
+Recovery requires the uncommitted announcements to remain in the control topic. Filtering announcements
+that were already committed also requires the per-table offset boundary stored in a reachable snapshot
+summary. Commits by other writers do not automatically carry that property forward. If the snapshots
+containing the boundary expire and the coordinator replays retained history without a valid Kafka
+checkpoint, files can be registered again. Coordinate snapshot retention and control-topic retention
+to preserve the required boundary; the reset policy alone does not guarantee safe historical replay.
+
+The coordinator buffers historical responses during startup before applying the per-table boundaries.
+A large retained history can increase startup time and exhaust heap. This cost can recur whenever a
+checkpoint is unavailable; topic retention is not a bound on the memory required to replay it.
+
 #### Message format
 
 Messages should be converted to a struct or map using the appropriate Kafka Connect converter.

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -60,13 +60,23 @@ abstract class Channel {
       IcebergSinkConfig config,
       KafkaClientFactory clientFactory,
       SinkTaskContext context) {
+    this(name, consumerGroupId, config, clientFactory, context, "latest");
+  }
+
+  Channel(
+      String name,
+      String consumerGroupId,
+      IcebergSinkConfig config,
+      KafkaClientFactory clientFactory,
+      SinkTaskContext context,
+      String autoOffsetReset) {
     this.controlTopic = config.controlTopic();
     this.connectGroupId = config.connectGroupId();
     this.context = context;
 
     String transactionalId = config.transactionalPrefix() + name + config.transactionalSuffix();
     this.producer = clientFactory.createProducer(transactionalId);
-    this.consumer = clientFactory.createConsumer(consumerGroupId);
+    this.consumer = clientFactory.createConsumer(consumerGroupId, autoOffsetReset);
     this.admin = clientFactory.createAdmin();
 
     this.producerId = UUID.randomUUID().toString();

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -93,8 +93,17 @@ class Coordinator extends Channel {
       Collection<MemberDescription> members,
       KafkaClientFactory clientFactory,
       SinkTaskContext context) {
-    // pass consumer group ID to which we commit low watermark offsets
-    super("coordinator", config.connectGroupId() + "-coord", config, clientFactory, context);
+    // pass consumer group ID to which we commit low watermark offsets. The group only gets a
+    // committed offset once a commit succeeds, so a coordinator that starts before that must read
+    // from the beginning: buffered responses an earlier coordinator never committed are still on
+    // the control topic, and the per-table offsets in the snapshot summary filter the rest.
+    super(
+        "coordinator",
+        config.connectGroupId() + "-coord",
+        config,
+        clientFactory,
+        context,
+        "earliest");
 
     this.catalog = catalog;
     this.config = config;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.connect.channel;
 
 import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -51,14 +52,32 @@ class KafkaClientFactory {
   }
 
   Consumer<String, byte[]> createConsumer(String consumerGroupId) {
+    return createConsumer(consumerGroupId, "latest");
+  }
+
+  /**
+   * Creates a control-topic consumer.
+   *
+   * @param autoOffsetReset applied only when the group has no committed offset. A group whose
+   *     progress is durable must use {@code earliest}, so that a member starting without a
+   *     committed offset re-reads records an earlier member consumed but never committed.
+   */
+  Consumer<String, byte[]> createConsumer(String consumerGroupId, String autoOffsetReset) {
+    return new KafkaConsumer<>(
+        consumerProps(consumerGroupId, autoOffsetReset),
+        new StringDeserializer(),
+        new ByteArrayDeserializer());
+  }
+
+  @VisibleForTesting
+  Map<String, Object> consumerProps(String consumerGroupId, String autoOffsetReset) {
     Map<String, Object> consumerProps = Maps.newHashMap(kafkaProps);
-    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
     consumerProps.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
-    return new KafkaConsumer<>(
-        consumerProps, new StringDeserializer(), new ByteArrayDeserializer());
+    return consumerProps;
   }
 
   Admin createAdmin() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
@@ -58,9 +58,8 @@ class KafkaClientFactory {
   /**
    * Creates a control-topic consumer.
    *
-   * @param autoOffsetReset applied only when the group has no committed offset. A group whose
-   *     progress is durable must use {@code earliest}, so that a member starting without a
-   *     committed offset re-reads records an earlier member consumed but never committed.
+   * @param autoOffsetReset default reset policy for partitions with no committed offset or an
+   *     offset that is out of range; an explicitly configured reset policy takes precedence
    */
   Consumer<String, byte[]> createConsumer(String consumerGroupId, String autoOffsetReset) {
     return new KafkaConsumer<>(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -124,6 +124,7 @@ public class ChannelTestBase {
     clientFactory = mock(KafkaClientFactory.class);
     when(clientFactory.createProducer(any())).thenReturn(producer);
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
+    when(clientFactory.createConsumer(any(), any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorOffsetReset.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorOffsetReset.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.connect.data.SinkWriter;
+import org.apache.iceberg.connect.events.AvroUtil;
+import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.DataWritten;
+import org.apache.iceberg.connect.events.Event;
+import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.Test;
+
+public class TestCoordinatorOffsetReset extends ChannelTestBase {
+
+  private static final TopicPartition CTL_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+  private Coordinator newCoordinator() {
+    MemberDescription member =
+        new MemberDescription(
+            null,
+            Optional.empty(),
+            null,
+            null,
+            new MemberAssignment(ImmutableSet.of(new TopicPartition(SRC_TOPIC_NAME, 0))));
+    return new Coordinator(
+        catalog, config, ImmutableList.of(member), clientFactory, mock(SinkTaskContext.class));
+  }
+
+  private UUID startCommit(Coordinator coordinator) {
+    coordinator.process();
+    byte[] bytes = producer.history().get(producer.history().size() - 1).value();
+    return ((StartCommit) AvroUtil.decode(bytes).payload()).commitId();
+  }
+
+  // The -coord group only gets a committed offset inside doCommit, so a coordinator that starts
+  // before the first successful commit has none. It must read from the beginning.
+  @Test
+  public void coordinatorConsumerReadsFromEarliest() {
+    newCoordinator();
+    verify(clientFactory).createConsumer(config.connectGroupId() + "-coord", "earliest");
+  }
+
+  // The worker's group is transient and never committed to, so it must not replay history.
+  @Test
+  public void workerConsumerReadsFromLatest() {
+    new Worker(config, clientFactory, mock(SinkWriter.class), mock(SinkTaskContext.class));
+    verify(clientFactory).createConsumer(anyString(), eq("latest"));
+  }
+
+  // A coordinator replaced before its group's first successful commit must still deliver files
+  // announced to its predecessor. Without an earliest reset it resumes at the log end and the
+  // worker's source offsets are already committed, so those records never come back.
+  @Test
+  public void replacementCoordinatorRecoversFilesBufferedByItsPredecessor() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    // Build each consumer from the reset strategy production actually asked for, so the test
+    // exercises the real wiring instead of hard-coding a strategy.
+    List<MockConsumer<String, byte[]>> created = Lists.newArrayList();
+    when(clientFactory.createConsumer(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              MockConsumer<String, byte[]> created2 =
+                  new MockConsumer<>(
+                      "earliest".equals(invocation.getArgument(1))
+                          ? OffsetResetStrategy.EARLIEST
+                          : OffsetResetStrategy.LATEST);
+              created.add(created2);
+              return created2;
+            });
+
+    Coordinator first = newCoordinator();
+    MockConsumer<String, byte[]> firstConsumer = created.get(0);
+    first.start();
+    firstConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
+    firstConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+    firstConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+
+    UUID commitId = startCommit(first);
+    DataFile file = EventTestUtil.createDataFile();
+    Event announcement = dataWritten(commitId, file);
+    firstConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
+    first.process(); // buffers the file; no DataComplete yet, so nothing is committed
+
+    // The leader partition moves. The first coordinator and its buffer are discarded, and the
+    // -coord group still has no committed offset because no commit ever succeeded. The record
+    // announcing the file is still on the control topic at offset 0.
+    Coordinator second = newCoordinator();
+    MockConsumer<String, byte[]> secondConsumer = created.get(1);
+    second.start();
+    secondConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
+    secondConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+    secondConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, 1L));
+
+    UUID nextCommitId = startCommit(second);
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(dataComplete(nextCommitId))));
+    second.process();
+
+    table.refresh();
+    assertThat(table.currentSnapshot())
+        .as("file announced to the replaced coordinator must still reach the table")
+        .isNotNull();
+    assertThat(table.currentSnapshot().addedDataFiles(table.io()))
+        .extracting(DataFile::location)
+        .containsExactly(file.location());
+  }
+
+  // Reading history from the beginning is only safe because the per-table offsets in the snapshot
+  // summary filter responses that were already committed. Replaying a committed response must not
+  // append its file a second time.
+  @Test
+  public void replayedResponsesAlreadyCoveredBySnapshotOffsetsAreNotCommittedTwice() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    List<MockConsumer<String, byte[]>> created = Lists.newArrayList();
+    when(clientFactory.createConsumer(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              MockConsumer<String, byte[]> consumer =
+                  new MockConsumer<>(
+                      "earliest".equals(invocation.getArgument(1))
+                          ? OffsetResetStrategy.EARLIEST
+                          : OffsetResetStrategy.LATEST);
+              created.add(consumer);
+              return consumer;
+            });
+
+    Coordinator first = newCoordinator();
+    MockConsumer<String, byte[]> firstConsumer = created.get(0);
+    first.start();
+    firstConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
+    firstConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+    firstConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+
+    UUID commitId = startCommit(first);
+    DataFile file = EventTestUtil.createDataFile();
+    Event announcement = dataWritten(commitId, file);
+    Event completion = dataComplete(commitId);
+    firstConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
+    firstConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(completion)));
+    first.process();
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    Snapshot committed = table.currentSnapshot();
+
+    // a replacement reads the same history from the beginning
+    Coordinator second = newCoordinator();
+    MockConsumer<String, byte[]> secondConsumer = created.get(1);
+    second.start();
+    secondConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
+    secondConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+    secondConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, 2L));
+
+    UUID nextCommitId = startCommit(second);
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(completion)));
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(dataComplete(nextCommitId))));
+    second.process();
+
+    table.refresh();
+    assertThat(table.snapshots())
+        .as("a response already covered by the snapshot offsets must not be appended again")
+        .hasSize(1);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(committed.snapshotId());
+  }
+
+  private Event dataWritten(UUID commitId, DataFile file) {
+    return new Event(
+        config.connectGroupId(),
+        new DataWritten(
+            StructType.of(),
+            commitId,
+            TableReference.of("catalog", TABLE_IDENTIFIER, table.uuid()),
+            ImmutableList.of(file),
+            ImmutableList.of()));
+  }
+
+  private Event dataComplete(UUID commitId) {
+    return new Event(
+        config.connectGroupId(),
+        new DataComplete(
+            commitId, ImmutableList.of(new TopicPartitionOffset(SRC_TOPIC_NAME, 0, 1L, null))));
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorOffsetReset.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorOffsetReset.java
@@ -26,10 +26,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.connect.data.SinkWriter;
 import org.apache.iceberg.connect.events.AvroUtil;
@@ -39,6 +42,7 @@ import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -53,7 +57,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
 
-public class TestCoordinatorOffsetReset extends ChannelTestBase {
+class TestCoordinatorOffsetReset extends ChannelTestBase {
 
   private static final TopicPartition CTL_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
 
@@ -78,14 +82,14 @@ public class TestCoordinatorOffsetReset extends ChannelTestBase {
   // The -coord group only gets a committed offset inside doCommit, so a coordinator that starts
   // before the first successful commit has none. It must read from the beginning.
   @Test
-  public void coordinatorConsumerReadsFromEarliest() {
+  void coordinatorConsumerReadsFromEarliest() {
     newCoordinator();
     verify(clientFactory).createConsumer(config.connectGroupId() + "-coord", "earliest");
   }
 
   // The worker's group is transient and never committed to, so it must not replay history.
   @Test
-  public void workerConsumerReadsFromLatest() {
+  void workerConsumerReadsFromLatest() {
     new Worker(config, clientFactory, mock(SinkWriter.class), mock(SinkTaskContext.class));
     verify(clientFactory).createConsumer(anyString(), eq("latest"));
   }
@@ -94,7 +98,7 @@ public class TestCoordinatorOffsetReset extends ChannelTestBase {
   // announced to its predecessor. Without an earliest reset it resumes at the log end and the
   // worker's source offsets are already committed, so those records never come back.
   @Test
-  public void replacementCoordinatorRecoversFilesBufferedByItsPredecessor() {
+  void replacementCoordinatorRecoversFilesBufferedByItsPredecessor() {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
 
@@ -154,11 +158,17 @@ public class TestCoordinatorOffsetReset extends ChannelTestBase {
         .containsExactly(file.location());
   }
 
-  // Reading history from the beginning is only safe because the per-table offsets in the snapshot
-  // summary filter responses that were already committed. Replaying a committed response must not
-  // append its file a second time.
   @Test
-  public void replayedResponsesAlreadyCoveredBySnapshotOffsetsAreNotCommittedTwice() {
+  void replayedResponsesAlreadyCoveredBySnapshotOffsetsAreNotCommittedTwice() throws IOException {
+    assertReplayRecovery(false);
+  }
+
+  @Test
+  void recoversPendingFilesWhileSkippingCommittedFiles() throws IOException {
+    assertReplayRecovery(true);
+  }
+
+  private void assertReplayRecovery(boolean hasPendingFiles) throws IOException {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
 
@@ -195,6 +205,26 @@ public class TestCoordinatorOffsetReset extends ChannelTestBase {
     table.refresh();
     assertThat(table.snapshots()).hasSize(1);
     Snapshot committed = table.currentSnapshot();
+    List<String> expectedFiles = Lists.newArrayList(file.location());
+    long nextOffset = 2L;
+    DataFile pendingFile =
+        DataFiles.builder(table.spec()).copy(file).withPath("pending.parquet").build();
+    Event pendingAnnouncement = dataWritten(startCommit(first), pendingFile);
+
+    if (hasPendingFiles) {
+      firstConsumer.addRecord(
+          new ConsumerRecord<>(
+              CTL_TOPIC_NAME, 0, nextOffset, "key", AvroUtil.encode(pendingAnnouncement)));
+      first.process();
+      nextOffset++;
+      expectedFiles.add(pendingFile.location());
+    }
+
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(committed.snapshotId());
+    assertThat(firstConsumer.committed(ImmutableSet.of(CTL_PARTITION)).get(CTL_PARTITION).offset())
+        .isEqualTo(2L);
+    first.terminate();
 
     // a replacement reads the same history from the beginning
     Coordinator second = newCoordinator();
@@ -202,23 +232,73 @@ public class TestCoordinatorOffsetReset extends ChannelTestBase {
     second.start();
     secondConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
     secondConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
-    secondConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, 2L));
+    secondConsumer.updateEndOffsets(ImmutableMap.of(CTL_PARTITION, nextOffset));
 
     UUID nextCommitId = startCommit(second);
+    assertThat(secondConsumer.position(CTL_PARTITION)).isZero();
+    assertThat(secondConsumer.committed(ImmutableSet.of(CTL_PARTITION)).get(CTL_PARTITION))
+        .isNull();
     secondConsumer.addRecord(
         new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
     secondConsumer.addRecord(
         new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(completion)));
+    if (hasPendingFiles) {
+      secondConsumer.addRecord(
+          new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(pendingAnnouncement)));
+    }
+
     secondConsumer.addRecord(
         new ConsumerRecord<>(
-            CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(dataComplete(nextCommitId))));
+            CTL_TOPIC_NAME, 0, nextOffset, "key", AvroUtil.encode(dataComplete(nextCommitId))));
     second.process();
 
     table.refresh();
+    try (CloseableIterable<FileScanTask> files = table.newScan().planFiles()) {
+      assertThat(files)
+          .extracting(task -> task.file().location())
+          .containsExactlyInAnyOrderElementsOf(expectedFiles);
+    }
+
     assertThat(table.snapshots())
         .as("a response already covered by the snapshot offsets must not be appended again")
-        .hasSize(1);
-    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(committed.snapshotId());
+        .hasSize(hasPendingFiles ? 2 : 1);
+    assertThat(secondConsumer.committed(ImmutableSet.of(CTL_PARTITION)).get(CTL_PARTITION).offset())
+        .isEqualTo(nextOffset + 1);
+    if (hasPendingFiles) {
+      assertThat(table.currentSnapshot().addedDataFiles(table.io()))
+          .extracting(DataFile::location)
+          .containsExactly(pendingFile.location());
+    } else {
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(committed.snapshotId());
+    }
+
+    long snapshotIdAfterRecovery = table.currentSnapshot().snapshotId();
+    UUID replayCommitId = startCommit(second);
+    secondConsumer.seek(CTL_PARTITION, 0L);
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0L, "key", AvroUtil.encode(announcement)));
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(completion)));
+    if (hasPendingFiles) {
+      secondConsumer.addRecord(
+          new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2L, "key", AvroUtil.encode(pendingAnnouncement)));
+    }
+
+    secondConsumer.addRecord(
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME,
+            0,
+            nextOffset + 1,
+            "key",
+            AvroUtil.encode(dataComplete(replayCommitId))));
+    second.process();
+
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(snapshotIdAfterRecovery);
+    assertThat(table.snapshots()).hasSize(hasPendingFiles ? 2 : 1);
+    assertThat(secondConsumer.committed(ImmutableSet.of(CTL_PARTITION)).get(CTL_PARTITION).offset())
+        .isEqualTo(nextOffset + 2);
+    second.terminate();
   }
 
   private Event dataWritten(UUID commitId, DataFile file) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestKafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestKafkaClientFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Test;
+
+class TestKafkaClientFactory {
+
+  private final KafkaClientFactory factory =
+      new KafkaClientFactory(ImmutableMap.of("bootstrap.servers", "localhost:9092"));
+
+  @Test
+  void appliesTheRequestedAutoOffsetReset() {
+    assertThat(factory.consumerProps("cg-coord", "earliest"))
+        .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        .containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "cg-coord");
+
+    assertThat(factory.consumerProps("cg-worker", "latest"))
+        .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+        .containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "cg-worker");
+  }
+
+  @Test
+  void operatorSuppliedResetWins() {
+    KafkaClientFactory configured =
+        new KafkaClientFactory(
+            ImmutableMap.of(
+                "bootstrap.servers",
+                "localhost:9092",
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                "none"));
+
+    assertThat(configured.consumerProps("cg-coord", "earliest"))
+        .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+  }
+
+  @Test
+  void alwaysDisablesAutoCommitAndReadsCommittedOnly() {
+    assertThat(factory.consumerProps("cg", "earliest"))
+        .containsEntry(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+        .containsEntry(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+  }
+}


### PR DESCRIPTION
## Problem

### Bug: the replacement skips an uncommitted file

The file exists in storage, but its control-topic announcement is the remaining path to registering it in Iceberg.

```mermaid
sequenceDiagram
    autonumber
    participant Worker
    participant Kafka
    participant First as First coordinator
    participant Next as Replacement

    Worker->>Worker: Write data file Y
    Worker->>Kafka: Commit transaction:<br/>DataWritten(Y) + source offsets
    Note over Worker,Kafka: Worker source offsets advance.<br/>Coordinator checkpoint is still absent.
    Kafka-->>First: Deliver DataWritten(Y)
    Note over First: Buffer Y in memory.<br/>No table commit yet.
    Note over First,Next: Leader changes before the first successful commit.<br/>The old in-memory buffer is lost.
    Next->>Kafka: Start with auto.offset.reset=latest
    Kafka-->>Next: Start at log end<br/>do not deliver earlier Y
    Note over Worker,Next: Source records are not automatically redelivered.<br/>File Y remains absent from the Iceberg table.
```

The coordinator's control-topic consumer group receives a committed offset in exactly one place — `Coordinator.doCommit`, after every table has committed successfully:

```java
// we should only get here if all tables committed successfully...
commitConsumerOffsets();
commitState.clearResponses();
```

Until that first success the `<group>-coord` group has **no committed offset**, so `auto.offset.reset` applies. `KafkaClientFactory` defaults it to `latest`:

```java
consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
```

A coordinator holds its `DataWritten` responses in memory (`CommitState.commitBuffer`). If it is replaced before that first successful commit — any rebalance that moves the leader partition will do it — the buffer is discarded with the object, and `Channel.stop()` does not commit offsets. The replacement starts at the **log end** and never re-reads the responses its predecessor consumed.

Those files are never registered in the table. They are not redelivered either, because `Channel.send()` publishes `DataWritten` and commits the worker's source offsets in a single transaction:

```java
recordList.forEach(producer::send);
if (!sourceOffsets.isEmpty()) {
  producer.sendOffsetsToTransaction(offsetsToCommit, KafkaUtils.consumerGroupMetadata(context));
}
producer.commitTransaction();
```

Once that transaction commits, the source records are consumed for good. The only record that the files exist is the control-topic message the replacement just skipped.

The result is silent: no exception, no warning, and the files sit unreferenced in object storage. The window is widest at connector startup, which is exactly when Connect rebalances most. It also reopens if the group's offsets are deleted — note that `offsets.retention.minutes` only starts counting once the group becomes **empty**, so this needs the connector stopped, not merely idle.

## Fix

### After fix: the replacement recovers the uncommitted file

This is the same first-commit failure as the bug timeline above. The announcement for Y is still retained, and no explicit reset override is configured.

```mermaid
sequenceDiagram
    autonumber
    participant Worker
    participant Kafka
    participant Next as Replacement
    participant Table as Iceberg table

    Worker->>Worker: Write data file Y
    Worker->>Kafka: Commit transaction:<br/>DataWritten(Y) + source offsets
    Note over Kafka,Next: First coordinator stops before the table commit.<br/>Its buffer is lost and its checkpoint is absent.
    Next->>Kafka: Start with auto.offset.reset=earliest
    Kafka-->>Next: Replay retained DataWritten(Y)
    Next->>Next: Buffer Y
    Note over Next: When a table commit is triggered
    Next->>Table: Read the snapshot offset boundary
    Table-->>Next: No previous connector commit<br/>in this first-commit example
    Next->>Table: Commit Y and the control-topic<br/>offset boundary in the snapshot
    Table-->>Next: Table commit succeeds
    Next->>Kafka: Commit coordinator Kafka next offsets<br/>after all table commits succeed
    Kafka-->>Next: Checkpoint succeeds
    Next->>Next: Clear buffered responses
    Note over Worker,Table: Y is now visible in Iceberg.<br/>Recovery did not require source-record redelivery.
```

### Fix: replay retained history, then checkpoint

This example assumes no explicit reset override and a reachable per-table snapshot offset boundary. File X was already committed; file Y was only announced.

```mermaid
flowchart TD
    start["Replacement coordinator:<br/>choose start offset per partition"] --> valid{"Valid Kafka<br/>checkpoint?"}
    valid -->|Yes| resume["Resume from the<br/>committed offset"]
    valid -->|No| replay["Default earliest:<br/>read earliest retained records"]
    resume --> buffer["Buffer DataWritten announcements"]
    replay --> buffer
    buffer --> trigger["When a table commit is triggered"]
    trigger --> covered{"Announcement already covered<br/>by the table snapshot boundary?"}
    covered -->|Yes: file X| skip["Skip already committed X"]
    covered -->|No: file Y| append["Commit Y and the updated<br/>offset boundary to Iceberg"]
    skip --> checkpoint["After all table commits succeed:<br/>commit coordinator Kafka next offsets"]
    append --> checkpoint
    checkpoint --> clear["Clear buffered responses"]
```

The snapshot boundary is applied at table-commit time, not while buffering startup history. If the announcements were deleted, they cannot be recovered; if a previously committed boundary was lost, replay can duplicate files. Those retention limits and startup memory costs remain outside this H1 fix.

Pass the reset strategy through `KafkaClientFactory` and `Channel`, and have the coordinator ask for `earliest`. The reset applies to partitions with missing or out-of-range offsets and starts at the earliest retained offset. Valid Kafka checkpoints take precedence, and an explicit `iceberg.kafka.auto.offset.reset` overrides the default.

Re-reading avoids duplicate appends only while the relevant per-table snapshot offset boundary remains reachable. The authoritative dedup floor is the per-table `kafka.connect.offsets.<topic>.<group>` property in the snapshot summary, and `commitToTable` already filters against it:

```java
Long minOffset = committedOffsets.get(envelope.partition());
return minOffset == null || envelope.offset() >= minOffset;
```

Announcements below that boundary are filtered out; retained, uncommitted announcements can be recovered. The replay regressions cover both committed-only history and mixed committed/pending history.

**Known limitation, reproduced and deferred.** `lastCommittedOffsets` walks reachable snapshot ancestry and returns an empty map if it cannot find the connector offset property. Ordinary commits by other writers do not automatically carry that custom property forward. If the boundary-carrying snapshots expire, retained announcements for already committed files can be appended again when the coordinator has no valid Kafka checkpoint. Broader startup replay with `earliest` exposes this retention-dependent risk.

A local probe reproduced it using real Iceberg snapshot expiration: the connector committed file X in snapshot S1; an ordinary append created S2 with an external file and no connector offset property; S1 was expired; and an independent earliest-reset `MockConsumer` without a checkpoint replayed X. A current-table file scan listed X twice, plus the external file. This was a unit-level reproduction, not a real-broker integration test. The failing expiration probe is kept separate from this PR.

This PR remains scoped to H1. A missing-boundary policy and durable checkpoint redesign are deferred, not solved by this change. Recovery also requires retained uncommitted announcements. The Kafka Connect documentation now describes these retention requirements and the startup buffering risk.

The worker deliberately keeps `latest`. Its group is transient (`controlGroupIdPrefix() + UUID.randomUUID()`), is never committed to, and only needs `StartCommit` messages published after it starts — it must not replay control-topic history on every restart.

## Tests

`TestKafkaClientFactory` — covers the configuration itself:

- `appliesTheRequestedAutoOffsetReset` — the requested strategy reaches the consumer properties.
- `operatorSuppliedResetWins` — `putIfAbsent` still honours `iceberg.kafka.auto.offset.reset`.
- `alwaysDisablesAutoCommitAndReadsCommittedOnly` — the fixed settings are unchanged.

`TestCoordinatorOffsetReset` — covers the coordinator's behaviour:

- `coordinatorConsumerReadsFromEarliest` / `workerConsumerReadsFromLatest` — the strategy each channel requests.
- `replacementCoordinatorRecoversFilesBufferedByItsPredecessor` — a file announced to one coordinator, whose successor replaces it without any committed offset, still reaches the table.
- `replayedResponsesAlreadyCoveredBySnapshotOffsetsAreNotCommittedTwice` - committed-only history does not double-append.
- `recoversPendingFilesWhileSkippingCommittedFiles` - a replacement recovers pending file Y while filtering already committed file X.

Both replay tests check current live file locations, snapshot identity/count, Kafka next-offset advancement, and a subsequent replay cycle.

`consumerProps` was extracted from `createConsumer` specifically so the factory is testable. Without it the channel-level tests verify only which strategy is *requested*: a factory that ignored its argument and hard-coded `latest` would leave them green while the bug persisted. Confirmed by temporarily sabotaging the factory — the channel tests passed, `TestKafkaClientFactory` failed.

Verified to fail without the fix:

```
coordinatorConsumerReadsFromEarliest()                          FAILED
replacementCoordinatorRecoversFilesBufferedByItsPredecessor()   FAILED
3 tests completed, 2 failed
```

and to pass with it, along with the existing suite and `spotlessCheck`.

For follow-up commit `bf9130b1d`, the complete connector unit suite passed: 141 tests across 20 suites, with no failures, errors, or skips. The connector `spotlessCheck`, `checkstyleMain`, and `checkstyleTest` checks also passed. No real-broker integration tests were run.

`ChannelTestBase` gains a stub for the new `createConsumer` overload.

## Why the existing suite never caught this

`ChannelTestBase` constructs its `MockConsumer` with `OffsetResetStrategy.EARLIEST`, while production defaults to `latest`. The harness could not express the failure. A probe confirms `MockConsumer` does honour the strategy:

```
PROBE strategy=earliest position=1 recordsReturned=1
PROBE strategy=latest   position=1 recordsReturned=0
```

## Scope and risk

Deliberately scoped to H1: the coordinator offset-reset default, regression coverage, and recovery documentation. A durable checkpoint redesign, missing-snapshot-boundary policy, and bounded startup replay are not implemented here.

The main risk is startup cost when a connect group has no checkpoint and the control topic is long-lived. Events for other groups are skipped by the existing `event.groupId().equals(connectGroupId)` check, but same-group `DataWritten` responses are buffered by `CommitState.addResponse` **before** any snapshot-offset filtering, which happens later at commit time. So replay is a heap cost, not only a read cost, and it recurs whenever the checkpoint is unavailable rather than strictly once per group. Control-topic retention bounds the history but is not a heap bound. Operators can still override with `iceberg.kafka.auto.offset.reset`. A bounded-replay follow-up may be worth considering.

Related but **not** addressed here: #16282's rebalance-replay mechanism (see #17713, #17933), and coordinator election hardening (#17376, #17450). This is an independent gap that none of them close — it is caused by coordinator *restart*, not by replay.

---
**AI Disclosure**
- Model: Claude Opus 5 (original contribution); GPT-6 Astra (follow-up).
- Platform/Tool: opencode (original contribution); GitHub Copilot (follow-up).
- Human Oversight: partially reviewed.
- Prompt Summary: An AI agent audited the Kafka Connect sink coordinator, identified this gap, wrote the reproduction, implemented the fix, and drafted this description. Two rounds of independent model review found real defects: fixture flaws in the first reproduction, and that the original tests would pass even if the factory ignored its argument. Both were corrected and verified by deliberately sabotaging the production code to confirm the tests fail. Follow-up work added mixed-history recovery and checkpoint assertions, reproduced the deferred snapshot-expiration limitation, documented recovery constraints, aligned test visibility and naming with contribution guidance, and ran the connector unit and style checks. Code and description are AI-generated and partially reviewed by the author.
