### PR TITLE
Kafka Connect: Use manual partition assignment for Worker's control-topic consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 .pytest_cache/
 
 # vscode/eclipse files
+.vscode/
 .classpath
 .factorypath
 .project

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestWorkerControlGroupManagement.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestWorkerControlGroupManagement.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test: the Worker's control-topic reader used consumer.subscribe() with a
+ * single-member, never-reused, randomly-named group (IcebergSinkConfig.DEFAULT_CONTROL_GROUP_PREFIX
+ * + UUID.randomUUID()). That group gets no benefit from consumer-group management (it never has
+ * more than one member), but is still exposed to the full JoinGroup/SyncGroup protocol -- including
+ * broker-side member-fencing failures that can permanently starve a task's commits. The fix is to
+ * use consumer.assign() for this reader instead, which never registers a consumer group with the
+ * broker at all.
+ */
+public class TestWorkerControlGroupManagement extends IntegrationTestBase {
+
+  private static final String TEST_TABLE = "control_group_test";
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(TEST_DB, TEST_TABLE);
+
+  @Test
+  public void testWorkerDoesNotRegisterEphemeralConsumerGroup() throws Exception {
+    catalog().createTable(TABLE_IDENTIFIER, TestEvent.TEST_SCHEMA);
+
+    runTest(null, true, ImmutableMap.of(), List.of(TABLE_IDENTIFIER));
+
+    try (Admin admin = context().initLocalAdmin()) {
+      Set<String> groupIds =
+          admin.listConsumerGroups().all().get().stream()
+              .map(ConsumerGroupListing::groupId)
+              .collect(Collectors.toSet());
+
+      assertThat(groupIds)
+          .as(
+              "Worker's control-topic consumer should never register a consumer group "
+                  + "(it should use assign(), not subscribe())")
+          .noneMatch(id -> id.startsWith(IcebergSinkConfig.DEFAULT_CONTROL_GROUP_PREFIX));
+    }
+  }
+
+  @Override
+  protected KafkaConnectUtils.Config createConfig(boolean useSchema) {
+    return createCommonConfig(useSchema)
+        .config("iceberg.tables", String.format("%s.%s", TEST_DB, TEST_TABLE));
+  }
+
+  @Override
+  protected void sendEvents(boolean useSchema) {
+    // send two events so both tasks (tasks.max=2, 2 topic partitions) receive at least one
+    // record -- otherwise the task that gets zero records never creates its Worker, never
+    // sends DataComplete, and the round waits forever (commit.timeout-ms is MAX_VALUE here)
+    send(testTopic(), new TestEvent(1, "type1", Instant.now(), "hello world!"), useSchema);
+    send(testTopic(), new TestEvent(2, "type2", Instant.now(), "having fun?"), useSchema);
+  }
+
+  @Override
+  void dropTables() {
+    catalog().dropTable(TABLE_IDENTIFIER);
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -207,9 +207,9 @@ abstract class Channel {
 
   /**
    * Subscribes this channel's consumer to the control topic. Coordinator relies on real
-   * consumer-group membership (a stable, shared group id) so the broker's rebalance protocol
-   * can help detect/evict a stale coordinator. Worker overrides this with manual assignment
-   * instead, since its group is single-member and never reused -- see the override for why.
+   * consumer-group membership (a stable, shared group id) so the broker's rebalance protocol can
+   * help detect/evict a stale coordinator. Worker overrides this with manual assignment instead,
+   * since its group is single-member and never reused -- see the override for why.
    */
   protected void subscribeToControlTopic() {
     consumer.subscribe(ImmutableList.of(controlTopic));

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
@@ -146,6 +148,18 @@ abstract class Channel {
     return controlTopicOffsets;
   }
 
+  protected String controlTopic() {
+    return controlTopic;
+  }
+
+  protected List<PartitionInfo> controlTopicPartitions() {
+    return consumer.partitionsFor(controlTopic);
+  }
+
+  protected void assignControlTopicPartitions(Collection<TopicPartition> partitions) {
+    consumer.assign(partitions);
+  }
+
   /**
    * Commit consumer offsets. Only commits offsets if it has not committed offsets before or the
    * value is greater than the cached offset.
@@ -185,10 +199,20 @@ abstract class Channel {
   }
 
   void start() {
-    consumer.subscribe(ImmutableList.of(controlTopic));
+    subscribeToControlTopic();
 
     // initial poll with longer duration so the consumer will initialize...
     consumeAvailable(Duration.ofSeconds(1));
+  }
+
+  /**
+   * Subscribes this channel's consumer to the control topic. Coordinator relies on real
+   * consumer-group membership (a stable, shared group id) so the broker's rebalance protocol
+   * can help detect/evict a stale coordinator. Worker overrides this with manual assignment
+   * instead, since its group is single-member and never reused -- see the override for why.
+   */
+  protected void subscribeToControlTopic() {
+    consumer.subscribe(ImmutableList.of(controlTopic));
   }
 
   void stop() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.data.Offset;
@@ -33,6 +34,10 @@ import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.util.Tasks;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
@@ -62,6 +67,47 @@ class Worker extends Channel {
 
   void process() {
     consumeAvailable(Duration.ZERO);
+  }
+
+  @Override
+  protected void subscribeToControlTopic() {
+    // this consumer's group id is a fresh, single-member, never-reused id (see constructor), so
+    // it gets no benefit from consumer-group management -- there is never more than one member
+    // to balance partitions against. Using assign() instead of subscribe() avoids the
+    // JoinGroup/SyncGroup protocol entirely, which otherwise exposes this reader to broker-side
+    // member-fencing failure modes for no reason, since group membership was never needed here.
+    assignControlTopicPartitions(awaitControlTopicPartitions());
+  }
+
+  // unlike subscribe(), a one-shot partitionsFor() lookup doesn't tolerate the control topic
+  // not existing yet at the moment this is called -- retry with a bounded backoff rather than
+  // silently assigning zero partitions, which would poll forever and never receive anything.
+  private List<TopicPartition> awaitControlTopicPartitions() {
+    AtomicReference<List<PartitionInfo>> partitionInfos = new AtomicReference<>();
+    // rely solely on exponentialBackoff's time cap (30s) to bound retries -- a large retry()
+    // count here would just be a second, redundant bound that has to be kept in sync with it.
+    Tasks.range(1)
+        .retry(Integer.MAX_VALUE - 1) // retry() adds 1 for maxAttempts; avoid overflow
+        .exponentialBackoff(200, 200, Duration.ofSeconds(30).toMillis(), 1)
+        .onlyRetryOn(ControlTopicNotReadyException.class)
+        .run(
+            i -> {
+              List<PartitionInfo> infos = controlTopicPartitions();
+              if (infos == null || infos.isEmpty()) {
+                throw new ControlTopicNotReadyException(controlTopic());
+              }
+              partitionInfos.set(infos);
+            });
+
+    return partitionInfos.get().stream()
+        .map(info -> new TopicPartition(info.topic(), info.partition()))
+        .collect(Collectors.toList());
+  }
+
+  private static class ControlTopicNotReadyException extends ConnectException {
+    ControlTopicNotReadyException(String controlTopic) {
+      super("Control topic " + controlTopic + " does not exist yet");
+    }
   }
 
   @Override

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -81,11 +82,17 @@ public class TestWorker extends ChannelTestBase {
       SinkWriter sinkWriter = mock(SinkWriter.class);
       when(sinkWriter.completeWrite()).thenReturn(sinkWriterResult);
 
+      // Worker now uses consumer.assign() (not subscribe()) for the control topic, so the mock
+      // consumer needs partition metadata available before start() is called, rather than a
+      // post-hoc rebalance() simulation.
+      TopicPartition tp = new TopicPartition(CTL_TOPIC_NAME, 0);
+      consumer.updatePartitions(
+          CTL_TOPIC_NAME,
+          ImmutableList.of(new PartitionInfo(CTL_TOPIC_NAME, 0, null, null, null)));
+      consumer.updateBeginningOffsets(ImmutableMap.of(tp, 0L));
+
       Worker worker = new Worker(config, clientFactory, sinkWriter, context);
       worker.start();
-
-      // init consumer after subscribe()
-      initConsumer();
 
       // save a record
       Map<String, Object> value = ImmutableMap.of();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -87,8 +87,7 @@ public class TestWorker extends ChannelTestBase {
       // post-hoc rebalance() simulation.
       TopicPartition tp = new TopicPartition(CTL_TOPIC_NAME, 0);
       consumer.updatePartitions(
-          CTL_TOPIC_NAME,
-          ImmutableList.of(new PartitionInfo(CTL_TOPIC_NAME, 0, null, null, null)));
+          CTL_TOPIC_NAME, ImmutableList.of(new PartitionInfo(CTL_TOPIC_NAME, 0, null, null, null)));
       consumer.updateBeginningOffsets(ImmutableMap.of(tp, 0L));
 
       Worker worker = new Worker(config, clientFactory, sinkWriter, context);


### PR DESCRIPTION
The Worker's control-topic reader used a single-member, never-reused, randomly-named consumer group via `consumer.subscribe()`. That group gets no benefit from consumer-group management (it never has more than one member) but is still exposed to the full JoinGroup/SyncGroup protocol, including broker-side member-fencing failures that can permanently starve a task's commits with no error or warning logged anywhere.

Switch to `consumer.assign()` for this reader, which never registers a consumer group with the broker at all, making this failure mode structurally impossible rather than just less likely. `Coordinator` is unaffected: its control-topic consumer uses a stable, reused group id and relies on real group membership for rebalance-based leader detection, so it keeps using `subscribe()`.

Also hardens the new `assign()`-based path against the control topic not existing yet at Worker startup (`subscribe()` tolerates this; a one-shot `assign()` does not), using `Tasks` for the bounded retry to match this package's existing retry idiom (see `Coordinator.java`).

Related: #15293, #16016 (open issues describing related control-topic/coordinator instability under rebalance; this fixes a distinct root cause found while investigating the same symptom class).

Adds a Testcontainers-based regression test asserting via `AdminClient.listConsumerGroups()` that the Worker never registers an ephemeral control-topic consumer group.
