### PR TITLE
Spark: Fix test metadata file locations

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -119,6 +119,22 @@ public class TestBaseReader {
   }
 
   @Test
+  public void metadataFilesAreCreatedUnderTableLocation() {
+    File location = temp.resolve("test").toFile();
+    Schema schema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
+    TestTables.TestTable testTable =
+        TestTables.create(location, "metadata_location", schema, PartitionSpec.unpartitioned());
+
+    try {
+      String metadataFileName = "metadata.avro";
+      assertThat(testTable.operations().metadataFileLocation(metadataFileName))
+          .isEqualTo(new File(new File(location, "metadata"), metadataFileName).getAbsolutePath());
+    } finally {
+      TestTables.clearTables();
+    }
+  }
+
+  @Test
   public void testClosureOnDataExhaustion() throws IOException {
     Integer totalTasks = 10;
     Integer recordPerTask = 10;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Files;
@@ -177,7 +178,8 @@ class TestTables {
 
     @Override
     public String metadataFileLocation(String fileName) {
-      return new File(new File(current.location(), "metadata"), fileName).getAbsolutePath();
+      File tableLocation = new File(URI.create(current.location()));
+      return new File(new File(tableLocation, "metadata"), fileName).getAbsolutePath();
     }
 
     @Override

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -119,6 +119,22 @@ public class TestBaseReader {
   }
 
   @Test
+  public void metadataFilesAreCreatedUnderTableLocation() {
+    File location = temp.resolve("test").toFile();
+    Schema schema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
+    TestTables.TestTable testTable =
+        TestTables.create(location, "metadata_location", schema, PartitionSpec.unpartitioned());
+
+    try {
+      String metadataFileName = "metadata.avro";
+      assertThat(testTable.operations().metadataFileLocation(metadataFileName))
+          .isEqualTo(new File(new File(location, "metadata"), metadataFileName).getAbsolutePath());
+    } finally {
+      TestTables.clearTables();
+    }
+  }
+
+  @Test
   public void testClosureOnDataExhaustion() throws IOException {
     Integer totalTasks = 10;
     Integer recordPerTask = 10;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Files;
@@ -177,7 +178,8 @@ class TestTables {
 
     @Override
     public String metadataFileLocation(String fileName) {
-      return new File(new File(current.location(), "metadata"), fileName).getAbsolutePath();
+      File tableLocation = new File(URI.create(current.location()));
+      return new File(new File(tableLocation, "metadata"), fileName).getAbsolutePath();
     }
 
     @Override

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -119,6 +119,22 @@ public class TestBaseReader {
   }
 
   @Test
+  public void metadataFilesAreCreatedUnderTableLocation() {
+    File location = temp.resolve("test").toFile();
+    Schema schema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
+    TestTables.TestTable testTable =
+        TestTables.create(location, "metadata_location", schema, PartitionSpec.unpartitioned());
+
+    try {
+      String metadataFileName = "metadata.avro";
+      assertThat(testTable.operations().metadataFileLocation(metadataFileName))
+          .isEqualTo(new File(new File(location, "metadata"), metadataFileName).getAbsolutePath());
+    } finally {
+      TestTables.clearTables();
+    }
+  }
+
+  @Test
   public void testClosureOnDataExhaustion() throws IOException {
     Integer totalTasks = 10;
     Integer recordPerTask = 10;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Files;
@@ -177,7 +178,8 @@ class TestTables {
 
     @Override
     public String metadataFileLocation(String fileName) {
-      return new File(new File(current.location(), "metadata"), fileName).getAbsolutePath();
+      File tableLocation = new File(URI.create(current.location()));
+      return new File(new File(tableLocation, "metadata"), fileName).getAbsolutePath();
     }
 
     @Override

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -119,6 +119,22 @@ public class TestBaseReader {
   }
 
   @Test
+  public void metadataFilesAreCreatedUnderTableLocation() {
+    File location = temp.resolve("test").toFile();
+    Schema schema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
+    TestTables.TestTable testTable =
+        TestTables.create(location, "metadata_location", schema, PartitionSpec.unpartitioned());
+
+    try {
+      String metadataFileName = "metadata.avro";
+      assertThat(testTable.operations().metadataFileLocation(metadataFileName))
+          .isEqualTo(new File(new File(location, "metadata"), metadataFileName).getAbsolutePath());
+    } finally {
+      TestTables.clearTables();
+    }
+  }
+
+  @Test
   public void testClosureOnDataExhaustion() throws IOException {
     Integer totalTasks = 10;
     Integer recordPerTask = 10;

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Files;
@@ -177,7 +178,8 @@ class TestTables {
 
     @Override
     public String metadataFileLocation(String fileName) {
-      return new File(new File(current.location(), "metadata"), fileName).getAbsolutePath();
+      File tableLocation = new File(URI.create(current.location()));
+      return new File(new File(tableLocation, "metadata"), fileName).getAbsolutePath();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix Spark’s `TestTables` helper so metadata files are created under the JUnit temporary table directory.

The helper previously passed a `file:` URI directly to `File`, which treated it as a relative path and created test artifacts inside the Git worktree. The location is now parsed as a URI before constructing the metadata path.

This change applies to Spark 3.5, 4.0, 4.1, and 4.2 and adds a regression test for the resolved location.

## Testing

- Ran `TestBaseReader` on all four Spark versions: 6/6 tests passed per version.
- Ran `spotlessCheck` on all four affected modules.
- Confirmed the tests create no untracked files or misplaced `file:` directories.