### PR TITLE
Flink: Exclude junit4 from connector-test-utils test dependency

### DIFF
--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -70,7 +70,9 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation libs.datasketches
     implementation libs.roaringbitmap
 
-    testImplementation libs.flink120.connector.test.utils
+    testImplementation(libs.flink120.connector.test.utils) {
+      exclude group: 'junit'
+    }
     testImplementation libs.flink120.core
     testImplementation libs.flink120.runtime
     testImplementation(libs.flink120.test.utilsjunit) {

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -70,7 +70,9 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation libs.datasketches
     implementation libs.roaringbitmap
 
-    testImplementation libs.flink21.connector.test.utils
+    testImplementation(libs.flink21.connector.test.utils) {
+      exclude group: 'junit'
+    }
     testImplementation libs.flink21.core
     testImplementation libs.flink21.runtime
     testImplementation(libs.flink21.test.utilsjunit) {

--- a/flink/v2.2/build.gradle
+++ b/flink/v2.2/build.gradle
@@ -70,7 +70,9 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation libs.datasketches
     implementation libs.roaringbitmap
 
-    testImplementation libs.flink22.connector.test.utils
+    testImplementation(libs.flink22.connector.test.utils) {
+      exclude group: 'junit'
+    }
     testImplementation libs.flink22.core
     testImplementation libs.flink22.runtime
     testImplementation(libs.flink22.test.utilsjunit) {

--- a/flink/v2.3/build.gradle
+++ b/flink/v2.3/build.gradle
@@ -70,7 +70,9 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation libs.datasketches
     implementation libs.roaringbitmap
 
-    testImplementation libs.flink23.connector.test.utils
+    testImplementation(libs.flink23.connector.test.utils) {
+      exclude group: 'junit'
+    }
     testImplementation libs.flink23.core
     testImplementation libs.flink23.runtime
     testImplementation(libs.flink23.test.utilsjunit) {


### PR DESCRIPTION
## Description

Follow-up to #12937. `connector-test-utils` still pulled in junit4 transitively even though none of the JUnit4-specific APIs it was needed for remain in use.

`TestIcebergSourceFailover` (cited in #12937 as the remaining blocker) already uses `org.apache.flink.test.junit5.MiniClusterExtension` instead of the JUnit4-only `MiniClusterWithClientResource`. I checked all 4 Flink version dirs (`v1.20`, `v2.1`, `v2.2`, `v2.3`) and found no other `org.junit.*` (non-jupiter) imports anywhere in their test sources — so this exclusion is now safe to add, matching the exclusion already applied to the neighboring `test.utilsjunit` dependency in the same block.