### PR TITLE
Core: (Nit) Encrypt manifest output files directly

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -625,8 +624,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     String manifestFileLocation =
         ops.metadataFileLocation(
             manifestFormat.addExtension(commitUUID + "-m" + manifestCount.getAndIncrement()));
-    return EncryptingFileIO.combine(ops.io(), ops.encryption())
-        .newEncryptingOutputFile(manifestFileLocation);
+    OutputFile rawOutputFile = ops.io().newOutputFile(manifestFileLocation);
+    return ops.encryption().encrypt(rawOutputFile);
   }
 
   protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec spec) {


### PR DESCRIPTION
No behaviour change - see https://github.com/apache/iceberg/pull/17987#discussion_r3957907385 for motivation. This makes the encryption more explicit rather than the code reading that we're constructing a new IO for every file (in reality, we're not due to https://github.com/apache/iceberg/pull/17987#discussion_r3957858236, but this code change arguably makes that clearer, arguably doesn't).

As mentioned in https://github.com/apache/iceberg/pull/17987#discussion_r3957907385 this is mostly just for consistency, so I want to wait to see what we decide in https://github.com/apache/iceberg/pull/17987. If we decide against this change, I'll close this PR out.