### PR TITLE
Core, Spark: Reduce remove orphan files join data

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/FileIdentifier.java
+++ b/core/src/main/java/org/apache/iceberg/actions/FileIdentifier.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+
+/**
+ * A normalized file identifier used to compare locations by path, scheme, and authority.
+ *
+ * <p>This type does not retain the original URI string. Use {@link FileURI} when the original
+ * location is required for an operation such as deleting a file.
+ */
+public class FileIdentifier {
+
+  private String authority;
+  private String path;
+  private String scheme;
+
+  public FileIdentifier(String scheme, String authority, String path) {
+    this.scheme = scheme;
+    this.authority = authority;
+    this.path = path;
+  }
+
+  public FileIdentifier(
+      URI uri, Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    this(
+        equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme()),
+        equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority()),
+        uri.getPath());
+  }
+
+  public FileIdentifier() {}
+
+  public String getAuthority() {
+    return authority;
+  }
+
+  public void setAuthority(String authority) {
+    this.authority = authority;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public void setScheme(String scheme) {
+    this.scheme = scheme;
+  }
+
+  public boolean authorityMatch(FileIdentifier another) {
+    return uriComponentMatch(authority, another.getAuthority());
+  }
+
+  public boolean schemeMatch(FileIdentifier another) {
+    return uriComponentMatch(scheme, another.getScheme());
+  }
+
+  private boolean uriComponentMatch(String valid, String actual) {
+    return Strings.isNullOrEmpty(valid) || valid.equalsIgnoreCase(actual);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/FileURI.java
+++ b/core/src/main/java/org/apache/iceberg/actions/FileURI.java
@@ -21,54 +21,28 @@ package org.apache.iceberg.actions;
 import java.net.URI;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
-public class FileURI {
+/**
+ * A normalized file identifier that also retains its original URI string.
+ *
+ * <p>Use {@link FileIdentifier} when only location matching is required so that the original URI is
+ * not retained or transferred unnecessarily.
+ */
+public class FileURI extends FileIdentifier {
 
-  private String scheme;
-  private String authority;
-  private String path;
   private String uriAsString;
 
   public FileURI(String scheme, String authority, String path, String uriAsString) {
-    this.scheme = scheme;
-    this.authority = authority;
-    this.path = path;
+    super(scheme, authority, path);
     this.uriAsString = uriAsString;
   }
 
   public FileURI(URI uri, Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-    this.scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
-    this.authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-    this.path = uri.getPath();
+    super(uri, equalSchemes, equalAuthorities);
     this.uriAsString = uri.toString();
   }
 
   public FileURI() {}
-
-  public String getScheme() {
-    return scheme;
-  }
-
-  public void setScheme(String scheme) {
-    this.scheme = scheme;
-  }
-
-  public String getAuthority() {
-    return authority;
-  }
-
-  public void setAuthority(String authority) {
-    this.authority = authority;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public void setPath(String path) {
-    this.path = path;
-  }
 
   public String getUriAsString() {
     return uriAsString;
@@ -79,23 +53,19 @@ public class FileURI {
   }
 
   public boolean schemeMatch(FileURI another) {
-    return uriComponentMatch(scheme, another.getScheme());
+    return super.schemeMatch(another);
   }
 
   public boolean authorityMatch(FileURI another) {
-    return uriComponentMatch(authority, another.getAuthority());
-  }
-
-  private boolean uriComponentMatch(String valid, String actual) {
-    return Strings.isNullOrEmpty(valid) || valid.equalsIgnoreCase(actual);
+    return super.authorityMatch(another);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("scheme", scheme)
-        .add("authority", authority)
-        .add("path", path)
+        .add("scheme", getScheme())
+        .add("authority", getAuthority())
+        .add("path", getPath())
         .add("uriAsString", uriAsString)
         .toString();
   }

--- a/core/src/test/java/org/apache/iceberg/actions/FileIdentifierTest.java
+++ b/core/src/test/java/org/apache/iceberg/actions/FileIdentifierTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FileIdentifierTest {
+
+  @Test
+  void matchesFileURIByNormalizedComponents() {
+    FileIdentifier identifier = new FileIdentifier("s3", "bucket", "/path");
+    FileIdentifier fileURI = new FileURI("S3", "bucket", "/path", "s3a://bucket/path");
+
+    assertThat(identifier.schemeMatch(fileURI)).isTrue();
+    assertThat(identifier.authorityMatch(fileURI)).isTrue();
+    assertThat(((FileURI) fileURI).getUriAsString()).isEqualTo("s3a://bucket/path");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/actions/TestFileIdentifier.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestFileIdentifier.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class FileIdentifierTest {
+class TestFileIdentifier {
 
   @Test
   void matchesFileURIByNormalizedComponents() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.actions.FileURI;
 import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -118,6 +119,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
   private static final int DELETE_GROUP_SIZE = 100000;
+  private static final Encoder<FileIdentifier> FILE_IDENTIFIER_ENCODER =
+      Encoders.bean(FileIdentifier.class);
+  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -131,7 +135,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
-  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -255,7 +258,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   private DeleteOrphanFiles.Result doExecute() {
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
-    Dataset<FileURI> validFileIdentDS = validFileIdentDS();
+    Dataset<FileIdentifier> validFileIdentDS = validFileIdentDS();
 
     Dataset<String> orphanFileDS =
         findOrphanFiles(actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
@@ -349,7 +352,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @VisibleForTesting
   static Dataset<String> findOrphanFiles(
       Dataset<FileURI> actualFileIdentDS,
-      Dataset<FileURI> validFileIdentDS,
+      Dataset<FileIdentifier> validFileIdentDS,
       PrefixMismatchMode prefixMismatchMode) {
 
     SetAccumulator<Pair<String, String>> conflicts = new SetAccumulator<>();
@@ -388,14 +391,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
   }
 
-  private Dataset<FileURI> validFileIdentDS() {
+  @VisibleForTesting
+  Dataset<FileIdentifier> validFileIdentDS() {
     // transform before union to avoid extra serialization/deserialization
-    FileInfoToFileURI toFileURI = new FileInfoToFileURI(equalSchemes, equalAuthorities);
+    FileInfoToFileIdentifier toFileIdentifier =
+        new FileInfoToFileIdentifier(equalSchemes, equalAuthorities);
 
-    Dataset<FileURI> contentFileIdentDS = toFileURI.apply(contentFileDS(table));
-    Dataset<FileURI> manifestFileIdentDS = toFileURI.apply(manifestDS(table));
-    Dataset<FileURI> manifestListIdentDS = toFileURI.apply(manifestListDS(table));
-    Dataset<FileURI> otherMetadataFileIdentDS = toFileURI.apply(otherMetadataFileDS(table));
+    Dataset<FileIdentifier> contentFileIdentDS = toFileIdentifier.apply(contentFileDS(table));
+    Dataset<FileIdentifier> manifestFileIdentDS = toFileIdentifier.apply(manifestDS(table));
+    Dataset<FileIdentifier> manifestListIdentDS = toFileIdentifier.apply(manifestListDS(table));
+    Dataset<FileIdentifier> otherMetadataFileIdentDS =
+        toFileIdentifier.apply(otherMetadataFileDS(table));
 
     return contentFileIdentDS
         .union(manifestFileIdentDS)
@@ -524,7 +530,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private static class FindOrphanFiles
-      implements MapPartitionsFunction<Tuple2<FileURI, FileURI>, String> {
+      implements MapPartitionsFunction<Tuple2<FileURI, FileIdentifier>, String> {
 
     private final PrefixMismatchMode mode;
     private final SetAccumulator<Pair<String, String>> conflicts;
@@ -535,14 +541,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
 
     @Override
-    public Iterator<String> call(Iterator<Tuple2<FileURI, FileURI>> rows) throws Exception {
+    public Iterator<String> call(Iterator<Tuple2<FileURI, FileIdentifier>> rows) throws Exception {
       Iterator<String> orphanFiles = Iterators.transform(rows, this::toOrphanFile);
       return Iterators.filter(orphanFiles, Objects::nonNull);
     }
 
-    private String toOrphanFile(Tuple2<FileURI, FileURI> row) {
+    private String toOrphanFile(Tuple2<FileURI, FileIdentifier> row) {
       FileURI actual = row._1;
-      FileURI valid = row._2;
+      FileIdentifier valid = row._2;
 
       if (valid == null) {
         return actual.getUriAsString();
@@ -568,56 +574,77 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   @VisibleForTesting
-  static class StringToFileURI extends ToFileURI<String> {
+  static class StringToFileURI extends ToFileIdentifier<String, FileURI> {
     StringToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+      super(equalSchemes, equalAuthorities, FILE_URI_ENCODER);
     }
 
     @Override
     protected String uriAsString(String input) {
       return input;
     }
+
+    @Override
+    protected FileURI newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileURI(scheme, authority, path, uriAsString);
+    }
   }
 
-  @VisibleForTesting
-  static class FileInfoToFileURI extends ToFileURI<FileInfo> {
-    FileInfoToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+  private static class FileInfoToFileIdentifier extends ToFileIdentifier<FileInfo, FileIdentifier> {
+    FileInfoToFileIdentifier(
+        Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+      super(equalSchemes, equalAuthorities, FILE_IDENTIFIER_ENCODER);
     }
 
     @Override
     protected String uriAsString(FileInfo fileInfo) {
       return fileInfo.getPath();
     }
+
+    @Override
+    protected FileIdentifier newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileIdentifier(scheme, authority, path);
+    }
   }
 
-  private abstract static class ToFileURI<I> implements MapPartitionsFunction<I, FileURI> {
+  private abstract static class ToFileIdentifier<I, O extends FileIdentifier>
+      implements MapPartitionsFunction<I, O> {
 
-    private final Map<String, String> equalSchemes;
+    private final Encoder<O> encoder;
     private final Map<String, String> equalAuthorities;
+    private final Map<String, String> equalSchemes;
 
-    ToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    ToFileIdentifier(
+        Map<String, String> equalSchemes,
+        Map<String, String> equalAuthorities,
+        Encoder<O> encoder) {
       this.equalSchemes = equalSchemes;
       this.equalAuthorities = equalAuthorities;
+      this.encoder = encoder;
     }
 
     protected abstract String uriAsString(I input);
 
-    Dataset<FileURI> apply(Dataset<I> ds) {
-      return ds.mapPartitions(this, FILE_URI_ENCODER);
+    protected abstract O newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString);
+
+    Dataset<O> apply(Dataset<I> ds) {
+      return ds.mapPartitions(this, encoder);
     }
 
     @Override
-    public Iterator<FileURI> call(Iterator<I> rows) throws Exception {
-      return Iterators.transform(rows, this::toFileURI);
+    public Iterator<O> call(Iterator<I> rows) throws Exception {
+      return Iterators.transform(rows, this::toFileIdentifier);
     }
 
-    private FileURI toFileURI(I input) {
+    private O toFileIdentifier(I input) {
       String uriAsString = uriAsString(input);
       URI uri = new Path(uriAsString).toUri();
       String scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
       String authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-      return new FileURI(scheme, authority, uri.getPath(), uriAsString);
+      return newFileIdentifier(scheme, authority, uri.getPath(), uriAsString);
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -1194,6 +1195,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testValidFileIdentifiersExcludeURI() {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    DeleteOrphanFilesSparkAction action = SparkActions.get().deleteOrphanFiles(table);
+
+    Dataset<FileIdentifier> validFileIdentDS = action.validFileIdentDS();
+
+    assertThat(validFileIdentDS.columns()).containsExactlyInAnyOrder("path", "scheme", "authority");
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1248,14 +1259,21 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
       Map<String, String> equalAuthorities,
       DeleteOrphanFiles.PrefixMismatchMode mode) {
 
-    StringToFileURI toFileUri = new StringToFileURI(equalSchemes, equalAuthorities);
+    StringToFileURI toFileURI = new StringToFileURI(equalSchemes, equalAuthorities);
 
-    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
     Dataset<String> actualFileDS = spark.createDataset(actualFiles, Encoders.STRING());
+    List<FileIdentifier> validFileIdentifiers =
+        validFiles.stream()
+            .map(
+                location ->
+                    new FileIdentifier(new Path(location).toUri(), equalSchemes, equalAuthorities))
+            .collect(Collectors.toList());
+    Dataset<FileIdentifier> validFileIdentDS =
+        spark.createDataset(validFileIdentifiers, Encoders.bean(FileIdentifier.class));
 
     Dataset<String> orphanFileDS =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
-            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+            toFileURI.apply(actualFileDS), validFileIdentDS, mode);
 
     List<String> orphanFiles = orphanFileDS.collectAsList();
     orphanFileDS.unpersist();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.actions.FileURI;
 import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -118,6 +119,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
   private static final int DELETE_GROUP_SIZE = 100000;
+  private static final Encoder<FileIdentifier> FILE_IDENTIFIER_ENCODER =
+      Encoders.bean(FileIdentifier.class);
+  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -131,7 +135,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
-  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -255,7 +258,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   private DeleteOrphanFiles.Result doExecute() {
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
-    Dataset<FileURI> validFileIdentDS = validFileIdentDS();
+    Dataset<FileIdentifier> validFileIdentDS = validFileIdentDS();
 
     Dataset<String> orphanFileDS =
         findOrphanFiles(actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
@@ -349,7 +352,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @VisibleForTesting
   static Dataset<String> findOrphanFiles(
       Dataset<FileURI> actualFileIdentDS,
-      Dataset<FileURI> validFileIdentDS,
+      Dataset<FileIdentifier> validFileIdentDS,
       PrefixMismatchMode prefixMismatchMode) {
 
     SetAccumulator<Pair<String, String>> conflicts = new SetAccumulator<>();
@@ -388,14 +391,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
   }
 
-  private Dataset<FileURI> validFileIdentDS() {
+  @VisibleForTesting
+  Dataset<FileIdentifier> validFileIdentDS() {
     // transform before union to avoid extra serialization/deserialization
-    FileInfoToFileURI toFileURI = new FileInfoToFileURI(equalSchemes, equalAuthorities);
+    FileInfoToFileIdentifier toFileIdentifier =
+        new FileInfoToFileIdentifier(equalSchemes, equalAuthorities);
 
-    Dataset<FileURI> contentFileIdentDS = toFileURI.apply(contentFileDS(table));
-    Dataset<FileURI> manifestFileIdentDS = toFileURI.apply(manifestDS(table));
-    Dataset<FileURI> manifestListIdentDS = toFileURI.apply(manifestListDS(table));
-    Dataset<FileURI> otherMetadataFileIdentDS = toFileURI.apply(otherMetadataFileDS(table));
+    Dataset<FileIdentifier> contentFileIdentDS = toFileIdentifier.apply(contentFileDS(table));
+    Dataset<FileIdentifier> manifestFileIdentDS = toFileIdentifier.apply(manifestDS(table));
+    Dataset<FileIdentifier> manifestListIdentDS = toFileIdentifier.apply(manifestListDS(table));
+    Dataset<FileIdentifier> otherMetadataFileIdentDS =
+        toFileIdentifier.apply(otherMetadataFileDS(table));
 
     return contentFileIdentDS
         .union(manifestFileIdentDS)
@@ -524,7 +530,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private static class FindOrphanFiles
-      implements MapPartitionsFunction<Tuple2<FileURI, FileURI>, String> {
+      implements MapPartitionsFunction<Tuple2<FileURI, FileIdentifier>, String> {
 
     private final PrefixMismatchMode mode;
     private final SetAccumulator<Pair<String, String>> conflicts;
@@ -535,14 +541,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
 
     @Override
-    public Iterator<String> call(Iterator<Tuple2<FileURI, FileURI>> rows) throws Exception {
+    public Iterator<String> call(Iterator<Tuple2<FileURI, FileIdentifier>> rows) throws Exception {
       Iterator<String> orphanFiles = Iterators.transform(rows, this::toOrphanFile);
       return Iterators.filter(orphanFiles, Objects::nonNull);
     }
 
-    private String toOrphanFile(Tuple2<FileURI, FileURI> row) {
+    private String toOrphanFile(Tuple2<FileURI, FileIdentifier> row) {
       FileURI actual = row._1;
-      FileURI valid = row._2;
+      FileIdentifier valid = row._2;
 
       if (valid == null) {
         return actual.getUriAsString();
@@ -568,56 +574,77 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   @VisibleForTesting
-  static class StringToFileURI extends ToFileURI<String> {
+  static class StringToFileURI extends ToFileIdentifier<String, FileURI> {
     StringToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+      super(equalSchemes, equalAuthorities, FILE_URI_ENCODER);
     }
 
     @Override
     protected String uriAsString(String input) {
       return input;
     }
+
+    @Override
+    protected FileURI newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileURI(scheme, authority, path, uriAsString);
+    }
   }
 
-  @VisibleForTesting
-  static class FileInfoToFileURI extends ToFileURI<FileInfo> {
-    FileInfoToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+  private static class FileInfoToFileIdentifier extends ToFileIdentifier<FileInfo, FileIdentifier> {
+    FileInfoToFileIdentifier(
+        Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+      super(equalSchemes, equalAuthorities, FILE_IDENTIFIER_ENCODER);
     }
 
     @Override
     protected String uriAsString(FileInfo fileInfo) {
       return fileInfo.getPath();
     }
+
+    @Override
+    protected FileIdentifier newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileIdentifier(scheme, authority, path);
+    }
   }
 
-  private abstract static class ToFileURI<I> implements MapPartitionsFunction<I, FileURI> {
+  private abstract static class ToFileIdentifier<I, O extends FileIdentifier>
+      implements MapPartitionsFunction<I, O> {
 
-    private final Map<String, String> equalSchemes;
+    private final Encoder<O> encoder;
     private final Map<String, String> equalAuthorities;
+    private final Map<String, String> equalSchemes;
 
-    ToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    ToFileIdentifier(
+        Map<String, String> equalSchemes,
+        Map<String, String> equalAuthorities,
+        Encoder<O> encoder) {
       this.equalSchemes = equalSchemes;
       this.equalAuthorities = equalAuthorities;
+      this.encoder = encoder;
     }
 
     protected abstract String uriAsString(I input);
 
-    Dataset<FileURI> apply(Dataset<I> ds) {
-      return ds.mapPartitions(this, FILE_URI_ENCODER);
+    protected abstract O newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString);
+
+    Dataset<O> apply(Dataset<I> ds) {
+      return ds.mapPartitions(this, encoder);
     }
 
     @Override
-    public Iterator<FileURI> call(Iterator<I> rows) throws Exception {
-      return Iterators.transform(rows, this::toFileURI);
+    public Iterator<O> call(Iterator<I> rows) throws Exception {
+      return Iterators.transform(rows, this::toFileIdentifier);
     }
 
-    private FileURI toFileURI(I input) {
+    private O toFileIdentifier(I input) {
       String uriAsString = uriAsString(input);
       URI uri = new Path(uriAsString).toUri();
       String scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
       String authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-      return new FileURI(scheme, authority, uri.getPath(), uriAsString);
+      return newFileIdentifier(scheme, authority, uri.getPath(), uriAsString);
     }
   }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -1194,6 +1195,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testValidFileIdentifiersExcludeURI() {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    DeleteOrphanFilesSparkAction action = SparkActions.get().deleteOrphanFiles(table);
+
+    Dataset<FileIdentifier> validFileIdentDS = action.validFileIdentDS();
+
+    assertThat(validFileIdentDS.columns()).containsExactlyInAnyOrder("path", "scheme", "authority");
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1248,14 +1259,21 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
       Map<String, String> equalAuthorities,
       DeleteOrphanFiles.PrefixMismatchMode mode) {
 
-    StringToFileURI toFileUri = new StringToFileURI(equalSchemes, equalAuthorities);
+    StringToFileURI toFileURI = new StringToFileURI(equalSchemes, equalAuthorities);
 
-    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
     Dataset<String> actualFileDS = spark.createDataset(actualFiles, Encoders.STRING());
+    List<FileIdentifier> validFileIdentifiers =
+        validFiles.stream()
+            .map(
+                location ->
+                    new FileIdentifier(new Path(location).toUri(), equalSchemes, equalAuthorities))
+            .collect(Collectors.toList());
+    Dataset<FileIdentifier> validFileIdentDS =
+        spark.createDataset(validFileIdentifiers, Encoders.bean(FileIdentifier.class));
 
     Dataset<String> orphanFileDS =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
-            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+            toFileURI.apply(actualFileDS), validFileIdentDS, mode);
 
     List<String> orphanFiles = orphanFileDS.collectAsList();
     orphanFileDS.unpersist();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.actions.FileURI;
 import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -118,6 +119,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
   private static final int DELETE_GROUP_SIZE = 100000;
+  private static final Encoder<FileIdentifier> FILE_IDENTIFIER_ENCODER =
+      Encoders.bean(FileIdentifier.class);
+  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -131,7 +135,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
-  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -255,7 +258,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   private DeleteOrphanFiles.Result doExecute() {
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
-    Dataset<FileURI> validFileIdentDS = validFileIdentDS();
+    Dataset<FileIdentifier> validFileIdentDS = validFileIdentDS();
 
     Dataset<String> orphanFileDS =
         findOrphanFiles(actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
@@ -349,7 +352,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @VisibleForTesting
   static Dataset<String> findOrphanFiles(
       Dataset<FileURI> actualFileIdentDS,
-      Dataset<FileURI> validFileIdentDS,
+      Dataset<FileIdentifier> validFileIdentDS,
       PrefixMismatchMode prefixMismatchMode) {
 
     SetAccumulator<Pair<String, String>> conflicts = new SetAccumulator<>();
@@ -388,14 +391,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
   }
 
-  private Dataset<FileURI> validFileIdentDS() {
+  @VisibleForTesting
+  Dataset<FileIdentifier> validFileIdentDS() {
     // transform before union to avoid extra serialization/deserialization
-    FileInfoToFileURI toFileURI = new FileInfoToFileURI(equalSchemes, equalAuthorities);
+    FileInfoToFileIdentifier toFileIdentifier =
+        new FileInfoToFileIdentifier(equalSchemes, equalAuthorities);
 
-    Dataset<FileURI> contentFileIdentDS = toFileURI.apply(contentFileDS(table));
-    Dataset<FileURI> manifestFileIdentDS = toFileURI.apply(manifestDS(table));
-    Dataset<FileURI> manifestListIdentDS = toFileURI.apply(manifestListDS(table));
-    Dataset<FileURI> otherMetadataFileIdentDS = toFileURI.apply(otherMetadataFileDS(table));
+    Dataset<FileIdentifier> contentFileIdentDS = toFileIdentifier.apply(contentFileDS(table));
+    Dataset<FileIdentifier> manifestFileIdentDS = toFileIdentifier.apply(manifestDS(table));
+    Dataset<FileIdentifier> manifestListIdentDS = toFileIdentifier.apply(manifestListDS(table));
+    Dataset<FileIdentifier> otherMetadataFileIdentDS =
+        toFileIdentifier.apply(otherMetadataFileDS(table));
 
     return contentFileIdentDS
         .union(manifestFileIdentDS)
@@ -524,7 +530,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private static class FindOrphanFiles
-      implements MapPartitionsFunction<Tuple2<FileURI, FileURI>, String> {
+      implements MapPartitionsFunction<Tuple2<FileURI, FileIdentifier>, String> {
 
     private final PrefixMismatchMode mode;
     private final SetAccumulator<Pair<String, String>> conflicts;
@@ -535,14 +541,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
 
     @Override
-    public Iterator<String> call(Iterator<Tuple2<FileURI, FileURI>> rows) throws Exception {
+    public Iterator<String> call(Iterator<Tuple2<FileURI, FileIdentifier>> rows) throws Exception {
       Iterator<String> orphanFiles = Iterators.transform(rows, this::toOrphanFile);
       return Iterators.filter(orphanFiles, Objects::nonNull);
     }
 
-    private String toOrphanFile(Tuple2<FileURI, FileURI> row) {
+    private String toOrphanFile(Tuple2<FileURI, FileIdentifier> row) {
       FileURI actual = row._1;
-      FileURI valid = row._2;
+      FileIdentifier valid = row._2;
 
       if (valid == null) {
         return actual.getUriAsString();
@@ -568,56 +574,77 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   @VisibleForTesting
-  static class StringToFileURI extends ToFileURI<String> {
+  static class StringToFileURI extends ToFileIdentifier<String, FileURI> {
     StringToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+      super(equalSchemes, equalAuthorities, FILE_URI_ENCODER);
     }
 
     @Override
     protected String uriAsString(String input) {
       return input;
     }
+
+    @Override
+    protected FileURI newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileURI(scheme, authority, path, uriAsString);
+    }
   }
 
-  @VisibleForTesting
-  static class FileInfoToFileURI extends ToFileURI<FileInfo> {
-    FileInfoToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+  private static class FileInfoToFileIdentifier extends ToFileIdentifier<FileInfo, FileIdentifier> {
+    FileInfoToFileIdentifier(
+        Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+      super(equalSchemes, equalAuthorities, FILE_IDENTIFIER_ENCODER);
     }
 
     @Override
     protected String uriAsString(FileInfo fileInfo) {
       return fileInfo.getPath();
     }
+
+    @Override
+    protected FileIdentifier newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileIdentifier(scheme, authority, path);
+    }
   }
 
-  private abstract static class ToFileURI<I> implements MapPartitionsFunction<I, FileURI> {
+  private abstract static class ToFileIdentifier<I, O extends FileIdentifier>
+      implements MapPartitionsFunction<I, O> {
 
-    private final Map<String, String> equalSchemes;
+    private final Encoder<O> encoder;
     private final Map<String, String> equalAuthorities;
+    private final Map<String, String> equalSchemes;
 
-    ToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    ToFileIdentifier(
+        Map<String, String> equalSchemes,
+        Map<String, String> equalAuthorities,
+        Encoder<O> encoder) {
       this.equalSchemes = equalSchemes;
       this.equalAuthorities = equalAuthorities;
+      this.encoder = encoder;
     }
 
     protected abstract String uriAsString(I input);
 
-    Dataset<FileURI> apply(Dataset<I> ds) {
-      return ds.mapPartitions(this, FILE_URI_ENCODER);
+    protected abstract O newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString);
+
+    Dataset<O> apply(Dataset<I> ds) {
+      return ds.mapPartitions(this, encoder);
     }
 
     @Override
-    public Iterator<FileURI> call(Iterator<I> rows) throws Exception {
-      return Iterators.transform(rows, this::toFileURI);
+    public Iterator<O> call(Iterator<I> rows) throws Exception {
+      return Iterators.transform(rows, this::toFileIdentifier);
     }
 
-    private FileURI toFileURI(I input) {
+    private O toFileIdentifier(I input) {
       String uriAsString = uriAsString(input);
       URI uri = new Path(uriAsString).toUri();
       String scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
       String authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-      return new FileURI(scheme, authority, uri.getPath(), uriAsString);
+      return newFileIdentifier(scheme, authority, uri.getPath(), uriAsString);
     }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -1195,6 +1196,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testValidFileIdentifiersExcludeURI() {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    DeleteOrphanFilesSparkAction action = SparkActions.get().deleteOrphanFiles(table);
+
+    Dataset<FileIdentifier> validFileIdentDS = action.validFileIdentDS();
+
+    assertThat(validFileIdentDS.columns()).containsExactlyInAnyOrder("path", "scheme", "authority");
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1249,14 +1260,21 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
       Map<String, String> equalAuthorities,
       DeleteOrphanFiles.PrefixMismatchMode mode) {
 
-    StringToFileURI toFileUri = new StringToFileURI(equalSchemes, equalAuthorities);
+    StringToFileURI toFileURI = new StringToFileURI(equalSchemes, equalAuthorities);
 
-    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
     Dataset<String> actualFileDS = spark.createDataset(actualFiles, Encoders.STRING());
+    List<FileIdentifier> validFileIdentifiers =
+        validFiles.stream()
+            .map(
+                location ->
+                    new FileIdentifier(new Path(location).toUri(), equalSchemes, equalAuthorities))
+            .collect(Collectors.toList());
+    Dataset<FileIdentifier> validFileIdentDS =
+        spark.createDataset(validFileIdentifiers, Encoders.bean(FileIdentifier.class));
 
     Dataset<String> orphanFileDS =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
-            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+            toFileURI.apply(actualFileDS), validFileIdentDS, mode);
 
     List<String> orphanFiles = orphanFileDS.collectAsList();
     orphanFileDS.unpersist();

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.actions.FileURI;
 import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -118,6 +119,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
   private static final int DELETE_GROUP_SIZE = 100000;
+  private static final Encoder<FileIdentifier> FILE_IDENTIFIER_ENCODER =
+      Encoders.bean(FileIdentifier.class);
+  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -131,7 +135,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
-  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -255,7 +258,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   private DeleteOrphanFiles.Result doExecute() {
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
-    Dataset<FileURI> validFileIdentDS = validFileIdentDS();
+    Dataset<FileIdentifier> validFileIdentDS = validFileIdentDS();
 
     Dataset<String> orphanFileDS =
         findOrphanFiles(actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
@@ -349,7 +352,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @VisibleForTesting
   static Dataset<String> findOrphanFiles(
       Dataset<FileURI> actualFileIdentDS,
-      Dataset<FileURI> validFileIdentDS,
+      Dataset<FileIdentifier> validFileIdentDS,
       PrefixMismatchMode prefixMismatchMode) {
 
     SetAccumulator<Pair<String, String>> conflicts = new SetAccumulator<>();
@@ -388,14 +391,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
   }
 
-  private Dataset<FileURI> validFileIdentDS() {
+  @VisibleForTesting
+  Dataset<FileIdentifier> validFileIdentDS() {
     // transform before union to avoid extra serialization/deserialization
-    FileInfoToFileURI toFileURI = new FileInfoToFileURI(equalSchemes, equalAuthorities);
+    FileInfoToFileIdentifier toFileIdentifier =
+        new FileInfoToFileIdentifier(equalSchemes, equalAuthorities);
 
-    Dataset<FileURI> contentFileIdentDS = toFileURI.apply(contentFileDS(table));
-    Dataset<FileURI> manifestFileIdentDS = toFileURI.apply(manifestDS(table));
-    Dataset<FileURI> manifestListIdentDS = toFileURI.apply(manifestListDS(table));
-    Dataset<FileURI> otherMetadataFileIdentDS = toFileURI.apply(otherMetadataFileDS(table));
+    Dataset<FileIdentifier> contentFileIdentDS = toFileIdentifier.apply(contentFileDS(table));
+    Dataset<FileIdentifier> manifestFileIdentDS = toFileIdentifier.apply(manifestDS(table));
+    Dataset<FileIdentifier> manifestListIdentDS = toFileIdentifier.apply(manifestListDS(table));
+    Dataset<FileIdentifier> otherMetadataFileIdentDS =
+        toFileIdentifier.apply(otherMetadataFileDS(table));
 
     return contentFileIdentDS
         .union(manifestFileIdentDS)
@@ -524,7 +530,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private static class FindOrphanFiles
-      implements MapPartitionsFunction<Tuple2<FileURI, FileURI>, String> {
+      implements MapPartitionsFunction<Tuple2<FileURI, FileIdentifier>, String> {
 
     private final PrefixMismatchMode mode;
     private final SetAccumulator<Pair<String, String>> conflicts;
@@ -535,14 +541,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     }
 
     @Override
-    public Iterator<String> call(Iterator<Tuple2<FileURI, FileURI>> rows) throws Exception {
+    public Iterator<String> call(Iterator<Tuple2<FileURI, FileIdentifier>> rows) throws Exception {
       Iterator<String> orphanFiles = Iterators.transform(rows, this::toOrphanFile);
       return Iterators.filter(orphanFiles, Objects::nonNull);
     }
 
-    private String toOrphanFile(Tuple2<FileURI, FileURI> row) {
+    private String toOrphanFile(Tuple2<FileURI, FileIdentifier> row) {
       FileURI actual = row._1;
-      FileURI valid = row._2;
+      FileIdentifier valid = row._2;
 
       if (valid == null) {
         return actual.getUriAsString();
@@ -568,56 +574,77 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   @VisibleForTesting
-  static class StringToFileURI extends ToFileURI<String> {
+  static class StringToFileURI extends ToFileIdentifier<String, FileURI> {
     StringToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+      super(equalSchemes, equalAuthorities, FILE_URI_ENCODER);
     }
 
     @Override
     protected String uriAsString(String input) {
       return input;
     }
+
+    @Override
+    protected FileURI newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileURI(scheme, authority, path, uriAsString);
+    }
   }
 
-  @VisibleForTesting
-  static class FileInfoToFileURI extends ToFileURI<FileInfo> {
-    FileInfoToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-      super(equalSchemes, equalAuthorities);
+  private static class FileInfoToFileIdentifier extends ToFileIdentifier<FileInfo, FileIdentifier> {
+    FileInfoToFileIdentifier(
+        Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+      super(equalSchemes, equalAuthorities, FILE_IDENTIFIER_ENCODER);
     }
 
     @Override
     protected String uriAsString(FileInfo fileInfo) {
       return fileInfo.getPath();
     }
+
+    @Override
+    protected FileIdentifier newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString) {
+      return new FileIdentifier(scheme, authority, path);
+    }
   }
 
-  private abstract static class ToFileURI<I> implements MapPartitionsFunction<I, FileURI> {
+  private abstract static class ToFileIdentifier<I, O extends FileIdentifier>
+      implements MapPartitionsFunction<I, O> {
 
-    private final Map<String, String> equalSchemes;
+    private final Encoder<O> encoder;
     private final Map<String, String> equalAuthorities;
+    private final Map<String, String> equalSchemes;
 
-    ToFileURI(Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    ToFileIdentifier(
+        Map<String, String> equalSchemes,
+        Map<String, String> equalAuthorities,
+        Encoder<O> encoder) {
       this.equalSchemes = equalSchemes;
       this.equalAuthorities = equalAuthorities;
+      this.encoder = encoder;
     }
 
     protected abstract String uriAsString(I input);
 
-    Dataset<FileURI> apply(Dataset<I> ds) {
-      return ds.mapPartitions(this, FILE_URI_ENCODER);
+    protected abstract O newFileIdentifier(
+        String scheme, String authority, String path, String uriAsString);
+
+    Dataset<O> apply(Dataset<I> ds) {
+      return ds.mapPartitions(this, encoder);
     }
 
     @Override
-    public Iterator<FileURI> call(Iterator<I> rows) throws Exception {
-      return Iterators.transform(rows, this::toFileURI);
+    public Iterator<O> call(Iterator<I> rows) throws Exception {
+      return Iterators.transform(rows, this::toFileIdentifier);
     }
 
-    private FileURI toFileURI(I input) {
+    private O toFileIdentifier(I input) {
       String uriAsString = uriAsString(input);
       URI uri = new Path(uriAsString).toUri();
       String scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
       String authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-      return new FileURI(scheme, authority, uri.getPath(), uriAsString);
+      return newFileIdentifier(scheme, authority, uri.getPath(), uriAsString);
     }
   }
 }

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileIdentifier;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -1195,6 +1196,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testValidFileIdentifiersExcludeURI() {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    DeleteOrphanFilesSparkAction action = SparkActions.get().deleteOrphanFiles(table);
+
+    Dataset<FileIdentifier> validFileIdentDS = action.validFileIdentDS();
+
+    assertThat(validFileIdentDS.columns()).containsExactlyInAnyOrder("path", "scheme", "authority");
+  }
+
+  @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
         .as(
@@ -1249,14 +1260,21 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
       Map<String, String> equalAuthorities,
       DeleteOrphanFiles.PrefixMismatchMode mode) {
 
-    StringToFileURI toFileUri = new StringToFileURI(equalSchemes, equalAuthorities);
+    StringToFileURI toFileURI = new StringToFileURI(equalSchemes, equalAuthorities);
 
-    Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
     Dataset<String> actualFileDS = spark.createDataset(actualFiles, Encoders.STRING());
+    List<FileIdentifier> validFileIdentifiers =
+        validFiles.stream()
+            .map(
+                location ->
+                    new FileIdentifier(new Path(location).toUri(), equalSchemes, equalAuthorities))
+            .collect(Collectors.toList());
+    Dataset<FileIdentifier> validFileIdentDS =
+        spark.createDataset(validFileIdentifiers, Encoders.bean(FileIdentifier.class));
 
     Dataset<String> orphanFileDS =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
-            toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
+            toFileURI.apply(actualFileDS), validFileIdentDS, mode);
 
     List<String> orphanFiles = orphanFileDS.collectAsList();
     orphanFileDS.unpersist();


### PR DESCRIPTION
Separate normalized file identity from the original URI. Spark now uses `FileIdentifier` for the valid-file side of the orphan-file join, so it shuffles only `path`, `scheme`, and `authority`.

## Why

The valid-file side previously used `FileURI`, including `uriAsString`. Matching does not use this duplicate URI string, but Spark still transferred it during the join. This adds network and sort data for tables with many files.

## How it works

`FileIdentifier` contains the normalized fields required for matching. `FileURI` extends it and retains the original URI string required for deletion and output.

The valid-file dataset now uses `Dataset<FileIdentifier>`, while listed files continue to use `Dataset<FileURI>`. The change is applied to Spark 3.5, 4.0, 4.1, and 4.2.

## Testing

- Full remove-orphan action tests for Spark 3.5–4.2
- Core `FileIdentifier` and `FileURI` tests
- Core Revapi compatibility check
- Flink 2.3 compilation
- Spotless checks