### PR TITLE
MR: Keep computed block locations in IcebergSplit.getLocations

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -71,11 +71,10 @@ public class IcebergSplit extends InputSplit
   public String[] getLocations() {
     // The implementation of getLocations() is only meant to be used during split computation
     // getLocations() won't be accurate when called on worker nodes and will always return "*"
-    if (locations == null && conf != null) {
-      boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
+    if (locations == null) {
+      boolean localityPreferred =
+          conf != null && conf.getBoolean(InputFormatConfig.LOCALITY, false);
       locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE.clone();
-    } else {
-      locations = ANYWHERE.clone();
     }
 
     return locations;

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -326,6 +326,8 @@ public class TestIcebergInputFormats {
 
     for (InputSplit split : testInputFormat.create(builder.conf()).getSplits()) {
       assertThat(split.getLocations()).containsExactly("localhost");
+      // repeated calls must return the same locations that were computed and cached above
+      assertThat(split.getLocations()).containsExactly("localhost");
     }
   }
 


### PR DESCRIPTION
Closes #18032

## Summary

- `IcebergSplit` declares `transient String[] locations` and checks `locations == null`, so the value is meant to be computed once and cached. The `else` branch overwrites it with `ANYWHERE` on every later call, so two calls on an unchanged split return different values — Hadoop's `InputSplit.getLocations()` contract expects them to match.
- The `else` branch came in with [#1582](https://github.com/apache/iceberg/pull/1582), which fixed an NPE when `getLocations()` runs on a worker node whose deserialized split has a null `conf`. The original implementation, [#1192](https://github.com/apache/iceberg/pull/1192), had `if (locations == null)` alone. This change restores that shape and keeps the guard by folding the null check into `localityPreferred`, so a null `conf` still resolves to `ANYWHERE` and never calls `Util.blockLocations`.
- No production failure is claimed here: plain MapReduce submission calls `getLocations()` once per split, so the case rests on the contract and on the caching the class already declares.

## Testing done

- Extended `TestIcebergInputFormats#testLocality` to call `getLocations()` twice on the same split and assert both calls return the computed locations. It fails before the fix — all 6 parameterized variants return `["*"]` on the second call — and passes after.
- `./gradlew :iceberg-mr:check` — 158 tests, 0 failures.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix `IcebergSplit.getLocations()` so a cache hit returns the previously computed block locations instead of overwriting them with `ANYWHERE`, keep the null-`conf` NPE guard added in #1582, and extend `testLocality` to cover repeated calls.
