### PR TITLE
Core: Make tracked v4 file adapters serializable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ class TrackedFileAdapters {
         file.contentType() == FileContent.DATA,
         "Invalid content type for DataFile: %s",
         file.contentType());
-    return new TrackedDataFile(file, resolveSpec(file, specsById));
+    return new TrackedDataFile(file, resolveSpecId(file, specsById));
   }
 
   static DeleteFile asDVDeleteFile(TrackedFile file, Map<Integer, PartitionSpec> specsById) {
@@ -42,7 +43,7 @@ class TrackedFileAdapters {
         file.contentType() == FileContent.DATA,
         "Invalid content type for DV delete file: %s",
         file.contentType());
-    return new TrackedDVDeleteFile(file, resolveSpec(file, specsById));
+    return new TrackedDVDeleteFile(file, resolveSpecId(file, specsById));
   }
 
   static DeleteFile asEqualityDeleteFile(TrackedFile file, Map<Integer, PartitionSpec> specsById) {
@@ -50,7 +51,7 @@ class TrackedFileAdapters {
         file.contentType() == FileContent.EQUALITY_DELETES,
         "Invalid content type for equality delete file: %s",
         file.contentType());
-    return new TrackedEqualityDeleteFile(file, resolveSpec(file, specsById));
+    return new TrackedEqualityDeleteFile(file, resolveSpecId(file, specsById));
   }
 
   static ManifestFile asManifestFile(TrackedFile file) {
@@ -64,26 +65,17 @@ class TrackedFileAdapters {
 
   /** Shared base for data and delete file adapters. */
   private abstract static class TrackedFileAdapter<F extends ContentFile<F>>
-      implements ContentFile<F> {
+      implements ContentFile<F>, Serializable {
     private final TrackedFile file;
-    private final PartitionSpec spec;
+    private final int specId;
 
-    private TrackedFileAdapter(TrackedFile file, PartitionSpec spec) {
-      Preconditions.checkArgument(
-          file.specId() == null ? spec.isUnpartitioned() : file.specId() == spec.specId(),
-          "File spec ID %s does not match partition spec %s",
-          file.specId(),
-          spec.specId());
+    private TrackedFileAdapter(TrackedFile file, int specId) {
       this.file = file;
-      this.spec = spec;
+      this.specId = specId;
     }
 
     protected TrackedFile file() {
       return file;
-    }
-
-    protected PartitionSpec spec() {
-      return spec;
     }
 
     protected Tracking tracking() {
@@ -104,7 +96,7 @@ class TrackedFileAdapters {
 
     @Override
     public int specId() {
-      return spec.specId();
+      return specId;
     }
 
     @Override
@@ -131,8 +123,8 @@ class TrackedFileAdapters {
    */
   private abstract static class TrackedContentFile<F extends ContentFile<F>>
       extends TrackedFileAdapter<F> {
-    private TrackedContentFile(TrackedFile file, PartitionSpec spec) {
-      super(file, spec);
+    private TrackedContentFile(TrackedFile file, int specId) {
+      super(file, specId);
     }
 
     @SuppressWarnings("deprecation")
@@ -214,8 +206,8 @@ class TrackedFileAdapters {
 
   /** Adapts a TrackedFile DATA entry to the {@link DataFile} interface. */
   private static class TrackedDataFile extends TrackedContentFile<DataFile> implements DataFile {
-    private TrackedDataFile(TrackedFile file, PartitionSpec spec) {
-      super(file, spec);
+    private TrackedDataFile(TrackedFile file, int specId) {
+      super(file, specId);
     }
 
     @Override
@@ -235,7 +227,7 @@ class TrackedFileAdapters {
 
     @Override
     public DataFile copy() {
-      return new TrackedDataFile(file().copy(), spec());
+      return new TrackedDataFile(file().copy(), specId());
     }
 
     @Override
@@ -245,20 +237,20 @@ class TrackedFileAdapters {
 
     @Override
     public DataFile copyWithoutStats() {
-      return new TrackedDataFile(file().copyWithoutStats(), spec());
+      return new TrackedDataFile(file().copyWithoutStats(), specId());
     }
 
     @Override
     public DataFile copyWithStats(Set<Integer> requestedColumnIds) {
-      return new TrackedDataFile(file().copyWithStats(requestedColumnIds), spec());
+      return new TrackedDataFile(file().copyWithStats(requestedColumnIds), specId());
     }
   }
 
   /** Adapts a TrackedFile EQUALITY_DELETES entry to the {@link DeleteFile} interface. */
   private static class TrackedEqualityDeleteFile extends TrackedContentFile<DeleteFile>
       implements DeleteFile {
-    private TrackedEqualityDeleteFile(TrackedFile file, PartitionSpec spec) {
-      super(file, spec);
+    private TrackedEqualityDeleteFile(TrackedFile file, int specId) {
+      super(file, specId);
     }
 
     @Override
@@ -273,7 +265,7 @@ class TrackedFileAdapters {
 
     @Override
     public DeleteFile copy() {
-      return new TrackedEqualityDeleteFile(file().copy(), spec());
+      return new TrackedEqualityDeleteFile(file().copy(), specId());
     }
 
     @Override
@@ -283,12 +275,12 @@ class TrackedFileAdapters {
 
     @Override
     public DeleteFile copyWithoutStats() {
-      return new TrackedEqualityDeleteFile(file().copyWithoutStats(), spec());
+      return new TrackedEqualityDeleteFile(file().copyWithoutStats(), specId());
     }
 
     @Override
     public DeleteFile copyWithStats(Set<Integer> requestedColumnIds) {
-      return new TrackedEqualityDeleteFile(file().copyWithStats(requestedColumnIds), spec());
+      return new TrackedEqualityDeleteFile(file().copyWithStats(requestedColumnIds), specId());
     }
   }
 
@@ -299,8 +291,8 @@ class TrackedFileAdapters {
       implements DeleteFile {
     private final DeletionVector dv;
 
-    private TrackedDVDeleteFile(TrackedFile file, PartitionSpec spec) {
-      super(file, spec);
+    private TrackedDVDeleteFile(TrackedFile file, int specId) {
+      super(file, specId);
       Preconditions.checkArgument(
           file.deletionVector() != null, "Cannot create DV delete file: no deletion vector");
       this.dv = file.deletionVector();
@@ -405,7 +397,7 @@ class TrackedFileAdapters {
 
     @Override
     public DeleteFile copy() {
-      return new TrackedDVDeleteFile(file().copyWithoutStats(), spec());
+      return new TrackedDVDeleteFile(file().copyWithoutStats(), specId());
     }
 
     @Override
@@ -552,20 +544,18 @@ class TrackedFileAdapters {
     }
   }
 
-  private static PartitionSpec resolveSpec(
-      TrackedFile file, Map<Integer, PartitionSpec> specsById) {
+  private static int resolveSpecId(TrackedFile file, Map<Integer, PartitionSpec> specsById) {
     Integer specId = file.specId();
     if (specId != null) {
-      PartitionSpec spec = specsById.get(specId);
       Preconditions.checkArgument(
-          spec != null, "Cannot find partition spec for spec ID: %s", specId);
-      return spec;
+          specsById.containsKey(specId), "Cannot find partition spec for spec ID: %s", specId);
+      return specId;
     }
 
     // A null spec ID means the file is unpartitioned; use the table's unpartitioned spec.
     for (PartitionSpec spec : specsById.values()) {
       if (spec.isUnpartitioned()) {
-        return spec;
+        return spec.specId();
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -364,6 +364,103 @@ class TestTrackedFileAdapters {
     assertThat(dvFile.upperBounds()).isNull();
   }
 
+  @Test
+  void dataFileAdapterIsSerializable() throws Exception {
+    DataFile dataFile =
+        TrackedFileAdapters.asDataFile(serializableDataEntry(), specsById(PARTITIONED_SPEC));
+
+    assertSameDataFile(TestHelpers.roundTripSerialize(dataFile), dataFile);
+    assertSameDataFile(TestHelpers.KryoHelpers.roundTripSerialize(dataFile), dataFile);
+  }
+
+  @Test
+  void dvDeleteFileAdapterIsSerializable() throws Exception {
+    DeleteFile dvFile =
+        TrackedFileAdapters.asDVDeleteFile(serializableDataEntry(), specsById(PARTITIONED_SPEC));
+
+    assertSameDeleteFile(TestHelpers.roundTripSerialize(dvFile), dvFile);
+    assertSameDeleteFile(TestHelpers.KryoHelpers.roundTripSerialize(dvFile), dvFile);
+  }
+
+  private static void assertSameDataFile(DataFile actual, DataFile expected) {
+    assertThat(actual.content()).isEqualTo(expected.content());
+    assertThat(actual.location()).isEqualTo(expected.location());
+    assertThat(actual.format()).isEqualTo(expected.format());
+    assertThat(actual.specId()).isEqualTo(expected.specId());
+    assertThat(actual.partition().get(0, String.class))
+        .isEqualTo(expected.partition().get(0, String.class));
+    assertThat(actual.recordCount()).isEqualTo(expected.recordCount());
+    assertThat(actual.fileSizeInBytes()).isEqualTo(expected.fileSizeInBytes());
+    assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
+    assertThat(actual.dataSequenceNumber()).isEqualTo(expected.dataSequenceNumber());
+    assertThat(actual.fileSequenceNumber()).isEqualTo(expected.fileSequenceNumber());
+    assertThat(actual.firstRowId()).isEqualTo(expected.firstRowId());
+    assertThat(actual.pos()).isEqualTo(expected.pos());
+    assertThat(actual.manifestLocation()).isEqualTo(expected.manifestLocation());
+    assertThat(actual.keyMetadata()).isEqualTo(expected.keyMetadata());
+    assertThat(actual.splitOffsets()).isEqualTo(expected.splitOffsets());
+  }
+
+  private static void assertSameDeleteFile(DeleteFile actual, DeleteFile expected) {
+    assertThat(actual.content()).isEqualTo(expected.content());
+    assertThat(actual.location()).isEqualTo(expected.location());
+    assertThat(actual.format()).isEqualTo(expected.format());
+    assertThat(actual.recordCount()).isEqualTo(expected.recordCount());
+    assertThat(actual.contentOffset()).isEqualTo(expected.contentOffset());
+    assertThat(actual.contentSizeInBytes()).isEqualTo(expected.contentSizeInBytes());
+    assertThat(actual.keyMetadata()).isEqualTo(expected.keyMetadata());
+    assertThat(actual.referencedDataFile()).isEqualTo(expected.referencedDataFile());
+    assertThat(actual.specId()).isEqualTo(expected.specId());
+    assertThat(actual.partition().get(0, String.class))
+        .isEqualTo(expected.partition().get(0, String.class));
+    assertThat(actual.dataSequenceNumber()).isEqualTo(expected.dataSequenceNumber());
+    assertThat(actual.fileSequenceNumber()).isEqualTo(expected.fileSequenceNumber());
+    assertThat(actual.pos()).isEqualTo(expected.pos());
+    assertThat(actual.manifestLocation()).isEqualTo(expected.manifestLocation());
+  }
+
+  private static TrackedFile serializableDataEntry() {
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.ADDED,
+            42L,
+            DATA_SEQUENCE_NUMBER,
+            FILE_SEQUENCE_NUMBER,
+            42L,
+            FIRST_ROW_ID,
+            null,
+            null);
+    tracking.setManifestLocation(MANIFEST_LOCATION);
+    tracking.set(MANIFEST_POS_ORDINAL, MANIFEST_POS);
+
+    DeletionVector dv =
+        DeletionVectorStruct.builder()
+            .location(DV_LOCATION)
+            .offset(128L)
+            .sizeInBytes(256L)
+            .cardinality(10L)
+            .keyMetadata(KEY_METADATA)
+            .build();
+
+    return new TrackedFileStruct(
+        tracking,
+        FileContent.DATA,
+        FORMAT_VERSION_V4,
+        DATA_FILE_LOCATION,
+        FileFormat.PARQUET,
+        100L, // recordCount
+        1024L, // fileSizeInBytes
+        PARTITIONED_SPEC_ID,
+        PARTITION,
+        null, // contentStats
+        3, // sortOrderId
+        dv, // deletionVector
+        null, // manifestInfo
+        KEY_METADATA,
+        ImmutableList.of(50L, 100L), // splitOffsets
+        null); // equalityIds
+  }
+
   @ParameterizedTest
   @EnumSource(value = FileContent.class, mode = EnumSource.Mode.EXCLUDE, names = "DATA")
   void dvDeleteFileAdapterRejectsNonDataContent(FileContent contentType) {
@@ -569,43 +666,6 @@ class TestTrackedFileAdapters {
     assertThatThrownBy(() -> TrackedFileAdapters.asDataFile(file, ImmutableMap.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot find partition spec for spec ID");
-  }
-
-  @Test
-  void specIdMismatchThrows() {
-    TrackedFileStruct file =
-        new TrackedFileStruct(
-            null,
-            FileContent.DATA,
-            0,
-            null,
-            null,
-            0L,
-            0L,
-            PARTITIONED_SPEC_ID,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null);
-    int mismatchedSpecId = PARTITIONED_SPEC_ID + 1;
-    PartitionSpec mismatched =
-        PartitionSpec.builderFor(PARTITION_SCHEMA)
-            .identity("category")
-            .withSpecId(mismatchedSpecId)
-            .build();
-
-    assertThatThrownBy(
-            () ->
-                TrackedFileAdapters.asDataFile(
-                    file, ImmutableMap.of(PARTITIONED_SPEC_ID, mismatched)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "File spec ID %s does not match partition spec %s",
-            PARTITIONED_SPEC_ID, mismatchedSpecId);
   }
 
   private static void assertNullTrackingFields(ContentFile<?> file) {


### PR DESCRIPTION
The scan planner emits FileScanTasks whose DataFile and DeleteFile are the tracked file adapters, and Spark serializes those to executors, so the adapters must be Serializable. Implement Serializable on the adapter base and replace the held PartitionSpec with the resolved spec ID, since the adapters only need the ID and carrying a full spec would be expensive to round trip. Add Java and Kryo serialization tests that compare the round-tripped file against the original.