### PR TITLE
Build: Include Spark 4.2 in source releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,3 @@
 /examples/**   export-ignore
 /docs          export-ignore
 /docs/**       export-ignore
-/spark/v4.2    export-ignore
-/spark/v4.2/** export-ignore
-

--- a/.github/workflows/source-release-ci.yml
+++ b/.github/workflows/source-release-ci.yml
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Source Release CI"
+on:
+  push:
+    branches:
+    - 'main'
+    - '0.*'
+    - '1.*'
+    - '2.*'
+    paths:
+    - '.gitattributes'
+    - '.github/workflows/source-release-ci.yml'
+    - 'build.gradle'
+    - 'dev/source-release.sh'
+    - 'gradle.properties'
+    - 'gradle/**'
+    - 'gradlew'
+    - 'settings.gradle'
+    - '**/*.gradle'
+    - '**/*.gradle.kts'
+  pull_request:
+    paths:
+    - '.gitattributes'
+    - '.github/workflows/source-release-ci.yml'
+    - 'build.gradle'
+    - 'dev/source-release.sh'
+    - 'gradle.properties'
+    - 'gradle/**'
+    - 'gradlew'
+    - 'settings.gradle'
+    - '**/*.gradle'
+    - '**/*.gradle.kts'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  source-release:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        distribution: zulu
+        java-version: 17
+    - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      with:
+        cache-read-only: true
+    - name: Generate release metadata
+      run: |
+        echo "0.0.0" > version.txt
+        ./gradlew generateGitProperties
+        cp build/iceberg-build.properties iceberg-build.properties
+    - name: Create source archive
+      run: |
+        git archive HEAD --worktree-attributes --prefix iceberg/ \
+          --add-file version.txt --add-file iceberg-build.properties \
+          -o "$RUNNER_TEMP/iceberg.tar.gz"
+        mkdir "$RUNNER_TEMP/source-release"
+        tar -xzf "$RUNNER_TEMP/iceberg.tar.gz" -C "$RUNNER_TEMP/source-release"
+    - name: Check default configuration
+      working-directory: ${{ runner.temp }}/source-release/iceberg
+      run: ./gradlew help --no-daemon
+    - name: Check all modules configuration
+      working-directory: ${{ runner.temp }}/source-release/iceberg
+      run: ./gradlew -DallModules help --no-daemon


### PR DESCRIPTION
Follow-up to #17967.

## Why this change is needed

Spark 4.2 is now selected by `defaultSparkVersions`, but the existing `export-ignore` entries omit `spark/v4.2` from source archives produced with `git archive`. As a result, every Gradle command run from an extracted source release, including `./gradlew help`, fails during configuration with:

```
A problem occurred evaluating project ':iceberg-spark'.
> Could not read script '.../spark/v4.2/build.gradle' as it does not exist.
```

This makes the source release impossible to configure or build. The `-DallModules` configuration is broken for the same reason because `knownSparkVersions` also includes Spark 4.2.

This PR removes the `export-ignore` entries for `spark/v4.2` so source release archives contain the module selected by `defaultSparkVersions` and `-DallModules`. It also adds a targeted source-release CI workflow that recreates the exported archive and loads both Gradle configurations when archive or Gradle configuration files change.

Spark 4.2 remains excluded from convenience binary publishing because `dev/stage-binaries.sh` still limits `SPARK_VERSIONS` to 3.5, 4.0, and 4.1.

Validation:
- Reproduced the missing `spark/v4.2/build.gradle` configuration failure from a pre-fix source archive.
- Created an archive with `git archive HEAD --worktree-attributes` and confirmed Spark 3.5, 4.0, 4.1, and 4.2 source directories are present.
- Ran the default Gradle `help` task from the extracted archive.
- Ran the Gradle `help` task with `-DallModules` from the extracted archive.
- Ran `./gradlew spotlessCheck`.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Include Spark 4.2 in source releases and add CI coverage that validates the exported source archive.
