### PR TITLE
Kafka Connect: Always convert UUID columns to java.util.UUID

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -71,7 +70,6 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.Variant;
@@ -506,23 +504,12 @@ class RecordConverter {
   }
 
   protected Object convertUUID(Object value) {
-    UUID uuid;
     if (value instanceof String) {
-      uuid = UUID.fromString((String) value);
+      return UUID.fromString((String) value);
     } else if (value instanceof UUID) {
-      uuid = (UUID) value;
-    } else {
-      throw new IllegalArgumentException("Cannot convert to UUID: " + value.getClass().getName());
+      return value;
     }
-
-    if (FileFormat.PARQUET
-        .name()
-        .toLowerCase(Locale.ROOT)
-        .equals(config.writeProps().get(TableProperties.DEFAULT_FILE_FORMAT))) {
-      return UUIDUtil.convert(uuid);
-    } else {
-      return uuid;
-    }
+    throw new IllegalArgumentException("Cannot convert to UUID: " + value.getClass().getName());
   }
 
   protected ByteBuffer convertBase64Binary(Object value) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -50,9 +51,15 @@ import org.apache.iceberg.connect.data.SchemaUpdate.AddColumn;
 import org.apache.iceberg.connect.data.SchemaUpdate.UpdateType;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.mapping.MappedField;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -77,7 +84,6 @@ import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
 import org.apache.iceberg.types.Types.VariantType;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.PhysicalType;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantValue;
@@ -280,7 +286,44 @@ public class TestRecordConverter {
         ImmutableMap.<String, Object>builder().put("uuid", UUID_VAL.toString()).build();
 
     Record record = converter.convert(data);
-    assertThat(record.getField("uuid")).isEqualTo(UUIDUtil.convert(UUID_VAL));
+    assertThat(record.getField("uuid")).isEqualTo(UUID_VAL);
+  }
+
+  @Test
+  public void testUUIDParquetWriteRoundTrip() throws IOException {
+    org.apache.iceberg.Schema schema =
+        new org.apache.iceberg.Schema(NestedField.required(1, "uuid", UUIDType.get()));
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(schema);
+    when(config.writeProps())
+        .thenReturn(
+            ImmutableMap.of(
+                TableProperties.DEFAULT_FILE_FORMAT,
+                FileFormat.PARQUET.name().toLowerCase(Locale.ROOT)));
+
+    RecordConverter converter = new RecordConverter(table, config);
+    Record record =
+        converter.convert(
+            ImmutableMap.<String, Object>builder().put("uuid", UUID_VAL.toString()).build());
+
+    InMemoryOutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> appender =
+        Parquet.write(output)
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      appender.add(record);
+    }
+
+    try (CloseableIterable<Record> reader =
+        Parquet.read(output.toInputFile())
+            .project(schema)
+            .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(schema, fileSchema))
+            .build()) {
+      List<Record> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(1);
+      assertThat(rows.get(0).getField("uuid")).isEqualTo(UUID_VAL);
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #17076

## Summary

`RecordConverter.convertUUID()` returned `byte[]` when `write.format.default=parquet`. After #11904, `ParquetValueWriters.uuids()` is a `PrimitiveWriter<UUID>` and does the byte conversion itself, so writes threw `ClassCastException: class [B cannot be cast to class java.util.UUID`.

The Parquet-only `byte[]` branch is removed so `convertUUID()` always returns `java.util.UUID`, matching ORC and Avro.

This is the same fix as #17079 (stale-bot closed, never reviewed). Credit to @thswlsqls for the original diagnosis and patch. The extra change here is a write-through test: the old `testUUIDConversionWithParquet` only asserted the converter's return type, so it passed on a converter that still could not write.

## Testing done

- `testUUIDConversionWithParquet` now expects the original `UUID`
- `testUUIDParquetWriteRoundTrip` appends through `Parquet.write(...)` and reads the value back
- `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:test --tests org.apache.iceberg.connect.data.TestRecordConverter` — BUILD SUCCESSFUL


Made with [Cursor](https://cursor.com)