### PR TITLE
Nessie: Check namespace existence at the ref HEAD in listNamespaces

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -272,11 +272,7 @@ public class NessieIcebergClient implements AutoCloseable {
         org.projectnessie.model.Namespace root =
             org.projectnessie.model.Namespace.of(namespace.levels());
         Content existing =
-            api.getContent()
-                .reference(getReference())
-                .key(root.toContentKey())
-                .get()
-                .get(root.toContentKey());
+            withReference(api.getContent()).key(root.toContentKey()).get().get(root.toContentKey());
         if (existing == null) {
           throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
         }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
@@ -112,6 +112,19 @@ public class TestMultipleClients extends BaseTestIceberg {
   }
 
   @Test
+  void listNestedNamespacesFromAnotherClient() {
+    // pins the other client to the current ref hash
+    assertThat(anotherCatalog.listNamespaces()).isEmpty();
+
+    catalog.createNamespace(Namespace.of("db1"), Collections.emptyMap());
+    catalog.createNamespace(Namespace.of("db1", "sub1"), Collections.emptyMap());
+
+    // the other client is still on the old ref hash, but listing reads the HEAD of the ref
+    assertThat(anotherCatalog.listNamespaces(Namespace.of("db1")))
+        .containsExactlyInAnyOrder(Namespace.of("db1", "sub1"));
+  }
+
+  @Test
   public void testLoadNamespaceMetadata() throws NessieConflictException, NessieNotFoundException {
     assertThatThrownBy(() -> catalog.loadNamespaceMetadata(Namespace.of("namespace1")))
         .isInstanceOf(NoSuchNamespaceException.class)


### PR DESCRIPTION
Closes #18034

## Summary

- `NessieIcebergClient.listNamespaces(Namespace)` read two commits in one call: the parent existence check was pinned to the hash the client cached when it first resolved the ref, while the child listing below it asked for the branch HEAD. A client behind that HEAD got `NoSuchNamespaceException` for a namespace another client had just created.
- The existence check now uses `withReference(api.getContent())`, matching `loadNamespaceMetadata()` in the same class.
- The three other `api.getContent().reference(getReference())` calls here (`createNamespace`, `dropNamespace`, `updateProperties`) are left alone: they are pre-checks run right before a commit against that same hash, so pinning it there is intended.
- The check was added by #12901 (fix for #12875).

## Testing done

- Added `TestMultipleClients#listNestedNamespacesFromAnotherClient`: one client creates `db1` and `db1.sub1`, a second client on the older ref hash lists `db1` and must see `db1.sub1`. It fails without the production change (API v1 and v2) and passes with it.
- `./gradlew :iceberg-nessie:check` — 488 tests passed, 0 failures, 30 skipped, including `TestBranchVisibility`, which covers the hash-pinned path where `withReference` falls back to `builder.reference(...)`. `:iceberg-nessie` is not REVAPI-published.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: Reviewed the diff and the regression test, and ran `:iceberg-nessie:check` locally before opening the PR.
- Prompt Summary: Make `listNamespaces(Namespace)` check the parent namespace at the HEAD of the ref instead of the client's cached hash, matching `loadNamespaceMetadata()`, and add a regression test to `TestMultipleClients`. Leave the other three hash-pinned pre-commit checks in the class untouched.



