### PR TITLE
Spark: Avoid eager orphan scans for non-error prefix mismatch modes

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -267,9 +267,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   /**
-   * Deletes orphan files from the cached dataset.
+   * Deletes orphan files from the dataset.
    *
-   * @param orphanFileDS the cached dataset of orphan files
+   * @param orphanFileDS the dataset of orphan files
    * @return result with orphan file paths
    */
   private DeleteOrphanFiles.Result deleteFiles(Dataset<String> orphanFileDS) {
@@ -362,13 +362,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
             .joinWith(validFileIdentDS, joinCond, "leftouter")
             .mapPartitions(new FindOrphanFiles(prefixMismatchMode, conflicts), Encoders.STRING());
 
+    if (prefixMismatchMode != PrefixMismatchMode.ERROR) {
+      return orphanFileDS;
+    }
+
     // Cache and force computation to populate conflicts accumulator
     orphanFileDS = orphanFileDS.cache();
 
     try {
       orphanFileDS.count();
 
-      if (prefixMismatchMode == PrefixMismatchMode.ERROR && !conflicts.value().isEmpty()) {
+      if (!conflicts.value().isEmpty()) {
         throw new ValidationException(
             "Unable to determine whether certain files are orphan. Metadata references files that"
                 + " match listed/provided files except for authority/scheme. Please, inspect the"

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -86,12 +86,14 @@ import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.LongAccumulator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1194,6 +1196,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void deleteModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.DELETE);
+  }
+
+  @TestTemplate
+  public void ignoreModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.IGNORE);
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1227,6 +1239,31 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   protected String randomName(String prefix) {
     return prefix + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private void assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode mode) {
+    LongAccumulator processedActualFiles = spark.sparkContext().longAccumulator();
+    List<String> actualFiles = Lists.newArrayList("file:///dir/orphan-file");
+    List<String> validFiles = Lists.newArrayList();
+    Dataset<String> actualFileDS =
+        spark
+            .createDataset(actualFiles, Encoders.STRING())
+            .map(
+                (MapFunction<String, String>)
+                    file -> {
+                      processedActualFiles.add(1L);
+                      return file;
+                    },
+                Encoders.STRING());
+    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
+    StringToFileURI toFileUri = new StringToFileURI(ImmutableMap.of(), ImmutableMap.of());
+
+    Dataset<String> orphanFileDS =
+        DeleteOrphanFilesSparkAction.findOrphanFiles(
+            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+
+    assertThat(processedActualFiles.value()).isZero();
+    assertThat(orphanFileDS.collectAsList()).containsExactly("file:///dir/orphan-file");
   }
 
   private void executeTest(

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -267,9 +267,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   /**
-   * Deletes orphan files from the cached dataset.
+   * Deletes orphan files from the dataset.
    *
-   * @param orphanFileDS the cached dataset of orphan files
+   * @param orphanFileDS the dataset of orphan files
    * @return result with orphan file paths
    */
   private DeleteOrphanFiles.Result deleteFiles(Dataset<String> orphanFileDS) {
@@ -362,13 +362,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
             .joinWith(validFileIdentDS, joinCond, "leftouter")
             .mapPartitions(new FindOrphanFiles(prefixMismatchMode, conflicts), Encoders.STRING());
 
+    if (prefixMismatchMode != PrefixMismatchMode.ERROR) {
+      return orphanFileDS;
+    }
+
     // Cache and force computation to populate conflicts accumulator
     orphanFileDS = orphanFileDS.cache();
 
     try {
       orphanFileDS.count();
 
-      if (prefixMismatchMode == PrefixMismatchMode.ERROR && !conflicts.value().isEmpty()) {
+      if (!conflicts.value().isEmpty()) {
         throw new ValidationException(
             "Unable to determine whether certain files are orphan. Metadata references files that"
                 + " match listed/provided files except for authority/scheme. Please, inspect the"

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -86,12 +86,14 @@ import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.LongAccumulator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1194,6 +1196,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void deleteModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.DELETE);
+  }
+
+  @TestTemplate
+  public void ignoreModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.IGNORE);
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1227,6 +1239,31 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   protected String randomName(String prefix) {
     return prefix + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private void assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode mode) {
+    LongAccumulator processedActualFiles = spark.sparkContext().longAccumulator();
+    List<String> actualFiles = Lists.newArrayList("file:///dir/orphan-file");
+    List<String> validFiles = Lists.newArrayList();
+    Dataset<String> actualFileDS =
+        spark
+            .createDataset(actualFiles, Encoders.STRING())
+            .map(
+                (MapFunction<String, String>)
+                    file -> {
+                      processedActualFiles.add(1L);
+                      return file;
+                    },
+                Encoders.STRING());
+    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
+    StringToFileURI toFileUri = new StringToFileURI(ImmutableMap.of(), ImmutableMap.of());
+
+    Dataset<String> orphanFileDS =
+        DeleteOrphanFilesSparkAction.findOrphanFiles(
+            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+
+    assertThat(processedActualFiles.value()).isZero();
+    assertThat(orphanFileDS.collectAsList()).containsExactly("file:///dir/orphan-file");
   }
 
   private void executeTest(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -267,9 +267,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   /**
-   * Deletes orphan files from the cached dataset.
+   * Deletes orphan files from the dataset.
    *
-   * @param orphanFileDS the cached dataset of orphan files
+   * @param orphanFileDS the dataset of orphan files
    * @return result with orphan file paths
    */
   private DeleteOrphanFiles.Result deleteFiles(Dataset<String> orphanFileDS) {
@@ -362,13 +362,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
             .joinWith(validFileIdentDS, joinCond, "leftouter")
             .mapPartitions(new FindOrphanFiles(prefixMismatchMode, conflicts), Encoders.STRING());
 
+    if (prefixMismatchMode != PrefixMismatchMode.ERROR) {
+      return orphanFileDS;
+    }
+
     // Cache and force computation to populate conflicts accumulator
     orphanFileDS = orphanFileDS.cache();
 
     try {
       orphanFileDS.count();
 
-      if (prefixMismatchMode == PrefixMismatchMode.ERROR && !conflicts.value().isEmpty()) {
+      if (!conflicts.value().isEmpty()) {
         throw new ValidationException(
             "Unable to determine whether certain files are orphan. Metadata references files that"
                 + " match listed/provided files except for authority/scheme. Please, inspect the"

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -87,12 +87,14 @@ import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.LongAccumulator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1195,6 +1197,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void deleteModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.DELETE);
+  }
+
+  @TestTemplate
+  public void ignoreModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.IGNORE);
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1228,6 +1240,31 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   protected String randomName(String prefix) {
     return prefix + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private void assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode mode) {
+    LongAccumulator processedActualFiles = spark.sparkContext().longAccumulator();
+    List<String> actualFiles = Lists.newArrayList("file:///dir/orphan-file");
+    List<String> validFiles = Lists.newArrayList();
+    Dataset<String> actualFileDS =
+        spark
+            .createDataset(actualFiles, Encoders.STRING())
+            .map(
+                (MapFunction<String, String>)
+                    file -> {
+                      processedActualFiles.add(1L);
+                      return file;
+                    },
+                Encoders.STRING());
+    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
+    StringToFileURI toFileUri = new StringToFileURI(ImmutableMap.of(), ImmutableMap.of());
+
+    Dataset<String> orphanFileDS =
+        DeleteOrphanFilesSparkAction.findOrphanFiles(
+            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+
+    assertThat(processedActualFiles.value()).isZero();
+    assertThat(orphanFileDS.collectAsList()).containsExactly("file:///dir/orphan-file");
   }
 
   private void executeTest(

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -267,9 +267,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   /**
-   * Deletes orphan files from the cached dataset.
+   * Deletes orphan files from the dataset.
    *
-   * @param orphanFileDS the cached dataset of orphan files
+   * @param orphanFileDS the dataset of orphan files
    * @return result with orphan file paths
    */
   private DeleteOrphanFiles.Result deleteFiles(Dataset<String> orphanFileDS) {
@@ -362,13 +362,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
             .joinWith(validFileIdentDS, joinCond, "leftouter")
             .mapPartitions(new FindOrphanFiles(prefixMismatchMode, conflicts), Encoders.STRING());
 
+    if (prefixMismatchMode != PrefixMismatchMode.ERROR) {
+      return orphanFileDS;
+    }
+
     // Cache and force computation to populate conflicts accumulator
     orphanFileDS = orphanFileDS.cache();
 
     try {
       orphanFileDS.count();
 
-      if (prefixMismatchMode == PrefixMismatchMode.ERROR && !conflicts.value().isEmpty()) {
+      if (!conflicts.value().isEmpty()) {
         throw new ValidationException(
             "Unable to determine whether certain files are orphan. Metadata references files that"
                 + " match listed/provided files except for authority/scheme. Please, inspect the"

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -87,12 +87,14 @@ import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.LongAccumulator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1195,6 +1197,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void deleteModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.DELETE);
+  }
+
+  @TestTemplate
+  public void ignoreModeDoesNotEvaluateEagerly() {
+    assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode.IGNORE);
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1228,6 +1240,31 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   protected String randomName(String prefix) {
     return prefix + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private void assertDoesNotEvaluateEagerly(DeleteOrphanFiles.PrefixMismatchMode mode) {
+    LongAccumulator processedActualFiles = spark.sparkContext().longAccumulator();
+    List<String> actualFiles = Lists.newArrayList("file:///dir/orphan-file");
+    List<String> validFiles = Lists.newArrayList();
+    Dataset<String> actualFileDS =
+        spark
+            .createDataset(actualFiles, Encoders.STRING())
+            .map(
+                (MapFunction<String, String>)
+                    file -> {
+                      processedActualFiles.add(1L);
+                      return file;
+                    },
+                Encoders.STRING());
+    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
+    StringToFileURI toFileUri = new StringToFileURI(ImmutableMap.of(), ImmutableMap.of());
+
+    Dataset<String> orphanFileDS =
+        DeleteOrphanFilesSparkAction.findOrphanFiles(
+            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+
+    assertThat(processedActualFiles.value()).isZero();
+    assertThat(orphanFileDS.collectAsList()).containsExactly("file:///dir/orphan-file");
   }
 
   private void executeTest(


### PR DESCRIPTION
## Summary

Avoid eagerly caching and counting the orphan-file dataset when `PrefixMismatchMode` is `IGNORE` or `DELETE`. The default `ERROR` behaviour remains unchanged.

## Why

`findOrphanFiles` previously cached and counted the complete joined dataset for every prefix mismatch mode. This eager Spark job is required for `ERROR`, where all scheme and authority conflicts must be collected before any files are deleted.

`IGNORE` and `DELETE` do not inspect the conflict accumulator. Eagerly materializing the dataset adds unnecessary work and cache pressure, which is particularly expensive for tables with very large file listings.

## How it works

For `IGNORE` and `DELETE`, `findOrphanFiles` now returns the lazy dataset immediately after constructing the join and partition mapping.

For `ERROR`, it retains the existing cache and count operation so conflicts are detected before deletion begins.

Regression tests use a Spark accumulator to verify that `IGNORE` and `DELETE` do not evaluate the input dataset until the result is consumed. The change is applied to Spark 3.5, 4.0, 4.1, and 4.2.

## Testing

- Ran the lazy evaluation and prefix conflict tests on all four Spark versions: 18/18 passed per version.
- Ran the complete Spark 4.0 orphan-file action test class: 175 passed and 23 skipped.
- Ran `spotlessCheck` on all affected modules.
