### PR TITLE
Core: [2/N] Send the referenced-by view chain to REST catalogs

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
@@ -111,10 +111,14 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
     return httpClient()
         .get(
             credentialsEndpoint,
-            null != planId ? Map.of("planId", planId) : null,
+            credentialsQueryParams(),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
+  }
+
+  private Map<String, String> credentialsQueryParams() {
+    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   private Optional<RefreshResult<AwsCredentials>> credentialFromProperties() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.HTTPClient;
-import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.auth.AuthManager;
@@ -52,7 +51,6 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
   private final CachedSupplier<AwsCredentials> credentialCache;
   private final String catalogEndpoint;
   private final String credentialsEndpoint;
-  private final String planId;
   private AuthManager authManager;
   private AuthSession authSession;
 
@@ -68,7 +66,6 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
             .build();
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
     this.credentialsEndpoint = properties.get(URI);
-    this.planId = properties.getOrDefault(RESTCatalogProperties.REST_SCAN_PLAN_ID, null);
   }
 
   @Override
@@ -111,14 +108,10 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
     return httpClient()
         .get(
             credentialsEndpoint,
-            credentialsQueryParams(),
+            RESTUtil.credentialsQueryParams(properties),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
-  }
-
-  private Map<String, String> credentialsQueryParams() {
-    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   private Optional<RefreshResult<AwsCredentials>> credentialFromProperties() {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestVendedCredentialsProvider.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestVendedCredentialsProvider.java
@@ -538,6 +538,53 @@ public class TestVendedCredentialsProvider {
     mockServer.verify(mockRequest, VerificationTimes.exactly(2));
   }
 
+  @Test
+  public void planIdAndReferencedByQueryParamsAreSent() {
+    String planId = "randomPlanId";
+    String encodedChain = "prod%1Fanalytics%1Fquarterly_view,prod%1Fanalytics%1Fmonthly_view";
+    String decodedChain =
+        "prod\u001Fanalytics\u001Fquarterly_view,prod\u001Fanalytics\u001Fmonthly_view";
+    HttpRequest mockRequest =
+        request("/v1/credentials")
+            .withMethod(HttpMethod.GET.name())
+            .withQueryStringParameter(RESTCatalogProperties.PLAN_ID_QUERY_PARAMETER, planId)
+            .withQueryStringParameter(
+                RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, decodedChain);
+    Credential credential =
+        ImmutableCredential.builder()
+            .prefix("s3")
+            .config(
+                ImmutableMap.of(
+                    S3FileIOProperties.ACCESS_KEY_ID,
+                    "randomAccessKey",
+                    S3FileIOProperties.SECRET_ACCESS_KEY,
+                    "randomSecretAccessKey",
+                    S3FileIOProperties.SESSION_TOKEN,
+                    "sessionToken",
+                    S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS,
+                    Long.toString(Instant.now().plus(1, ChronoUnit.MINUTES).toEpochMilli())))
+            .build();
+    LoadCredentialsResponse response =
+        ImmutableLoadCredentialsResponse.builder().addCredentials(credential).build();
+
+    mockServer
+        .when(mockRequest)
+        .respond(response(LoadCredentialsResponseParser.toJson(response)).withStatusCode(200));
+
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .putAll(PROPERTIES)
+            .put(RESTCatalogProperties.REST_SCAN_PLAN_ID, planId)
+            .put(RESTCatalogProperties.REST_REFERENCED_BY, encodedChain)
+            .build();
+
+    try (VendedCredentialsProvider provider = VendedCredentialsProvider.create(properties)) {
+      verifyCredentials(provider.resolveCredentials(), credential);
+    }
+
+    mockServer.verify(mockRequest, VerificationTimes.once());
+  }
+
   private void verifyCredentials(AwsCredentials awsCredentials, Credential credential) {
     assertThat(awsCredentials).isInstanceOf(AwsSessionCredentials.class);
     AwsSessionCredentials creds = (AwsSessionCredentials) awsCredentials;

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
@@ -173,10 +173,14 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     return httpClient()
         .get(
             credentialsEndpoint,
-            null != planId ? Map.of("planId", planId) : null,
+            credentialsQueryParams(),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
+  }
+
+  private Map<String, String> credentialsQueryParams() {
+    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   private void checkCredential(Credential credential, String property) {

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
@@ -38,7 +38,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.HTTPClient;
-import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.auth.AuthManager;
@@ -56,7 +55,6 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
   private final SerializableMap<String, String> properties;
   private final String credentialsEndpoint;
   private final String catalogEndpoint;
-  private final String planId;
   private transient volatile Map<String, SimpleTokenCache> sasCredentialByAccount;
   private transient volatile HTTPClient client;
   private transient AuthManager authManager;
@@ -70,7 +68,6 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     this.properties = SerializableMap.copyOf(properties);
     this.credentialsEndpoint = properties.get(URI);
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
-    this.planId = properties.getOrDefault(RESTCatalogProperties.REST_SCAN_PLAN_ID, null);
   }
 
   Mono<String> credentialForAccount(String storageAccount) {
@@ -173,14 +170,10 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     return httpClient()
         .get(
             credentialsEndpoint,
-            credentialsQueryParams(),
+            RESTUtil.credentialsQueryParams(properties),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
-  }
-
-  private Map<String, String> credentialsQueryParams() {
-    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   private void checkCredential(Credential credential, String property) {

--- a/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
@@ -165,5 +165,10 @@ public abstract class BaseSessionCatalog implements SessionCatalog {
     public boolean namespaceExists(Namespace namespace) {
       return BaseSessionCatalog.this.namespaceExists(context, namespace);
     }
+
+    @Override
+    public Table loadTable(TableIdentifier identifier, LoadContext loadContext) {
+      return BaseSessionCatalog.this.loadTable(context, identifier, loadContext);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/catalog/BaseViewSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/BaseViewSessionCatalog.java
@@ -59,6 +59,11 @@ public abstract class BaseViewSessionCatalog extends BaseSessionCatalog
     }
 
     @Override
+    public View loadView(TableIdentifier identifier, LoadContext loadContext) {
+      return BaseViewSessionCatalog.this.loadView(context, identifier, loadContext);
+    }
+
+    @Override
     public boolean viewExists(TableIdentifier identifier) {
       return BaseViewSessionCatalog.this.viewExists(context, identifier);
     }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
@@ -66,8 +66,26 @@ public interface HTTPRequest {
 
     try {
       URIBuilder builder = new URIBuilder(fullPath);
-      queryParameters().forEach(builder::addParameter);
-      return builder.build();
+      String referencedBy = null;
+      for (Map.Entry<String, String> entry : queryParameters().entrySet()) {
+        if (RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER.equals(entry.getKey())) {
+          // URIBuilder.addParameter would re-encode the comma chain delimiter, breaking the spec
+          // wire form. Append this value verbatim instead.
+          referencedBy = entry.getValue();
+        } else {
+          builder.addParameter(entry.getKey(), entry.getValue());
+        }
+      }
+      URI uri = builder.build();
+      if (referencedBy != null) {
+        String suffix =
+            (uri.getRawQuery() == null ? "?" : "&")
+                + RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER
+                + "="
+                + referencedBy;
+        uri = new URI(uri.toString() + suffix);
+      }
+      return uri;
     } catch (URISyntaxException e) {
       throw new RESTException(
           "Failed to create request URI from base %s, params %s", fullPath, queryParameters());

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
@@ -64,28 +64,27 @@ public interface HTTPRequest {
       fullPath = RESTUtil.stripTrailingSlash(String.format("%s/%s", baseUri, path()));
     }
 
+    String referencedBy =
+        queryParameters().get(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER);
     try {
       URIBuilder builder = new URIBuilder(fullPath);
-      String referencedBy = null;
-      for (Map.Entry<String, String> entry : queryParameters().entrySet()) {
-        if (RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER.equals(entry.getKey())) {
-          // URIBuilder.addParameter would re-encode the comma chain delimiter, breaking the spec
-          // wire form. Append this value verbatim instead.
-          referencedBy = entry.getValue();
-        } else {
-          builder.addParameter(entry.getKey(), entry.getValue());
-        }
-      }
+      queryParameters()
+          .forEach(
+              (key, value) -> {
+                // addParameter would re-encode referenced-by, turning %1F into %251F
+                if (!RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER.equals(key)) {
+                  builder.addParameter(key, value);
+                }
+              });
+
       URI uri = builder.build();
-      if (referencedBy != null) {
-        String suffix =
-            (uri.getRawQuery() == null ? "?" : "&")
-                + RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER
-                + "="
-                + referencedBy;
-        uri = new URI(uri.toString() + suffix);
+      if (referencedBy == null) {
+        return uri;
       }
-      return uri;
+
+      String prefix = uri.getRawQuery() == null ? "?" : "&";
+      return new URI(
+          uri + prefix + RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER + "=" + referencedBy);
     } catch (URISyntaxException e) {
       throw new RESTException(
           "Failed to create request URI from base %s, params %s", fullPath, queryParameters());

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -122,6 +123,11 @@ public class RESTCatalog
   @Override
   public Table loadTable(TableIdentifier ident) {
     return delegate.loadTable(ident);
+  }
+
+  @Override
+  public Table loadTable(TableIdentifier identifier, LoadContext loadContext) {
+    return sessionCatalog.loadTable(context, identifier, loadContext);
   }
 
   @Override
@@ -309,6 +315,11 @@ public class RESTCatalog
   @Override
   public View loadView(TableIdentifier identifier) {
     return viewSessionCatalog.loadView(identifier);
+  }
+
+  @Override
+  public View loadView(TableIdentifier identifier, LoadContext loadContext) {
+    return sessionCatalog.loadView(context, identifier, loadContext);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -127,7 +127,7 @@ public class RESTCatalog
 
   @Override
   public Table loadTable(TableIdentifier identifier, LoadContext loadContext) {
-    return sessionCatalog.loadTable(context, identifier, loadContext);
+    return delegate.loadTable(identifier, loadContext);
   }
 
   @Override
@@ -319,7 +319,7 @@ public class RESTCatalog
 
   @Override
   public View loadView(TableIdentifier identifier, LoadContext loadContext) {
-    return sessionCatalog.loadView(context, identifier, loadContext);
+    return viewSessionCatalog.loadView(identifier, loadContext);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
@@ -32,6 +32,10 @@ public final class RESTCatalogProperties {
   public static final SnapshotMode SNAPSHOT_LOADING_MODE_DEFAULT = SnapshotMode.ALL;
   public static final String SNAPSHOTS_QUERY_PARAMETER = "snapshots";
 
+  public static final String REFERENCED_BY_QUERY_PARAMETER = "referenced-by";
+
+  public static final String PLAN_ID_QUERY_PARAMETER = "planId";
+
   public static final String METRICS_REPORTING_ENABLED = "rest-metrics-reporting-enabled";
   public static final boolean METRICS_REPORTING_ENABLED_DEFAULT = true;
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
@@ -33,7 +33,6 @@ public final class RESTCatalogProperties {
   public static final String SNAPSHOTS_QUERY_PARAMETER = "snapshots";
 
   public static final String REFERENCED_BY_QUERY_PARAMETER = "referenced-by";
-
   public static final String PLAN_ID_QUERY_PARAMETER = "planId";
 
   public static final String METRICS_REPORTING_ENABLED = "rest-metrics-reporting-enabled";
@@ -56,6 +55,8 @@ public final class RESTCatalogProperties {
   public static final ScanPlanningMode SCAN_PLANNING_MODE_DEFAULT = ScanPlanningMode.CLIENT;
 
   public static final String REST_SCAN_PLAN_ID = "rest-scan-plan-id";
+
+  public static final String REST_REFERENCED_BY = "rest-referenced-by";
 
   public static final String REST_SCAN_PLANNING_POLL_TIMEOUT_MS =
       "rest-scan-planning.poll-timeout-ms";

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.Transactions;
 import org.apache.iceberg.catalog.BaseViewSessionCatalog;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -168,7 +169,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private CloseableGroup closeables = null;
   private Set<Endpoint> endpoints;
   private Supplier<Map<String, String>> mutationHeaders = Map::of;
-  private String namespaceSeparator = null;
+  private String namespaceSeparator = RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
   private ScanPlanningMode clientScanPlanningMode = null;
 
   private RESTTableCache tableCache;
@@ -440,21 +441,67 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       SnapshotMode mode,
       Map<String, String> headers,
       Consumer<Map<String, String>> responseHeaders) {
+    return loadInternal(context, identifier, mode, List.of(), headers, responseHeaders);
+  }
+
+  private LoadTableResponse loadInternal(
+      SessionContext context,
+      TableIdentifier identifier,
+      SnapshotMode mode,
+      List<TableIdentifier> referencedBy,
+      Map<String, String> headers,
+      Consumer<Map<String, String>> responseHeaders) {
     Endpoint.check(endpoints, Endpoint.V1_LOAD_TABLE);
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
     return client
         .withAuthSession(contextualSession)
         .get(
             paths.table(identifier),
-            snapshotModeToParam(mode),
+            paramsForLoadTable(mode, referencedBy),
             LoadTableResponse.class,
             headers,
             ErrorHandlers.tableErrorHandler(),
             responseHeaders);
   }
 
+  @VisibleForTesting
+  Map<String, String> paramsForLoadTable(SnapshotMode mode, List<TableIdentifier> referencedBy) {
+    Map<String, String> params = Maps.newHashMap(snapshotModeToParam(mode));
+    params.putAll(RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator));
+    return params;
+  }
+
+  @VisibleForTesting
+  Map<String, String> referencedByToQueryParam(List<TableIdentifier> referencedBy) {
+    return RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator);
+  }
+
+  /**
+   * Injects the pre-encoded referenced-by value into config properties so that credential providers
+   * can extract it and pass it as a query parameter to the loadCredentials endpoint.
+   */
+  private Map<String, String> injectReferencedBy(
+      Map<String, String> config, List<TableIdentifier> referencedBy) {
+    Map<String, String> referencedByParam =
+        RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator);
+    if (referencedByParam.isEmpty()) {
+      return config;
+    }
+
+    Map<String, String> merged = Maps.newHashMap(config);
+    merged.putAll(referencedByParam);
+    return merged;
+  }
+
   @Override
   public Table loadTable(SessionContext context, TableIdentifier identifier) {
+    return loadTable(context, identifier, LoadContext.empty());
+  }
+
+  @Override
+  public Table loadTable(
+      SessionContext context, TableIdentifier identifier, LoadContext loadContext) {
+    List<TableIdentifier> referencedBy = loadContext.referencedBy();
     Endpoint.check(
         endpoints,
         Endpoint.V1_LOAD_TABLE,
@@ -478,6 +525,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               context,
               identifier,
               snapshotMode,
+              referencedBy,
               headersForLoadTable(cachedTable),
               responseHeaders::putAll);
 
@@ -504,6 +552,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   context,
                   baseIdent,
                   snapshotMode,
+                  referencedBy,
                   headersForLoadTable(cachedTable),
                   responseHeaders::putAll);
 
@@ -528,7 +577,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     TableIdentifier finalIdentifier = loadedIdent;
-    Map<String, String> tableConf = response.config();
+    Map<String, String> tableConf = injectReferencedBy(response.config(), referencedBy);
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
     AuthSession tableSession =
         authManager.tableSession(finalIdentifier, tableConf, contextualSession);
@@ -541,7 +590,13 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               .setPreviousFileLocation(null)
               .setSnapshotsSupplier(
                   () ->
-                      loadInternal(context, finalIdentifier, SnapshotMode.ALL, Map.of(), h -> {})
+                      loadInternal(
+                              context,
+                              finalIdentifier,
+                              SnapshotMode.ALL,
+                              referencedBy,
+                              Map.of(),
+                              h -> {})
                           .tableMetadata()
                           .snapshots())
               .discardChanges()
@@ -1493,6 +1548,13 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   @Override
   public View loadView(SessionContext context, TableIdentifier identifier) {
+    return loadView(context, identifier, LoadContext.empty());
+  }
+
+  @Override
+  public View loadView(
+      SessionContext context, TableIdentifier identifier, LoadContext loadContext) {
+    List<TableIdentifier> referencedBy = loadContext.referencedBy();
     Endpoint.check(
         endpoints,
         Endpoint.V1_LOAD_VIEW,
@@ -1509,11 +1571,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             .withAuthSession(contextualSession)
             .get(
                 paths.view(identifier),
+                referencedByToQueryParam(referencedBy),
                 LoadViewResponse.class,
                 Map.of(),
                 ErrorHandlers.viewErrorHandler());
 
-    Map<String, String> tableConf = response.config();
+    Map<String, String> tableConf = injectReferencedBy(response.config(), referencedBy);
     AuthSession tableSession = authManager.tableSession(identifier, tableConf, contextualSession);
     ViewMetadata metadata = response.metadata();
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -169,7 +169,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private CloseableGroup closeables = null;
   private Set<Endpoint> endpoints;
   private Supplier<Map<String, String>> mutationHeaders = Map::of;
-  private String namespaceSeparator = RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
+  private String namespaceSeparator = null;
   private ScanPlanningMode clientScanPlanningMode = null;
 
   private RESTTableCache tableCache;
@@ -439,16 +439,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       SessionContext context,
       TableIdentifier identifier,
       SnapshotMode mode,
-      Map<String, String> headers,
-      Consumer<Map<String, String>> responseHeaders) {
-    return loadInternal(context, identifier, mode, List.of(), headers, responseHeaders);
-  }
-
-  private LoadTableResponse loadInternal(
-      SessionContext context,
-      TableIdentifier identifier,
-      SnapshotMode mode,
-      List<TableIdentifier> referencedBy,
+      LoadContext loadContext,
       Map<String, String> headers,
       Consumer<Map<String, String>> responseHeaders) {
     Endpoint.check(endpoints, Endpoint.V1_LOAD_TABLE);
@@ -457,40 +448,20 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         .withAuthSession(contextualSession)
         .get(
             paths.table(identifier),
-            paramsForLoadTable(mode, referencedBy),
+            RESTUtil.merge(
+                snapshotModeToParam(mode),
+                referencedByParam(
+                    loadContext, RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER)),
             LoadTableResponse.class,
             headers,
             ErrorHandlers.tableErrorHandler(),
             responseHeaders);
   }
 
-  @VisibleForTesting
-  Map<String, String> paramsForLoadTable(SnapshotMode mode, List<TableIdentifier> referencedBy) {
-    Map<String, String> params = Maps.newHashMap(snapshotModeToParam(mode));
-    params.putAll(RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator));
-    return params;
-  }
-
-  @VisibleForTesting
-  Map<String, String> referencedByToQueryParam(List<TableIdentifier> referencedBy) {
-    return RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator);
-  }
-
-  /**
-   * Injects the pre-encoded referenced-by value into config properties so that credential providers
-   * can extract it and pass it as a query parameter to the loadCredentials endpoint.
-   */
-  private Map<String, String> injectReferencedBy(
-      Map<String, String> config, List<TableIdentifier> referencedBy) {
-    Map<String, String> referencedByParam =
-        RESTUtil.referencedByToQueryParam(referencedBy, namespaceSeparator);
-    if (referencedByParam.isEmpty()) {
-      return config;
-    }
-
-    Map<String, String> merged = Maps.newHashMap(config);
-    merged.putAll(referencedByParam);
-    return merged;
+  /** Keys the encoded chain as either the wire query parameter or the internal client property. */
+  private Map<String, String> referencedByParam(LoadContext loadContext, String key) {
+    String encoded = RESTUtil.encodeReferencedBy(loadContext.referencedBy(), namespaceSeparator);
+    return encoded == null ? Map.of() : Map.of(key, encoded);
   }
 
   @Override
@@ -501,7 +472,6 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   @Override
   public Table loadTable(
       SessionContext context, TableIdentifier identifier, LoadContext loadContext) {
-    List<TableIdentifier> referencedBy = loadContext.referencedBy();
     Endpoint.check(
         endpoints,
         Endpoint.V1_LOAD_TABLE,
@@ -525,7 +495,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               context,
               identifier,
               snapshotMode,
-              referencedBy,
+              loadContext,
               headersForLoadTable(cachedTable),
               responseHeaders::putAll);
 
@@ -552,7 +522,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   context,
                   baseIdent,
                   snapshotMode,
-                  referencedBy,
+                  loadContext,
                   headersForLoadTable(cachedTable),
                   responseHeaders::putAll);
 
@@ -577,7 +547,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     TableIdentifier finalIdentifier = loadedIdent;
-    Map<String, String> tableConf = injectReferencedBy(response.config(), referencedBy);
+    Map<String, String> tableConf = response.config();
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
     AuthSession tableSession =
         authManager.tableSession(finalIdentifier, tableConf, contextualSession);
@@ -594,7 +564,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                               context,
                               finalIdentifier,
                               SnapshotMode.ALL,
-                              referencedBy,
+                              loadContext,
                               Map.of(),
                               h -> {})
                           .tableMetadata()
@@ -615,6 +585,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             context,
             tableClient,
             tableConf,
+            loadContext,
             credentials,
             remoteSigningConfig);
 
@@ -636,6 +607,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       SessionContext context,
       RESTClient tableClient,
       Map<String, String> tableConf,
+      LoadContext loadContext,
       List<Credential> credentials,
       RemoteSigningConfig remoteSigningConfig) {
     return () -> {
@@ -645,7 +617,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               paths.table(identifier),
               Map::of,
               mutationHeaders,
-              tableFileIO(identifier, context, tableConf, credentials, remoteSigningConfig),
+              tableFileIO(
+                  identifier, context, tableConf, loadContext, credentials, remoteSigningConfig),
               tableMetadata,
               endpoints);
 
@@ -792,7 +765,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             Map::of,
             mutationHeaders,
             tableFileIO(
-                ident, context, tableConf, response.credentials(), response.remoteSigningConfig()),
+                ident,
+                context,
+                tableConf,
+                LoadContext.empty(),
+                response.credentials(),
+                response.remoteSigningConfig()),
             response.tableMetadata(),
             endpoints);
 
@@ -1065,6 +1043,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ident,
                   context,
                   tableConf,
+                  LoadContext.empty(),
                   response.credentials(),
                   response.remoteSigningConfig()),
               response.tableMetadata(),
@@ -1103,6 +1082,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ident,
                   context,
                   tableConf,
+                  LoadContext.empty(),
                   response.credentials(),
                   response.remoteSigningConfig()),
               RESTTableOperations.UpdateType.CREATE,
@@ -1123,7 +1103,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         throw new AlreadyExistsException("View with same name already exists: %s", ident);
       }
 
-      LoadTableResponse response = loadInternal(context, ident, snapshotMode, Map.of(), h -> {});
+      LoadTableResponse response =
+          loadInternal(context, ident, snapshotMode, LoadContext.empty(), Map.of(), h -> {});
 
       String fullName = fullTableName(ident);
 
@@ -1173,6 +1154,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   ident,
                   context,
                   tableConf,
+                  LoadContext.empty(),
                   response.credentials(),
                   response.remoteSigningConfig()),
               RESTTableOperations.UpdateType.REPLACE,
@@ -1303,6 +1285,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableIdentifier tableIdentifier,
       SessionContext context,
       Map<String, String> tableConf,
+      LoadContext loadContext,
       List<Credential> storageCredentials,
       RemoteSigningConfig remoteSigningConfig) {
 
@@ -1320,6 +1303,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         ImmutableMap.<String, String>builder()
             .putAll(properties())
             .putAll(tableConf)
+            .putAll(referencedByParam(loadContext, RESTCatalogProperties.REST_REFERENCED_BY))
             .put(RESTCatalogProperties.REMOTE_SIGNING_ENDPOINT, paths.remoteSign(tableIdentifier));
 
     if (!remoteSigningConfig.isEmpty()) {
@@ -1554,7 +1538,6 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   @Override
   public View loadView(
       SessionContext context, TableIdentifier identifier, LoadContext loadContext) {
-    List<TableIdentifier> referencedBy = loadContext.referencedBy();
     Endpoint.check(
         endpoints,
         Endpoint.V1_LOAD_VIEW,
@@ -1571,12 +1554,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             .withAuthSession(contextualSession)
             .get(
                 paths.view(identifier),
-                referencedByToQueryParam(referencedBy),
+                referencedByParam(loadContext, RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER),
                 LoadViewResponse.class,
                 Map.of(),
                 ErrorHandlers.viewErrorHandler());
 
-    Map<String, String> tableConf = injectReferencedBy(response.config(), referencedBy);
+    Map<String, String> tableConf = response.config();
     AuthSession tableSession = authManager.tableSession(identifier, tableConf, contextualSession);
     ViewMetadata metadata = response.metadata();
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.rest;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.hc.core5.net.PercentCodec;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -33,7 +35,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.UUIDUtil;
 
@@ -441,58 +442,44 @@ public class RESTUtil {
     return ImmutableMap.of(IDEMPOTENCY_KEY_HEADER, UUIDUtil.generateUuidV7().toString());
   }
 
-  /**
-   * Builds query parameters for credential endpoints, including planId and referenced-by if
-   * present.
-   *
-   * @param planId the scan plan ID, or null if not set
-   * @param properties configuration properties that may contain a referenced-by value
-   * @return a map of query parameters, or null if no parameters are needed
-   */
-  public static Map<String, String> credentialsQueryParams(
-      String planId, Map<String, String> properties) {
-    Map<String, String> queryParams = Maps.newHashMap();
+  /** Query parameters for the loadCredentials endpoint, from client-side request context. */
+  public static Map<String, String> credentialsQueryParams(Map<String, String> properties) {
+    ImmutableMap.Builder<String, String> queryParams = ImmutableMap.builder();
+    String planId = properties.get(RESTCatalogProperties.REST_SCAN_PLAN_ID);
     if (planId != null) {
       queryParams.put(RESTCatalogProperties.PLAN_ID_QUERY_PARAMETER, planId);
     }
 
-    String referencedBy = properties.get(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER);
+    String referencedBy = properties.get(RESTCatalogProperties.REST_REFERENCED_BY);
     if (referencedBy != null) {
       queryParams.put(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, referencedBy);
     }
 
-    return queryParams.isEmpty() ? null : queryParams;
+    return queryParams.build();
   }
 
   /**
-   * Encode a view identifier chain as a referenced-by query parameter.
+   * Encodes a view chain (outermost first) as the {@code referenced-by} value.
    *
-   * <p>The returned value is the wire-form: each level and the view name are URL-encoded, joined by
-   * the (URL-encoded) namespace separator, and entries are joined by a literal comma matching the
-   * {@code referenced-by} OpenAPI definition. The HTTP layer must pass this value through verbatim
-   * (no further URL-encoding) so the comma chain delimiter and {@code %1F} separators survive on
-   * the wire.
-   *
-   * @param referencedBy ordered list of view identifiers from outermost to innermost
-   * @param namespaceSeparator the URL-encoded namespace separator (e.g. {@code %1F})
-   * @return a map with the referenced-by query parameter, or an empty map if no chain is present
+   * <p>Within an entry, the namespace levels and the view name are encoded like the {@code parent}
+   * query parameter, as the spec requires, and joined by the namespace separator as-is; entries are
+   * joined by a literal comma. The result is already percent-encoded and must reach the wire
+   * verbatim, see {@link HTTPRequest#requestUri()}.
    */
-  public static Map<String, String> referencedByToQueryParam(
-      List<TableIdentifier> referencedBy, String namespaceSeparator) {
+  static String encodeReferencedBy(List<TableIdentifier> referencedBy, String namespaceSeparator) {
     if (referencedBy == null || referencedBy.isEmpty()) {
-      return Map.of();
+      return null;
     }
 
-    List<String> entries =
-        referencedBy.stream()
-            .map(
-                ident ->
-                    encodeNamespace(ident.namespace(), namespaceSeparator)
-                        + namespaceSeparator
-                        + encodeString(ident.name()))
-            .collect(Collectors.toList());
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(namespaceSeparator), "Invalid separator: null or empty");
 
-    return ImmutableMap.of(
-        RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, Joiner.on(",").join(entries));
+    return referencedBy.stream()
+        .map(
+            ident ->
+                Stream.concat(Arrays.stream(ident.namespace().levels()), Stream.of(ident.name()))
+                    .map(level -> PercentCodec.encode(level, StandardCharsets.UTF_8))
+                    .collect(Collectors.joining(namespaceSeparator)))
+        .collect(Collectors.joining(","));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -21,15 +21,19 @@ package org.apache.iceberg.rest;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.hc.core5.net.PercentCodec;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.UUIDUtil;
 
@@ -435,5 +439,60 @@ public class RESTUtil {
    */
   public static Map<String, String> idempotencyHeaders() {
     return ImmutableMap.of(IDEMPOTENCY_KEY_HEADER, UUIDUtil.generateUuidV7().toString());
+  }
+
+  /**
+   * Builds query parameters for credential endpoints, including planId and referenced-by if
+   * present.
+   *
+   * @param planId the scan plan ID, or null if not set
+   * @param properties configuration properties that may contain a referenced-by value
+   * @return a map of query parameters, or null if no parameters are needed
+   */
+  public static Map<String, String> credentialsQueryParams(
+      String planId, Map<String, String> properties) {
+    Map<String, String> queryParams = Maps.newHashMap();
+    if (planId != null) {
+      queryParams.put(RESTCatalogProperties.PLAN_ID_QUERY_PARAMETER, planId);
+    }
+
+    String referencedBy = properties.get(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER);
+    if (referencedBy != null) {
+      queryParams.put(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, referencedBy);
+    }
+
+    return queryParams.isEmpty() ? null : queryParams;
+  }
+
+  /**
+   * Encode a view identifier chain as a referenced-by query parameter.
+   *
+   * <p>The returned value is the wire-form: each level and the view name are URL-encoded, joined by
+   * the (URL-encoded) namespace separator, and entries are joined by a literal comma matching the
+   * {@code referenced-by} OpenAPI definition. The HTTP layer must pass this value through verbatim
+   * (no further URL-encoding) so the comma chain delimiter and {@code %1F} separators survive on
+   * the wire.
+   *
+   * @param referencedBy ordered list of view identifiers from outermost to innermost
+   * @param namespaceSeparator the URL-encoded namespace separator (e.g. {@code %1F})
+   * @return a map with the referenced-by query parameter, or an empty map if no chain is present
+   */
+  public static Map<String, String> referencedByToQueryParam(
+      List<TableIdentifier> referencedBy, String namespaceSeparator) {
+    if (referencedBy == null || referencedBy.isEmpty()) {
+      return Map.of();
+    }
+
+    List<String> entries =
+        referencedBy.stream()
+            .map(
+                ident ->
+                    encodeNamespace(ident.namespace(), namespaceSeparator)
+                        + namespaceSeparator
+                        + encodeString(ident.name()))
+            .collect(Collectors.toList());
+
+    return ImmutableMap.of(
+        RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, Joiner.on(",").join(entries));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
@@ -98,7 +98,33 @@ class TestHTTPRequest {
                 .path("v1/main%7Cwarehouse/namespaces/sales%20report/tables")
                 .build(),
             URI.create(
-                "http://localhost:8080/v1/main%7Cwarehouse/namespaces/sales%20report/tables")));
+                "http://localhost:8080/v1/main%7Cwarehouse/namespaces/sales%20report/tables")),
+        Arguments.of(
+            ImmutableHTTPRequest.builder()
+                .baseUri(URI.create("http://localhost:8080"))
+                .method(HTTPRequest.HTTPMethod.GET)
+                .path("v1/namespaces/ns/tables/tbl")
+                .putQueryParameter("snapshots", "all")
+                // pre-encoded: appended verbatim, and the whole chain is one parameter
+                .putQueryParameter(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "outer_ns%1Fouter_view,inner_ns%1Finner_view")
+                .build(),
+            URI.create(
+                "http://localhost:8080/v1/namespaces/ns/tables/tbl?snapshots=all"
+                    + "&referenced-by=outer_ns%1Fouter_view,inner_ns%1Finner_view")),
+        Arguments.of(
+            ImmutableHTTPRequest.builder()
+                .baseUri(URI.create("http://localhost:8080"))
+                .method(HTTPRequest.HTTPMethod.GET)
+                .path("v1/namespaces/ns/tables/tbl")
+                // pre-encoded parameter alone still opens the query string
+                .putQueryParameter(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1Fouter_view")
+                .build(),
+            URI.create(
+                "http://localhost:8080/v1/namespaces/ns/tables/tbl"
+                    + "?referenced-by=ns%1Fouter_view")));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -77,7 +77,6 @@ import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.CatalogTests;
-import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
@@ -4125,111 +4124,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
     return catalog;
-  }
-
-  @Test
-  public void loadTableWithReferencedByQueryParam() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
-    catalog.createTable(tableIdent, SCHEMA);
-
-    Mockito.clearInvocations(adapter);
-
-    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(ns, "outer_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
-
-    catalog.loadTable(tableIdent, loadContext);
-
-    // The test adapter uses %2E as the namespace separator
-    Mockito.verify(adapter)
-        .execute(
-            matches(
-                HTTPMethod.GET,
-                "v1/namespaces/ns/tables/test_table",
-                Map.of(),
-                ImmutableMap.of(
-                    RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER,
-                    "all",
-                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-                    "ns%2Eouter_view")),
-            eq(LoadTableResponse.class),
-            any(),
-            any());
-  }
-
-  @Test
-  public void loadTableWithoutContextHasNoReferencedByParam() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
-    catalog.createTable(tableIdent, SCHEMA);
-
-    Mockito.clearInvocations(adapter);
-
-    catalog.loadTable(tableIdent);
-
-    Mockito.verify(adapter)
-        .execute(
-            matches(
-                HTTPMethod.GET,
-                "v1/namespaces/ns/tables/test_table",
-                Map.of(),
-                ImmutableMap.of(RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, "all")),
-            eq(LoadTableResponse.class),
-            any(),
-            any());
-  }
-
-  @Test
-  public void loadTableWithNestedViewChainReferencedBy() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
-    catalog.createTable(tableIdent, SCHEMA);
-
-    Mockito.clearInvocations(adapter);
-
-    List<TableIdentifier> viewChain =
-        ImmutableList.of(
-            TableIdentifier.of(ns, "outer_view"), TableIdentifier.of(ns, "inner_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
-
-    catalog.loadTable(tableIdent, loadContext);
-
-    // The test adapter uses %2E as the namespace separator
-    Mockito.verify(adapter)
-        .execute(
-            matches(
-                HTTPMethod.GET,
-                "v1/namespaces/ns/tables/test_table",
-                Map.of(),
-                ImmutableMap.of(
-                    RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER,
-                    "all",
-                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-                    "ns%2Eouter_view,ns%2Einner_view")),
-            eq(LoadTableResponse.class),
-            any(),
-            any());
   }
 
   private static List<HTTPRequest> allRequests(RESTCatalogAdapter adapter) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -77,6 +77,7 @@ import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
@@ -4124,6 +4125,111 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
     return catalog;
+  }
+
+  @Test
+  public void loadTableWithReferencedByQueryParam() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
+    catalog.createTable(tableIdent, SCHEMA);
+
+    Mockito.clearInvocations(adapter);
+
+    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(ns, "outer_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    catalog.loadTable(tableIdent, loadContext);
+
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER,
+                    "all",
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "ns%2Eouter_view")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadTableWithoutContextHasNoReferencedByParam() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
+    catalog.createTable(tableIdent, SCHEMA);
+
+    Mockito.clearInvocations(adapter);
+
+    catalog.loadTable(tableIdent);
+
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of(RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadTableWithNestedViewChainReferencedBy() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier tableIdent = TableIdentifier.of(ns, "test_table");
+    catalog.createTable(tableIdent, SCHEMA);
+
+    Mockito.clearInvocations(adapter);
+
+    List<TableIdentifier> viewChain =
+        ImmutableList.of(
+            TableIdentifier.of(ns, "outer_view"), TableIdentifier.of(ns, "inner_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    catalog.loadTable(tableIdent, loadContext);
+
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER,
+                    "all",
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "ns%2Eouter_view,ns%2Einner_view")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
   }
 
   private static List<HTTPRequest> allRequests(RESTCatalogAdapter adapter) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -22,9 +22,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.apache.hc.core5.net.URIBuilder;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -198,6 +203,93 @@ public class TestRESTUtil {
     assertThat(RESTUtil.decodePathSegment(encodedOldJava)).isNotEqualTo(input).isEqualTo("++%20");
     assertThat(RESTUtil.decodePathSegment(encodedNewJava)).isEqualTo(input);
     assertThat(RESTUtil.decodePathSegment(encodedOther)).isEqualTo(input);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"%1F", "%2D", "%2E", "#", "_"})
+  public void encodeReferencedBy(String namespaceSeparator) {
+    // the separator is used as configured, joining the namespace levels and the view name
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "viewName")),
+                namespaceSeparator))
+        .isEqualTo(String.format("ns%sviewName", namespaceSeparator));
+
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(Namespace.of("prod", "analytics"), "view")),
+                namespaceSeparator))
+        .isEqualTo(String.format("prod%sanalytics%sview", namespaceSeparator, namespaceSeparator));
+
+    // a chain is joined by a literal comma, outermost first
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(
+                    TableIdentifier.of(Namespace.of("outer_ns"), "outer_view"),
+                    TableIdentifier.of(Namespace.of("inner_ns"), "inner_view")),
+                namespaceSeparator))
+        .isEqualTo(
+            String.format(
+                "outer_ns%souter_view,inner_ns%sinner_view",
+                namespaceSeparator, namespaceSeparator));
+
+    assertThat(RESTUtil.encodeReferencedBy(null, namespaceSeparator)).isNull();
+    assertThat(RESTUtil.encodeReferencedBy(ImmutableList.of(), namespaceSeparator)).isNull();
+  }
+
+  @Test
+  public void encodeReferencedByEncodesReservedCharacters() {
+    String separator = RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
+
+    // a space is %20 rather than the + that URLEncoder alone would produce
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(Namespace.of("ns with spaces"), "view/name")),
+                separator))
+        .isEqualTo("ns%20with%20spaces%1Fview%2Fname");
+
+    // a comma inside a view name is encoded, so splitting the chain on bare commas still works
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "view,name")), separator))
+        .isEqualTo("ns%1Fview%2Cname");
+
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(Namespace.of("a+b"), "c*d")), separator))
+        .isEqualTo("a%2Bb%1Fc%2Ad");
+
+    // the example given in the referenced-by OpenAPI parameter description
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(
+                    TableIdentifier.of(Namespace.of("prod", "analytics"), "quarterly_view"),
+                    TableIdentifier.of(Namespace.of("prod", "analytics"), "monthly_view")),
+                separator))
+        .isEqualTo("prod%1Fanalytics%1Fquarterly_view,prod%1Fanalytics%1Fmonthly_view");
+  }
+
+  @Test
+  public void encodeReferencedByMatchesParentParamEncoding() {
+    // the spec ties this parameter's encoding to the parent query parameter's rules
+    Namespace namespace = Namespace.of("a b", "c*d", "e+f");
+    String parentValue;
+    try {
+      parentValue =
+          new URIBuilder("http://localhost/v1/namespaces")
+              .addParameter("parent", RESTUtil.namespaceToQueryParam(namespace))
+              .build()
+              .getRawQuery()
+              .substring("parent=".length());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    assertThat(
+            RESTUtil.encodeReferencedBy(
+                ImmutableList.of(TableIdentifier.of(namespace, "v")),
+                RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8))
+        .isEqualTo(parentValue + RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8 + "v");
   }
 
   @Test
@@ -426,6 +518,16 @@ public class TestRESTUtil {
         .hasMessage(errorMsg);
 
     assertThatThrownBy(() -> RESTUtil.namespaceFromQueryParam("namespace", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(errorMsg);
+
+    List<TableIdentifier> chain =
+        ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "viewName"));
+    assertThatThrownBy(() -> RESTUtil.encodeReferencedBy(chain, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(errorMsg);
+
+    assertThatThrownBy(() -> RESTUtil.encodeReferencedBy(chain, ""))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(errorMsg);
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -441,5 +442,121 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
   @Override
   protected boolean supportsServerSideRetry() {
     return true;
+  }
+
+  @Test
+  public void testLoadViewWithReferencedByQueryParam() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
+    catalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    Mockito.clearInvocations(adapter);
+
+    // load the view with a referenced-by context
+    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(ns, "outer_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    catalog.loadView(viewIdent, loadContext);
+
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/views/test_view",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%2Eouter_view")),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testLoadViewWithoutContextHasNoReferencedByParam() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
+    catalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    Mockito.clearInvocations(adapter);
+
+    // load the view without any context
+    catalog.loadView(viewIdent);
+
+    // verify the GET request has no query parameters
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.GET, "v1/namespaces/ns/views/test_view", Map.of(), Map.of()),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testLoadViewWithNestedViewChainReferencedBy() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize("test", ImmutableMap.of());
+
+    Namespace ns = Namespace.of("ns");
+    catalog.createNamespace(ns);
+
+    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
+    catalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    Mockito.clearInvocations(adapter);
+
+    // load the view with a nested view chain
+    List<TableIdentifier> viewChain =
+        ImmutableList.of(
+            TableIdentifier.of(ns, "outer_view"), TableIdentifier.of(ns, "inner_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    catalog.loadView(viewIdent, loadContext);
+
+    // verify the GET request includes comma-separated referenced-by chain
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/views/test_view",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "ns%2Eouter_view,ns%2Einner_view")),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -442,121 +441,5 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
   @Override
   protected boolean supportsServerSideRetry() {
     return true;
-  }
-
-  @Test
-  public void testLoadViewWithReferencedByQueryParam() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
-    catalog
-        .buildView(viewIdent)
-        .withSchema(SCHEMA)
-        .withDefaultNamespace(ns)
-        .withQuery("spark", "select * from ns.tbl")
-        .create();
-
-    Mockito.clearInvocations(adapter);
-
-    // load the view with a referenced-by context
-    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(ns, "outer_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
-
-    catalog.loadView(viewIdent, loadContext);
-
-    // The test adapter uses %2E as the namespace separator
-    Mockito.verify(adapter)
-        .execute(
-            matches(
-                HTTPMethod.GET,
-                "v1/namespaces/ns/views/test_view",
-                Map.of(),
-                ImmutableMap.of(
-                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%2Eouter_view")),
-            eq(LoadViewResponse.class),
-            any(),
-            any());
-  }
-
-  @Test
-  public void testLoadViewWithoutContextHasNoReferencedByParam() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
-    catalog
-        .buildView(viewIdent)
-        .withSchema(SCHEMA)
-        .withDefaultNamespace(ns)
-        .withQuery("spark", "select * from ns.tbl")
-        .create();
-
-    Mockito.clearInvocations(adapter);
-
-    // load the view without any context
-    catalog.loadView(viewIdent);
-
-    // verify the GET request has no query parameters
-    Mockito.verify(adapter)
-        .execute(
-            matches(HTTPMethod.GET, "v1/namespaces/ns/views/test_view", Map.of(), Map.of()),
-            eq(LoadViewResponse.class),
-            any(),
-            any());
-  }
-
-  @Test
-  public void testLoadViewWithNestedViewChainReferencedBy() {
-    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize("test", ImmutableMap.of());
-
-    Namespace ns = Namespace.of("ns");
-    catalog.createNamespace(ns);
-
-    TableIdentifier viewIdent = TableIdentifier.of(ns, "test_view");
-    catalog
-        .buildView(viewIdent)
-        .withSchema(SCHEMA)
-        .withDefaultNamespace(ns)
-        .withQuery("spark", "select * from ns.tbl")
-        .create();
-
-    Mockito.clearInvocations(adapter);
-
-    // load the view with a nested view chain
-    List<TableIdentifier> viewChain =
-        ImmutableList.of(
-            TableIdentifier.of(ns, "outer_view"), TableIdentifier.of(ns, "inner_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
-
-    catalog.loadView(viewIdent, loadContext);
-
-    // verify the GET request includes comma-separated referenced-by chain
-    // The test adapter uses %2E as the namespace separator
-    Mockito.verify(adapter)
-        .execute(
-            matches(
-                HTTPMethod.GET,
-                "v1/namespaces/ns/views/test_view",
-                Map.of(),
-                ImmutableMap.of(
-                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-                    "ns%2Eouter_view,ns%2Einner_view")),
-            eq(LoadViewResponse.class),
-            any(),
-            any());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestReferencedByQueryParam.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestReferencedByQueryParam.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.apache.iceberg.rest.RequestMatcher.matches;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.LoadContext;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestReferencedByQueryParam {
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  private static final Namespace NS = Namespace.of("ns");
+  private static final TableIdentifier TABLE_IDENT = TableIdentifier.of(NS, "test_table");
+
+  private final RESTSessionCatalog catalog = new RESTSessionCatalog(config -> null, null);
+
+  private RESTCatalogAdapter adapter;
+  private RESTCatalog restCatalog;
+
+  @BeforeEach
+  public void before() {
+    InMemoryCatalog backendCatalog = new InMemoryCatalog();
+    backendCatalog.initialize("test", ImmutableMap.of());
+
+    adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    restCatalog = new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    restCatalog.initialize("test", ImmutableMap.of());
+
+    restCatalog.createNamespace(NS);
+    restCatalog.buildTable(TABLE_IDENT, SCHEMA).create();
+    Mockito.clearInvocations(adapter);
+  }
+
+  @AfterEach
+  public void after() throws Exception {
+    if (restCatalog != null) {
+      restCatalog.close();
+    }
+  }
+
+  @Test
+  public void singleViewSimpleNamespace() {
+    List<TableIdentifier> chain =
+        ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "viewName"));
+
+    Map<String, String> result = catalog.referencedByToQueryParam(chain);
+
+    assertThat(result)
+        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1FviewName");
+  }
+
+  @Test
+  public void singleViewNestedNamespace() {
+    List<TableIdentifier> chain =
+        ImmutableList.of(TableIdentifier.of(Namespace.of("prod", "analytics"), "quarterly_view"));
+
+    Map<String, String> result = catalog.referencedByToQueryParam(chain);
+
+    assertThat(result)
+        .containsEntry(
+            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+            "prod%1Fanalytics%1Fquarterly_view");
+  }
+
+  @Test
+  public void nestedViewChain() {
+    List<TableIdentifier> chain =
+        ImmutableList.of(
+            TableIdentifier.of(Namespace.of("outer_ns"), "outer_view"),
+            TableIdentifier.of(Namespace.of("inner_ns"), "inner_view"));
+
+    Map<String, String> result = catalog.referencedByToQueryParam(chain);
+
+    assertThat(result)
+        .containsEntry(
+            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+            "outer_ns%1Fouter_view,inner_ns%1Finner_view");
+  }
+
+  @Test
+  public void viewNameWithCommaIsEncoded() {
+    List<TableIdentifier> chain =
+        ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "view,name"));
+
+    Map<String, String> result = catalog.referencedByToQueryParam(chain);
+
+    // Comma in view name is URL-encoded as %2C so the chain split on bare comma still works
+    assertThat(result)
+        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1Fview%2Cname");
+  }
+
+  @Test
+  public void paramsForLoadTableMergesSnapshotModeAndReferencedBy() {
+    List<TableIdentifier> chain = ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "view"));
+
+    Map<String, String> result =
+        catalog.paramsForLoadTable(RESTCatalogProperties.SnapshotMode.ALL, chain);
+
+    assertThat(result)
+        .containsEntry("snapshots", "all")
+        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1Fview");
+  }
+
+  @Test
+  public void namespaceWithSpecialCharsEncoded() {
+    List<TableIdentifier> chain =
+        ImmutableList.of(TableIdentifier.of(Namespace.of("ns with spaces"), "view/name"));
+
+    Map<String, String> result = catalog.referencedByToQueryParam(chain);
+
+    // Levels and name are URL-encoded (spaces -> +, / -> %2F) and joined by the URL-encoded
+    // separator; the value is then sent verbatim on the wire
+    assertThat(result)
+        .containsEntry(
+            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns+with+spaces%1Fview%2Fname");
+  }
+
+  @Test
+  public void loadTableWithReferencedByQueryParam() {
+    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(NS, "outer_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    restCatalog.loadTable(TABLE_IDENT, loadContext);
+
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of(
+                    "snapshots",
+                    "all",
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "ns%2Eouter_view")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadTableWithoutContextHasNoReferencedByParam() {
+    restCatalog.loadTable(TABLE_IDENT);
+
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of("snapshots", "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadTableWithNestedViewChainReferencedBy() {
+    List<TableIdentifier> viewChain =
+        ImmutableList.of(
+            TableIdentifier.of(NS, "outer_view"), TableIdentifier.of(NS, "inner_view"));
+    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+
+    restCatalog.loadTable(TABLE_IDENT, loadContext);
+
+    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/tables/test_table",
+                Map.of(),
+                ImmutableMap.of(
+                    "snapshots",
+                    "all",
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
+                    "ns%2Eouter_view,ns%2Einner_view")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestReferencedByQueryParam.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestReferencedByQueryParam.java
@@ -23,18 +23,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.LoadContext;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,8 +52,6 @@ public class TestReferencedByQueryParam {
   private static final Namespace NS = Namespace.of("ns");
   private static final TableIdentifier TABLE_IDENT = TableIdentifier.of(NS, "test_table");
 
-  private final RESTSessionCatalog catalog = new RESTSessionCatalog(config -> null, null);
-
   private RESTCatalogAdapter adapter;
   private RESTCatalog restCatalog;
 
@@ -61,7 +62,10 @@ public class TestReferencedByQueryParam {
 
     adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     restCatalog = new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    restCatalog.initialize("test", ImmutableMap.of());
+    restCatalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
 
     restCatalog.createNamespace(NS);
     restCatalog.buildTable(TABLE_IDENT, SCHEMA).create();
@@ -76,90 +80,10 @@ public class TestReferencedByQueryParam {
   }
 
   @Test
-  public void singleViewSimpleNamespace() {
-    List<TableIdentifier> chain =
-        ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "viewName"));
+  public void loadTableSendsReferencedBy() {
+    restCatalog.loadTable(TABLE_IDENT, referencedBy("outer_view"));
 
-    Map<String, String> result = catalog.referencedByToQueryParam(chain);
-
-    assertThat(result)
-        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1FviewName");
-  }
-
-  @Test
-  public void singleViewNestedNamespace() {
-    List<TableIdentifier> chain =
-        ImmutableList.of(TableIdentifier.of(Namespace.of("prod", "analytics"), "quarterly_view"));
-
-    Map<String, String> result = catalog.referencedByToQueryParam(chain);
-
-    assertThat(result)
-        .containsEntry(
-            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-            "prod%1Fanalytics%1Fquarterly_view");
-  }
-
-  @Test
-  public void nestedViewChain() {
-    List<TableIdentifier> chain =
-        ImmutableList.of(
-            TableIdentifier.of(Namespace.of("outer_ns"), "outer_view"),
-            TableIdentifier.of(Namespace.of("inner_ns"), "inner_view"));
-
-    Map<String, String> result = catalog.referencedByToQueryParam(chain);
-
-    assertThat(result)
-        .containsEntry(
-            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-            "outer_ns%1Fouter_view,inner_ns%1Finner_view");
-  }
-
-  @Test
-  public void viewNameWithCommaIsEncoded() {
-    List<TableIdentifier> chain =
-        ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "view,name"));
-
-    Map<String, String> result = catalog.referencedByToQueryParam(chain);
-
-    // Comma in view name is URL-encoded as %2C so the chain split on bare comma still works
-    assertThat(result)
-        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1Fview%2Cname");
-  }
-
-  @Test
-  public void paramsForLoadTableMergesSnapshotModeAndReferencedBy() {
-    List<TableIdentifier> chain = ImmutableList.of(TableIdentifier.of(Namespace.of("ns"), "view"));
-
-    Map<String, String> result =
-        catalog.paramsForLoadTable(RESTCatalogProperties.SnapshotMode.ALL, chain);
-
-    assertThat(result)
-        .containsEntry("snapshots", "all")
-        .containsEntry(RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%1Fview");
-  }
-
-  @Test
-  public void namespaceWithSpecialCharsEncoded() {
-    List<TableIdentifier> chain =
-        ImmutableList.of(TableIdentifier.of(Namespace.of("ns with spaces"), "view/name"));
-
-    Map<String, String> result = catalog.referencedByToQueryParam(chain);
-
-    // Levels and name are URL-encoded (spaces -> +, / -> %2F) and joined by the URL-encoded
-    // separator; the value is then sent verbatim on the wire
-    assertThat(result)
-        .containsEntry(
-            RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns+with+spaces%1Fview%2Fname");
-  }
-
-  @Test
-  public void loadTableWithReferencedByQueryParam() {
-    List<TableIdentifier> viewChain = ImmutableList.of(TableIdentifier.of(NS, "outer_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
-
-    restCatalog.loadTable(TABLE_IDENT, loadContext);
-
-    // The test adapter uses %2E as the namespace separator
+    // the test adapter uses %2E as the namespace separator
     Mockito.verify(adapter)
         .execute(
             matches(
@@ -193,15 +117,106 @@ public class TestReferencedByQueryParam {
   }
 
   @Test
-  public void loadTableWithNestedViewChainReferencedBy() {
-    List<TableIdentifier> viewChain =
-        ImmutableList.of(
-            TableIdentifier.of(NS, "outer_view"), TableIdentifier.of(NS, "inner_view"));
-    LoadContext loadContext = LoadContext.builder().referencedBy(viewChain).build();
+  public void loadViewSendsReferencedBy() {
+    TableIdentifier viewIdent = createView();
 
-    restCatalog.loadTable(TABLE_IDENT, loadContext);
+    restCatalog.loadView(viewIdent, referencedBy("outer_view"));
 
-    // The test adapter uses %2E as the namespace separator
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/views/test_view",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%2Eouter_view")),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadViewWithoutContextHasNoReferencedByParam() {
+    TableIdentifier viewIdent = createView();
+
+    restCatalog.loadView(viewIdent);
+
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.GET, "v1/namespaces/ns/views/test_view", Map.of(), Map.of()),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void loadViewThroughViewCatalogBridgeSendsReferencedBy() {
+    TableIdentifier viewIdent = createView();
+
+    // the ViewCatalog returned by asViewCatalog must forward the load context, otherwise
+    // ViewCatalog's default implementation silently drops the view chain
+    SessionCatalog.SessionContext session = SessionCatalog.SessionContext.createEmpty();
+    ViewCatalog viewCatalog = restCatalog.sessionCatalog().asViewCatalog(session);
+
+    viewCatalog.loadView(viewIdent, referencedBy("outer_view"));
+
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.GET,
+                "v1/namespaces/ns/views/test_view",
+                Map.of(),
+                ImmutableMap.of(
+                    RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER, "ns%2Eouter_view")),
+            eq(LoadViewResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void referencedByReachesTableFileIOProperties() {
+    // a non-empty table config forces a table-level FileIO; that FileIO's properties are what
+    // credential providers read the chain back out of
+    Mockito.doAnswer(
+            invocation -> {
+              LoadTableResponse response = (LoadTableResponse) invocation.callRealMethod();
+              return LoadTableResponse.builder()
+                  .withTableMetadata(response.tableMetadata())
+                  .addAllConfig(response.config())
+                  .addAllConfig(ImmutableMap.of("table-scoped", "config"))
+                  .build();
+            })
+        .when(adapter)
+        .execute(
+            matches(HTTPMethod.GET, "v1/namespaces/ns/tables/test_table"),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+
+    Table table = restCatalog.loadTable(TABLE_IDENT, referencedBy("outer_view"));
+
+    assertThat(table.io().properties())
+        .containsEntry(RESTCatalogProperties.REST_REFERENCED_BY, "ns%2Eouter_view");
+  }
+
+  @Test
+  public void referencedByLoadStillReusesCatalogFileIO() {
+    // with no table-scoped config from the server there are no per-table credentials to scope, so
+    // the chain must not force a new FileIO per load
+    Table plain = restCatalog.loadTable(TABLE_IDENT);
+    Table viaView = restCatalog.loadTable(TABLE_IDENT, referencedBy("outer_view"));
+
+    assertThat(viaView.io()).isSameAs(plain.io());
+  }
+
+  @Test
+  public void loadMetadataTableSendsReferencedBy() {
+    // the first GET 404s, and the retry against the base table must still carry the chain
+    TableIdentifier metadataIdent =
+        TableIdentifier.of(Namespace.of("ns", "test_table"), "snapshots");
+
+    restCatalog.loadTable(metadataIdent, referencedBy("outer_view"));
+
     Mockito.verify(adapter)
         .execute(
             matches(
@@ -212,9 +227,27 @@ public class TestReferencedByQueryParam {
                     "snapshots",
                     "all",
                     RESTCatalogProperties.REFERENCED_BY_QUERY_PARAMETER,
-                    "ns%2Eouter_view,ns%2Einner_view")),
+                    "ns%2Eouter_view")),
             eq(LoadTableResponse.class),
             any(),
             any());
+  }
+
+  private static LoadContext referencedBy(String viewName) {
+    return LoadContext.builder()
+        .referencedBy(ImmutableList.of(TableIdentifier.of(NS, viewName)))
+        .build();
+  }
+
+  private TableIdentifier createView() {
+    TableIdentifier viewIdent = TableIdentifier.of(NS, "test_view");
+    restCatalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS)
+        .withQuery("spark", "select * from ns.test_table")
+        .create();
+    Mockito.clearInvocations(adapter);
+    return viewIdent;
   }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
@@ -93,7 +93,7 @@ public class OAuth2RefreshCredentialsHandler
     return httpClient()
         .get(
             credentialsEndpoint,
-            null != planId ? Map.of("planId", planId) : null,
+            credentialsQueryParams(),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
@@ -127,6 +127,10 @@ public class OAuth2RefreshCredentialsHandler
     }
 
     return client;
+  }
+
+  private Map<String, String> credentialsQueryParams() {
+    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   @Override

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.HTTPClient;
-import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.auth.AuthManager;
@@ -45,7 +44,6 @@ public class OAuth2RefreshCredentialsHandler
     implements OAuth2CredentialsWithRefresh.OAuth2RefreshHandler, AutoCloseable {
   private final Map<String, String> properties;
   private final String credentialsEndpoint;
-  private final String planId;
   // will be used to refresh the OAuth2 token
   private final String catalogEndpoint;
   private volatile HTTPClient client;
@@ -62,7 +60,6 @@ public class OAuth2RefreshCredentialsHandler
         properties.get(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT);
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
     this.properties = properties;
-    this.planId = properties.getOrDefault(RESTCatalogProperties.REST_SCAN_PLAN_ID, null);
   }
 
   @SuppressWarnings("JavaUtilDate") // GCP API uses java.util.Date
@@ -93,7 +90,7 @@ public class OAuth2RefreshCredentialsHandler
     return httpClient()
         .get(
             credentialsEndpoint,
-            credentialsQueryParams(),
+            RESTUtil.credentialsQueryParams(properties),
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
@@ -127,10 +124,6 @@ public class OAuth2RefreshCredentialsHandler
     }
 
     return client;
-  }
-
-  private Map<String, String> credentialsQueryParams() {
-    return RESTUtil.credentialsQueryParams(planId, properties);
   }
 
   @Override


### PR DESCRIPTION
When a table or view is loaded through a view, the catalog can't currently tell. This sends the chain of referencing views to the REST server as the spec'd referenced-by query parameter, and forwards it to credential providers, so a server can scope authorization and credentials to how the data was reached.

Builds on the LoadContext API from #15895. No spec changes needed — referenced-by is already defined.

Flow: LoadContext.referencedBy([outer, …, inner]) → RESTCatalog → RESTSessionCatalog → referenced-by on the load request → the table's FileIO config → /v1/credentials.

Notes for reviewers

- The whole chain is a single referenced-by key, with entries comma-separated and ordered outermost first, per the spec. A comma inside a view name is encoded as %2C so the delimiter stays unambiguous.
- The value is appended verbatim in HTTPRequest.requestUri instead of going through URIBuilder. Entries are percent-encoded and the delimiter is literal, and addParameter would double-encode % (%1F → %251F). Nothing on the classpath produces this format.
- Entries are encoded like the parent parameter, using PercentCodec. The namespace separator is used as configured.
- The ETag cache is untouched. Servers already owe distinct ETags for responses that differ by query parameter, so this needs no client-side handling.
- Credential providers read the chain from rest-referenced-by, an internal property mirroring rest-scan-plan-id. It's added inside tableFileIO, so the server's config still decides whether the catalog FileIO can be reused.

-----------------

