### PR TITLE
Kafka Connect: Fail incomplete commits for missing or replaced tables

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -94,6 +94,38 @@ If `iceberg.tables.dynamic-enabled` is `false` (the default) then you must speci
 `iceberg.tables.dynamic-enabled` is `true` then you must specify `iceberg.tables.route-field` which will
 contain the name of the table.
 
+### Missing or replaced tables during commit
+
+If a table cannot be found when the coordinator commits buffered files, or its
+UUID no longer matches the UUID recorded in the response, the commit cycle
+fails. The coordinator retains the buffered responses, does not advance its
+control-topic consumer checkpoint, and does not publish `CommitComplete`.
+A UUID mismatch is not resolved by writing the files into the replacement
+table. Other tables may already have committed successfully; those Iceberg
+commits are not rolled back.
+
+These failures count toward `iceberg.control.commit.max-consecutive-failures`,
+including failures in timed-out partial commits. The default is `1`, which
+terminates the coordinator on the first failure. A higher value permits retries
+in later commit cycles. A successful full commit resets the consecutive-failure
+count. Partial table-lookup failures also increment the partial-commit failure
+counter.
+
+For temporary table unavailability, restore the original table under the
+expected identifier and with its original UUID before the retry limit is
+reached. If the coordinator has already failed, resolve the table lookup before
+restarting the affected task. Recovery by control-topic replay requires the
+relevant records to remain retained and a suitable consumer starting offset;
+retaining the in-memory buffer does not by itself guarantee recovery after a
+restart.
+
+A deliberately dropped or permanently replaced table requires operator
+intervention. Increasing the retry limit cannot reconcile responses for
+different table UUIDs under the same name. The connector does not automatically
+discard those responses or migrate them to the replacement table. This policy
+applies to buffered file commits, not the initial missing-table behavior of
+dynamic routing described below.
+
 ### Kafka configuration
 
 By default the connector will attempt to use Kafka client config from the worker properties for connecting to

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -98,6 +98,10 @@ class CommitState {
     currentCommitId = null;
   }
 
+  int bufferedResponseCount() {
+    return commitBuffer.size();
+  }
+
   void clearResponses() {
     commitBuffer.clear();
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -28,10 +28,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -160,12 +162,14 @@ class Coordinator extends Channel {
     } catch (RuntimeException e) {
       if (partialCommit) {
         partialCommitFailures.incrementAndGet();
-        LOG.warn(
-            "Partial commit {} failed for task {}, will retry",
-            commitState.currentCommitId(),
-            taskId,
-            e);
-        return;
+        if (!(e instanceof IncompleteCommitException)) {
+          LOG.warn(
+              "Partial commit {} failed for task {}, will retry",
+              commitState.currentCommitId(),
+              taskId,
+              e);
+          return;
+        }
       }
 
       if (!(e instanceof CommitFailedException)) {
@@ -198,16 +202,24 @@ class Coordinator extends Channel {
   private void doCommit(boolean partialCommit) {
     Map<TableReference, List<Envelope>> commitMap = commitState.tableCommitMap();
     OffsetDateTime validThroughTs = commitState.validThroughTs(partialCommit);
+    AtomicBoolean everyTableCommitted = new AtomicBoolean(true);
 
     Tasks.foreach(commitMap.entrySet())
         .executeWith(exec)
         .stopOnFailure()
         .run(
-            entry ->
-                commitToTable(
-                    entry.getKey(), entry.getValue(), controlTopicOffsets(), validThroughTs));
+            entry -> {
+              if (!commitToTable(
+                  entry.getKey(), entry.getValue(), controlTopicOffsets(), validThroughTs)) {
+                everyTableCommitted.set(false);
+              }
+            });
 
-    // we should only get here if all tables committed successfully...
+    if (!everyTableCommitted.get()) {
+      throw new IncompleteCommitException(
+          commitState.currentCommitId(), commitState.bufferedResponseCount());
+    }
+
     commitConsumerOffsets();
     commitState.clearResponses();
 
@@ -233,8 +245,14 @@ class Coordinator extends Channel {
     }
   }
 
+  /**
+   * Commits the responses collected for one table.
+   *
+   * @return false when the responses did not reach a table and must be retried, true when they were
+   *     committed or contained nothing to commit
+   */
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  private void commitToTable(
+  private boolean commitToTable(
       TableReference tableReference,
       List<Envelope> envelopeList,
       Map<Integer, Long> controlTopicOffsets,
@@ -244,17 +262,17 @@ class Coordinator extends Channel {
     try {
       table = catalog.loadTable(tableIdentifier);
     } catch (NoSuchTableException e) {
-      LOG.warn("Table not found, skipping commit: {}", tableIdentifier, e);
-      return;
+      LOG.warn("Table not found, retaining responses to retry: {}", tableIdentifier, e);
+      return false;
     }
 
     if (tableReference.uuid() != null && !tableReference.uuid().equals(table.uuid())) {
       LOG.warn(
-          "Skipping commits to table {} due to target table mismatch.  Expected: {} Received: {}",
+          "Table UUID mismatch, retaining responses to retry: {}. Expected: {} Found: {}",
           tableIdentifier,
-          table.uuid(),
-          tableReference.uuid());
-      return;
+          tableReference.uuid(),
+          table.uuid());
+      return false;
     }
 
     String branch = config.tableConfig(tableIdentifier.toString()).commitBranch();
@@ -303,6 +321,7 @@ class Coordinator extends Channel {
     if (dataFiles.isEmpty() && deleteFiles.isEmpty()) {
       LOG.info(
           "Coordinator {} found nothing to commit to table {}, skipping", taskId, tableIdentifier);
+      return true;
     } else {
       if (deleteFiles.isEmpty()) {
         AppendFiles appendOp =
@@ -351,6 +370,8 @@ class Coordinator extends Channel {
           commitState.currentCommitId(),
           validThroughTs);
     }
+
+    return true;
   }
 
   private SnapshotAncestryValidator offsetValidator(
@@ -424,6 +445,14 @@ class Coordinator extends Channel {
 
   long partialCommitFailureCount() {
     return partialCommitFailures.get();
+  }
+
+  private static class IncompleteCommitException extends CommitFailedException {
+    private IncompleteCommitException(UUID commitId, int responseCount) {
+      super(
+          "Cannot complete commit %s: unresolved tables, retaining %s buffered response(s)",
+          commitId, responseCount);
+    }
   }
 
   void terminate() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorTableLookup.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorTableLookup.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.connect.events.AvroUtil;
+import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.DataWritten;
+import org.apache.iceberg.connect.events.Event;
+import org.apache.iceberg.connect.events.PayloadType;
+import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TestCoordinatorTableLookup extends ChannelTestBase {
+  private static final TopicPartition CONTROL_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
+  private Coordinator activeCoordinator;
+
+  @AfterEach
+  void stopCoordinator() {
+    if (activeCoordinator != null) {
+      activeCoordinator.terminate();
+      activeCoordinator.stop();
+    }
+  }
+
+  @Test
+  void availableTableRegistersFileBeforeCheckpointing() {
+    Coordinator coordinator = startCoordinator();
+    UUID commitId = currentCommitId();
+    DataFile dataFile = EventTestUtil.createDataFile();
+    bufferFile(coordinator, commitId, dataFile);
+    completeCommit(coordinator, commitId, 2L);
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(
+            SnapshotChanges.builderFor(table)
+                .snapshot(table.currentSnapshot())
+                .build()
+                .addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(dataFile.location());
+    assertThat(table.currentSnapshot().summary()).containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":3}");
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(3L));
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(
+            PayloadType.START_COMMIT, PayloadType.COMMIT_TO_TABLE, PayloadType.COMMIT_COMPLETE);
+  }
+
+  @Test
+  void missingTableFailsAtDefaultRetryLimitWithoutCheckpointing() {
+    Coordinator coordinator = startCoordinator();
+    UUID commitId = currentCommitId();
+    bufferFile(coordinator, commitId, EventTestUtil.createDataFile());
+    catalog.renameTable(TABLE_IDENTIFIER, TableIdentifier.of(NAMESPACE, "unavailable"));
+
+    assertThatThrownBy(() -> completeCommit(coordinator, commitId, 2L))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Cannot complete commit")
+        .hasMessageContaining("unresolved tables");
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(1L));
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(PayloadType.START_COMMIT);
+  }
+
+  @Test
+  void missingTableRetainsResponsesAndCommitsThemWhenTheTableReturns() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    UUID commitId = currentCommitId();
+    UUID originalUuid = table.uuid();
+    DataFile dataFile = EventTestUtil.createDataFile();
+    bufferFile(coordinator, commitId, dataFile);
+
+    TableIdentifier movedIdentifier = TableIdentifier.of(NAMESPACE, "temporarily_moved");
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    assertThat(catalog.tableExists(TABLE_IDENTIFIER)).isFalse();
+    completeCommit(coordinator, commitId, 2L);
+
+    // nothing reached a table, so the control-topic offsets must not move past the response and
+    // the commit must not be announced as complete
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(1L));
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(PayloadType.START_COMMIT);
+    assertThat(catalog.loadTable(movedIdentifier).snapshots()).isEmpty();
+
+    catalog.renameTable(movedIdentifier, TABLE_IDENTIFIER);
+    assertThat(catalog.loadTable(TABLE_IDENTIFIER).uuid()).isEqualTo(originalUuid);
+    coordinator.process();
+    completeCommit(coordinator, currentCommitId(), 3L);
+
+    Table recovered = catalog.loadTable(TABLE_IDENTIFIER);
+    assertThat(recovered.snapshots()).hasSize(1);
+    assertThat(
+            SnapshotChanges.builderFor(recovered)
+                .snapshot(recovered.currentSnapshot())
+                .build()
+                .addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(dataFile.location());
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(4L));
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(
+            PayloadType.START_COMMIT,
+            PayloadType.START_COMMIT,
+            PayloadType.COMMIT_TO_TABLE,
+            PayloadType.COMMIT_COMPLETE);
+  }
+
+  @Test
+  void replacementTableIsProtectedAndTheOriginalFileIsCommittedWhenTheTableReturns() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    UUID commitId = currentCommitId();
+    UUID originalUuid = table.uuid();
+    DataFile dataFile = EventTestUtil.createDataFile();
+    bufferFile(coordinator, commitId, dataFile);
+
+    TableIdentifier movedIdentifier = TableIdentifier.of(NAMESPACE, "original_table");
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    Table replacement = catalog.createTable(TABLE_IDENTIFIER, SCHEMA);
+    assertThat(replacement.uuid()).isNotEqualTo(originalUuid);
+    completeCommit(coordinator, commitId, 2L);
+
+    // the replacement must not receive the previous table's file, and the response must survive
+    replacement.refresh();
+    assertThat(replacement.snapshots()).isEmpty();
+    assertThat(catalog.loadTable(movedIdentifier).snapshots()).isEmpty();
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(1L));
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(PayloadType.START_COMMIT);
+
+    assertThat(catalog.dropTable(TABLE_IDENTIFIER, false)).isTrue();
+    catalog.renameTable(movedIdentifier, TABLE_IDENTIFIER);
+    assertThat(catalog.loadTable(TABLE_IDENTIFIER).uuid()).isEqualTo(originalUuid);
+    coordinator.process();
+    completeCommit(coordinator, currentCommitId(), 3L);
+
+    Table recovered = catalog.loadTable(TABLE_IDENTIFIER);
+    assertThat(recovered.snapshots()).hasSize(1);
+    assertThat(
+            SnapshotChanges.builderFor(recovered)
+                .snapshot(recovered.currentSnapshot())
+                .build()
+                .addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(dataFile.location());
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(4L));
+  }
+
+  @Test
+  void missingTableFailsAfterConfiguredLimit() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    UUID commitId = currentCommitId();
+    bufferFile(coordinator, commitId, EventTestUtil.createDataFile());
+    catalog.renameTable(TABLE_IDENTIFIER, TableIdentifier.of(NAMESPACE, "unavailable"));
+
+    completeCommit(coordinator, commitId, 2L);
+    coordinator.process();
+    assertThatThrownBy(() -> completeCommit(coordinator, currentCommitId(), 3L))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void mixedTableUUIDsFailWithinLimitEvenWhenBothFilesHaveCommitted() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
+    when(config.commitThreads()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    UUID originalUUID = table.uuid();
+    DataFile originalFile = dataFile("original");
+    bufferFile(coordinator, currentCommitId(), originalFile);
+
+    TableIdentifier originalIdentifier = TableIdentifier.of(NAMESPACE, "original_table");
+    TableIdentifier replacementIdentifier = TableIdentifier.of(NAMESPACE, "replacement_table");
+    catalog.renameTable(TABLE_IDENTIFIER, originalIdentifier);
+    Table replacement = catalog.createTable(TABLE_IDENTIFIER, SCHEMA);
+    assertThat(replacement.uuid()).isNotEqualTo(originalUUID);
+    completeCommit(coordinator, currentCommitId(), 2L);
+
+    coordinator.process();
+    DataFile replacementFile = dataFile("replacement");
+    writeResponse(TABLE_IDENTIFIER, replacement.uuid(), replacementFile, 3L);
+    completeCommit(coordinator, currentCommitId(), 4L);
+    assertFiles(catalog.loadTable(TABLE_IDENTIFIER), replacementFile);
+    assertCheckpoint(1L);
+
+    catalog.renameTable(TABLE_IDENTIFIER, replacementIdentifier);
+    catalog.renameTable(originalIdentifier, TABLE_IDENTIFIER);
+    coordinator.process();
+    assertThatThrownBy(() -> completeCommit(coordinator, currentCommitId(), 5L))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertFiles(catalog.loadTable(TABLE_IDENTIFIER), originalFile);
+    assertFiles(catalog.loadTable(replacementIdentifier), replacementFile);
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void missingTablePartialCommitsCountFailuresAndRespectLimit() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    bufferFile(coordinator, currentCommitId(), EventTestUtil.createDataFile());
+    catalog.renameTable(TABLE_IDENTIFIER, TableIdentifier.of(NAMESPACE, "unavailable"));
+    when(config.commitTimeoutMs()).thenReturn(-1);
+
+    coordinator.process();
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1L);
+    assertCheckpoint(1L);
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(2L);
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void replacementTablePartialCommitFailsAtDefaultLimit() {
+    Coordinator coordinator = startCoordinator();
+    UUID originalUUID = table.uuid();
+    bufferFile(coordinator, currentCommitId(), EventTestUtil.createDataFile());
+    TableIdentifier originalIdentifier = TableIdentifier.of(NAMESPACE, "original_table");
+    catalog.renameTable(TABLE_IDENTIFIER, originalIdentifier);
+    Table replacement = catalog.createTable(TABLE_IDENTIFIER, SCHEMA);
+    assertThat(replacement.uuid()).isNotEqualTo(originalUUID);
+    when(config.commitTimeoutMs()).thenReturn(-1);
+
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1L);
+    assertThat(catalog.loadTable(originalIdentifier).snapshots()).isEmpty();
+    assertThat(catalog.loadTable(TABLE_IDENTIFIER).snapshots()).isEmpty();
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void fullAndPartialLookupFailuresShareRetryLimit() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    bufferFile(coordinator, currentCommitId(), EventTestUtil.createDataFile());
+    catalog.renameTable(TABLE_IDENTIFIER, TableIdentifier.of(NAMESPACE, "unavailable"));
+    completeCommit(coordinator, currentCommitId(), 2L);
+    when(config.commitTimeoutMs()).thenReturn(-1);
+
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1L);
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void missingTableDoesNotResetEarlierCommitFailure() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
+    Coordinator coordinator = startCoordinator();
+    bufferFile(coordinator, currentCommitId(), EventTestUtil.createDataFile());
+    doThrow(new CommitFailedException("Injected commit failure"))
+        .when(catalog)
+        .loadTable(TABLE_IDENTIFIER);
+    completeCommit(coordinator, currentCommitId(), 2L);
+
+    doCallRealMethod().when(catalog).loadTable(TABLE_IDENTIFIER);
+    TableIdentifier movedIdentifier = TableIdentifier.of(NAMESPACE, "unavailable");
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    coordinator.process();
+    completeCommit(coordinator, currentCommitId(), 3L);
+
+    catalog.renameTable(movedIdentifier, TABLE_IDENTIFIER);
+    doThrow(new CommitFailedException("Injected commit failure"))
+        .when(catalog)
+        .loadTable(TABLE_IDENTIFIER);
+    coordinator.process();
+    assertThatThrownBy(() -> completeCommit(coordinator, currentCommitId(), 4L))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected commit failure");
+    assertCheckpoint(1L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void successfulFullCommitResetsLookupFailureCount() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    Coordinator coordinator = startCoordinator();
+    DataFile firstFile = dataFile("first");
+    bufferFile(coordinator, currentCommitId(), firstFile);
+    TableIdentifier movedIdentifier = TableIdentifier.of(NAMESPACE, "unavailable");
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    completeCommit(coordinator, currentCommitId(), 2L);
+
+    catalog.renameTable(movedIdentifier, TABLE_IDENTIFIER);
+    coordinator.process();
+    completeCommit(coordinator, currentCommitId(), 3L);
+    assertFiles(catalog.loadTable(TABLE_IDENTIFIER), firstFile);
+    assertCheckpoint(4L);
+    producer.clear();
+
+    coordinator.process();
+    writeResponse(TABLE_IDENTIFIER, table.uuid(), dataFile("second"), 4L);
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    completeCommit(coordinator, currentCommitId(), 5L);
+    assertCheckpoint(4L);
+    coordinator.process();
+    assertThatThrownBy(() -> completeCommit(coordinator, currentCommitId(), 6L))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("unresolved tables");
+    assertCheckpoint(4L);
+    assertNoCommitComplete();
+  }
+
+  @Test
+  void missingTableRetryDoesNotDuplicateHealthyTableFiles() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    when(config.commitThreads()).thenReturn(2);
+    TableIdentifier healthyIdentifier = TableIdentifier.of(NAMESPACE, "healthy_table");
+    Table healthy = catalog.createTable(healthyIdentifier, SCHEMA);
+    Coordinator coordinator = startCoordinator();
+    DataFile missingFile = dataFile("missing");
+    DataFile healthyFile = dataFile("healthy");
+    bufferFile(coordinator, currentCommitId(), missingFile);
+    writeResponse(healthyIdentifier, healthy.uuid(), healthyFile, 2L);
+    TableIdentifier movedIdentifier = TableIdentifier.of(NAMESPACE, "unavailable");
+    catalog.renameTable(TABLE_IDENTIFIER, movedIdentifier);
+    completeCommit(coordinator, currentCommitId(), 3L);
+    assertCheckpoint(1L);
+    assertFiles(catalog.loadTable(healthyIdentifier), healthyFile);
+    assertNoCommitComplete();
+
+    catalog.renameTable(movedIdentifier, TABLE_IDENTIFIER);
+    coordinator.process();
+    completeCommit(coordinator, currentCommitId(), 4L);
+    assertCheckpoint(5L);
+    assertFiles(catalog.loadTable(TABLE_IDENTIFIER), missingFile);
+    assertFiles(catalog.loadTable(healthyIdentifier), healthyFile);
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .containsExactly(
+            PayloadType.START_COMMIT,
+            PayloadType.COMMIT_TO_TABLE,
+            PayloadType.START_COMMIT,
+            PayloadType.COMMIT_TO_TABLE,
+            PayloadType.COMMIT_COMPLETE);
+  }
+
+  private void writeResponse(
+      TableIdentifier identifier, UUID tableUUID, DataFile file, long offset) {
+    Event event =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId(),
+                TableReference.of("catalog", identifier, tableUUID),
+                List.of(file),
+                List.of()));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset, "key", AvroUtil.encode(event)));
+    activeCoordinator.process();
+  }
+
+  private void assertCheckpoint(long offset) {
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(offset));
+  }
+
+  private void assertNoCommitComplete() {
+    assertThat(producer.history())
+        .extracting(record -> AvroUtil.decode(record.value()).type())
+        .doesNotContain(PayloadType.COMMIT_COMPLETE);
+  }
+
+  private static DataFile dataFile(String name) {
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withPath(name + ".parquet")
+        .withFileSizeInBytes(100)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private static void assertFiles(Table target, DataFile expected) {
+    assertThat(target.snapshots()).hasSize(1);
+    assertThat(
+            SnapshotChanges.builderFor(target)
+                .snapshot(target.currentSnapshot())
+                .build()
+                .addedDataFiles())
+        .extracting(DataFile::location)
+        .containsExactly(expected.location());
+  }
+
+  private Coordinator startCoordinator() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+    MemberAssignment assignment =
+        new MemberAssignment(Set.of(new TopicPartition(SRC_TOPIC_NAME, 0)));
+    MemberDescription member =
+        new MemberDescription("member", Optional.empty(), "client", "host", assignment);
+    this.activeCoordinator =
+        new Coordinator(
+            catalog, config, List.of(member), clientFactory, mock(SinkTaskContext.class));
+    activeCoordinator.start();
+    initConsumer();
+    consumer.commitSync(Map.of(CONTROL_PARTITION, new OffsetAndMetadata(1L)));
+    activeCoordinator.process();
+    return activeCoordinator;
+  }
+
+  private UUID currentCommitId() {
+    return producer.history().stream()
+        .map(record -> AvroUtil.decode(record.value()))
+        .filter(event -> event.type() == PayloadType.START_COMMIT)
+        .map(event -> ((StartCommit) event.payload()).commitId())
+        .reduce((previous, current) -> current)
+        .orElseThrow();
+  }
+
+  private void bufferFile(Coordinator coordinator, UUID commitId, DataFile dataFile) {
+    Event event =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitId,
+                TableReference.of("catalog", TABLE_IDENTIFIER, table.uuid()),
+                List.of(dataFile),
+                List.of()));
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1L, "key", AvroUtil.encode(event)));
+    coordinator.process();
+    assertThat(consumer.committed(Set.of(CONTROL_PARTITION)))
+        .containsEntry(CONTROL_PARTITION, new OffsetAndMetadata(1L));
+    assertThat(table.snapshots()).isEmpty();
+  }
+
+  private void completeCommit(Coordinator coordinator, UUID commitId, long offset) {
+    Event event =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                commitId, List.of(new TopicPartitionOffset(SRC_TOPIC_NAME, 0, offset, null))));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset, "key", AvroUtil.encode(event)));
+    coordinator.process();
+  }
+}


### PR DESCRIPTION
## Problem

`doCommit` carried this comment:

```java
// we should only get here if all tables committed successfully...
commitConsumerOffsets();
commitState.clearResponses();
```

The comment was not true. `commitToTable` returned `void`, and two paths exited
early after only a warning:

```java
} catch (NoSuchTableException e) {
  LOG.warn("Table not found, skipping commit: {}", tableIdentifier, e);
  return;                                      // indistinguishable from success
}

if (tableReference.uuid() != null && !tableReference.uuid().equals(table.uuid())) {
  LOG.warn("Skipping commits to table {} due to target table mismatch. ...");
  return;                                      // indistinguishable from success
}
```

Because nothing propagated, the cycle advanced its control-topic checkpoint past
those responses, cleared them from the buffer, and published `CommitComplete` —
as though the files had been registered.

The worker had already published `DataWritten` and committed its source offsets
in a single Kafka transaction, so the input records are not redelivered. The
data files remain in object storage, referenced by no snapshot.

```mermaid
sequenceDiagram
    autonumber
    participant W as Sink worker
    participant K as Control topic
    participant C as Coordinator
    participant T as Destination table

    W->>K: DataWritten(file X) + source offsets<br/>(one transaction)
    K-->>C: buffer file X
    Note over T: table renamed, dropped,<br/>or replaced with a new UUID
    C->>T: loadTable / UUID check
    T--x C: NoSuchTableException or UUID mismatch
    Note over C: warn, return -- read as success
    C->>K: commitConsumerOffsets()<br/>checkpoint advances past X
    C->>C: clearResponses()<br/>X is discarded
    C->>K: CommitComplete
    Note over C,T: file X is in storage, in no snapshot,<br/>and its source records are already consumed
```

Restoring the original table afterwards does not recover the discarded response.

Retaining the batch and returning normally is not sufficient on its own.
Responses for an old and a new UUID under one table name can then block
completion indefinitely, even after both tables have received their own files.
Returning normally also resets the consecutive-failure counter despite the
incomplete cycle.

## Changes

- Report missing-table and UUID-mismatch outcomes to the enclosing commit.
- Raise a private `IncompleteCommitException` before checkpointing, buffer
  cleanup, or `CommitComplete` publication when any table remains unresolved.
- Reuse `iceberg.control.commit.max-consecutive-failures` for these failures in
  both full and timed-out partial commits. The existing default of `1` fails on
  the first incomplete attempt; higher values permit later-cycle retries.
- Preserve failure accounting until a full commit succeeds, and increment the
  partial-commit failure counter for incomplete partial attempts.
- Preserve UUID validation and per-table snapshot-offset deduplication.
- Document the retry policy and operational recovery constraints.

```mermaid
flowchart TD
    A[doCommit] --> B{every table committed?}
    B -- yes --> C[commitConsumerOffsets]
    C --> D[clearResponses]
    D --> E[publish CommitComplete]
    B -- no --> F[throw IncompleteCommitException]
    F --> G{consecutive failures<br/>below configured limit?}
    G -- yes --> H[keep buffer and checkpoint<br/>retry on a later cycle]
    G -- no --> I[terminate the coordinator<br/>operator resolves the table]

    classDef ok fill:#dcfce7,stroke:#16a34a,color:#14532d
    classDef bad fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
    class C,D,E,H ok
    class F,I bad
```

`IncompleteCommitException` extends `CommitFailedException` so that the existing
retry classification in `commit()` applies without a second code path. It is
private to `Coordinator` and is never thrown across a public boundary.

No new configuration property, dependency, or public API is introduced. Other
partial-commit exception handling is unchanged.

## Behavior and recovery

This deliberately changes missing/replaced-table handling from warn-and-discard
to bounded retry followed by coordinator failure. It does not silently discard
old-identity files, and it does not append them to a replacement table.

The same scenario as the first diagram, after the fix:

```mermaid
sequenceDiagram
    autonumber
    participant W as Sink worker
    participant K as Control topic
    participant C as Coordinator
    participant T as Destination table

    W->>K: DataWritten(file X) + source offsets<br/>(one transaction)
    K-->>C: buffer file X
    Note over T: table renamed, dropped,<br/>or replaced with a new UUID
    C->>T: loadTable / UUID check
    T--x C: NoSuchTableException or UUID mismatch
    Note over C: commitToTable reports false,<br/>doCommit throws IncompleteCommitException
    Note over C,K: checkpoint not advanced,<br/>buffer not cleared,<br/>no CommitComplete published

    alt original table restored within the retry budget
        Note over T: original identifier and UUID restored
        C->>T: loadTable / UUID check
        T-->>C: table
        C->>T: append file X
        T-->>C: snapshot created
        C->>K: commitConsumerOffsets()
        C->>C: clearResponses()
        C->>K: CommitComplete
        Note over C,T: file X is registered exactly once
    else retry budget exhausted
        Note over C: coordinator terminates with<br/>IncompleteCommitException
        Note over C,K: file X is still buffered and still<br/>announced on the control topic
        Note over C,T: operator resolves the table,<br/>then the task restarts
    end
```

Neither branch discards file X, and neither writes it into a replacement table.

| Situation | Before | After |
| --- | --- | --- |
| Table briefly unavailable | checkpoint advances, response discarded | response retained, commits when the table returns |
| Table replaced with a new UUID | replacement protected, original file discarded | replacement protected, original file retained |
| Table permanently gone | silent data loss | bounded retries, then the coordinator fails loudly |
| Other tables in the same batch | committed | still committed, not rolled back |

Temporary unavailability recovers when the original identifier and UUID are
restored within the retry budget. Permanent deletion or replacement, and
buffered responses for multiple UUIDs under one name, require operator
intervention. Raising the retry limit cannot reconcile incompatible identities.

Successful Iceberg commits to other tables are not rolled back. Their buffered
responses stay until the batch completes; the existing snapshot-offset checks
prevent duplicate registration when those responses are retried, provided the
required snapshot history is still available.

The retry limit bounds failed attempts, not the bytes accumulated within an
attempt. The checkpoint is not advanced by an incomplete cycle, so recovery
after a task restart still depends on retained control-topic records and a
suitable consumer starting offset. This change does not alter offset-reset
policy, nor guarantee recovery once control records or deduplication history
have expired.

The initial missing-table behavior of dynamic routing is unchanged and remains
outside this change.

## Regression coverage

`TestCoordinatorTableLookup`, 12 tests covering default and configured limits,
same-UUID recovery, replacement protection, mixed-UUID termination, full and
partial retry accounting, failure-counter preservation and reset, and
deduplication when a healthy table's responses are retried. The mixed-table
cases run with two commit threads and assert file locations, Kafka checkpoints,
and completion-event behavior.

The suite is not vacuous. With the `IncompleteCommitException` throw removed —
restoring the old skip-and-checkpoint behavior — **11 of the 12 fail**; only the
healthy-table case still passes:

```
missingTableFailsAtDefaultRetryLimitWithoutCheckpointing()                    FAILED
missingTableRetainsResponsesAndCommitsThemWhenTheTableReturns()               FAILED
replacementTableIsProtectedAndTheOriginalFileIsCommittedWhenTheTableReturns() FAILED
mixedTableUUIDsFailWithinLimitEvenWhenBothFilesHaveCommitted()                FAILED
missingTableRetryDoesNotDuplicateHealthyTableFiles()                          FAILED
... 12 tests completed, 11 failed
```

## Validation

Validated on 2026-09-08 against base `af86b8399`:

- Full connector unit suite: **145 tests across 19 suites**, zero failures,
  errors, or skips.
- `spotlessCheck`, `checkstyleMain`, and `checkstyleTest` passed.
- `git diff --check` passed.

```sh
./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions=3 \
  :iceberg-kafka-connect:iceberg-kafka-connect:check -x integrationTest --rerun-tasks
```

The tests use an in-memory Iceberg catalog and Kafka mock clients. No
real-broker integration test, coordinator-restart test, or heap stress test was
run.

---

<!-- markdownlint-disable-next-line MD036 -->
**AI Disclosure**

- Model: GPT-6 Astra (implementation, tests, and documentation); Claude Opus 5
  (audit that identified the defect, and review of this change).
- Platform/Tool: GitHub Copilot (implementation); opencode (audit and review).
- Human Oversight: partially reviewed.
- Prompt Summary: An AI audit of the Kafka Connect coordinator identified that
  missing-table and UUID-mismatch commits were checkpointed and discarded as if
  they had succeeded. A second agent implemented bounded-retry handling, the
  regression suite, and the documentation. The first agent then reviewed the
  result and verified the claims independently, including confirming the tests
  fail when the fix is reverted. Code, tests, and this description are
  AI-generated and partially reviewed by the author.
