### PR TITLE
API: Add tests for CharSequenceUtil.unequalPaths

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TestCharSequenceUtil {
+  @Test
+  void sameReferenceIsEqual() {
+    CharSequence path = "s3://bucket/table/data/file.parquet";
+    assertThat(CharSequenceUtil.unequalPaths(path, path)).isFalse();
+  }
+
+  @Test
+  void equalContentAcrossCharSequenceTypesIsEqual() {
+    CharSequence string = "s3://bucket/table/data/file.parquet";
+    CharSequence builder = new StringBuilder("s3://bucket/table/data/file.parquet");
+    assertThat(CharSequenceUtil.unequalPaths(string, builder)).isFalse();
+  }
+
+  @Test
+  void differentLengthsAreUnequal() {
+    assertThat(CharSequenceUtil.unequalPaths("a/b", "a/b/c")).isTrue();
+  }
+
+  @Test
+  void differingSuffixIsUnequal() {
+    assertThat(CharSequenceUtil.unequalPaths("data/00000-0.parquet", "data/00001-0.parquet"))
+        .isTrue();
+  }
+
+  @Test
+  void differingPrefixIsUnequal() {
+    assertThat(CharSequenceUtil.unequalPaths("a/x/file.parquet", "b/x/file.parquet")).isTrue();
+  }
+
+  @Test
+  void emptySequencesAreEqual() {
+    assertThat(CharSequenceUtil.unequalPaths("", new StringBuilder())).isFalse();
+  }
+}


### PR DESCRIPTION
Adds unit test coverage for `CharSequenceUtil.unequalPaths`, which `FileScopedPositionDeleteWriter` uses to detect when the write path changes. Covers the identity shortcut, length mismatch, reverse-scan suffix/prefix differences, cross-CharSequence-type equality, and empty sequences.