### PR TITLE
kafka connect: use a stable coordinator transactional id to fence stale coordinators

### DIFF
--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestContext.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestContext.java
@@ -119,6 +119,19 @@ public class TestContext {
         new StringSerializer());
   }
 
+  public KafkaProducer<String, String> initLocalTransactionalProducer(String transactionalId) {
+    return new KafkaProducer<>(
+        ImmutableMap.of(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            BOOTSTRAP_SERVERS,
+            ProducerConfig.CLIENT_ID_CONFIG,
+            UUID.randomUUID().toString(),
+            ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+            transactionalId),
+        new StringSerializer(),
+        new StringSerializer());
+  }
+
   public Admin initLocalAdmin() {
     return Admin.create(
         ImmutableMap.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS));

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
@@ -79,6 +79,11 @@ public class TestCoordinatorFencing {
     Map<String, String> connectorProps = connectorProps();
     String staleCoordinatorId = new IcebergSinkConfig(connectorProps).coordinatorTransactionalId();
     String newCoordinatorId = new IcebergSinkConfig(connectorProps).coordinatorTransactionalId();
+    assertThat(newCoordinatorId)
+        .as(
+            "coordinator·transactional·id·must·be·deterministic·and·match·across"
+                + "independently derived instances for the same connector")
+        .isEqualTo(staleCoordinatorId);
     KafkaProducer<String, String> staleCoordinator =
         context.initLocalTransactionalProducer(staleCoordinatorId);
     KafkaProducer<String, String> newCoordinator =

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a stale coordinator cannot overwrite offsets committed by a newer coordinator, even
+ * when the stale coordinator commits an offset ahead of its own previous one but still behind the
+ * newer coordinator's.
+ */
+public class TestCoordinatorFencing {
+
+  private static final long STALE_INITIAL_OFFSET = 100L;
+  private static final long NEW_COORDINATOR_OFFSET = 200L;
+  private static final long NEXT_STALE_OFFSET = 150L;
+
+  private final TestContext context = TestContext.instance();
+
+  private String topicName;
+  private String groupId;
+  private TopicPartition topicPartition;
+  private Admin admin;
+
+  @BeforeEach
+  public void before() {
+    topicName = "coord-fencing-topic-" + UUID.randomUUID();
+    groupId = "coord-fencing-group-" + UUID.randomUUID();
+    topicPartition = new TopicPartition(topicName, 0);
+    admin = context.initLocalAdmin();
+    createTopic(topicName);
+  }
+
+  @AfterEach
+  public void after() {
+    deleteTopic(topicName);
+    admin.close();
+  }
+
+  @Test
+  public void newCoordinatorFencesStaleCoordinatorOffsetCommits() throws Exception {
+    Map<String, String> connectorProps = connectorProps();
+    String staleCoordinatorId = new IcebergSinkConfig(connectorProps).coordinatorTransactionalId();
+    String newCoordinatorId = new IcebergSinkConfig(connectorProps).coordinatorTransactionalId();
+    KafkaProducer<String, String> staleCoordinator =
+        context.initLocalTransactionalProducer(staleCoordinatorId);
+    KafkaProducer<String, String> newCoordinator =
+        context.initLocalTransactionalProducer(newCoordinatorId);
+
+    try {
+      staleCoordinator.initTransactions();
+      commitOffset(staleCoordinator, STALE_INITIAL_OFFSET);
+      awaitCommittedOffset(STALE_INITIAL_OFFSET);
+
+      newCoordinator.initTransactions();
+      commitOffset(newCoordinator, NEW_COORDINATOR_OFFSET);
+      awaitCommittedOffset(NEW_COORDINATOR_OFFSET);
+
+      assertThatThrownBy(() -> commitOffset(staleCoordinator, NEXT_STALE_OFFSET))
+          .isInstanceOf(ProducerFencedException.class);
+
+      assertThat(committedOffset())
+          .as("fenced coordinator must not clobber the new coordinator's committed offset")
+          .isEqualTo(NEW_COORDINATOR_OFFSET);
+    } finally {
+      staleCoordinator.close();
+      newCoordinator.close();
+    }
+  }
+
+  private Map<String, String> connectorProps() {
+    return ImmutableMap.of(
+        "iceberg.catalog.type", "rest",
+        "iceberg.tables", "db.tbl",
+        "name", "coord-fencing-connector-" + UUID.randomUUID());
+  }
+
+  private void commitOffset(KafkaProducer<String, String> producer, long offset) {
+    producer.beginTransaction();
+    producer.sendOffsetsToTransaction(
+        ImmutableMap.of(topicPartition, new OffsetAndMetadata(offset)),
+        new ConsumerGroupMetadata(groupId));
+    producer.commitTransaction();
+  }
+
+  private void awaitCommittedOffset(long expected) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(() -> assertThat(committedOffset()).isEqualTo(expected));
+  }
+
+  private long committedOffset() throws InterruptedException, ExecutionException, TimeoutException {
+    Map<TopicPartition, OffsetAndMetadata> offsets =
+        admin
+            .listConsumerGroupOffsets(groupId)
+            .partitionsToOffsetAndMetadata()
+            .get(10, TimeUnit.SECONDS);
+    OffsetAndMetadata metadata = offsets.get(topicPartition);
+    return metadata == null ? -1L : metadata.offset();
+  }
+
+  private void createTopic(String topic) {
+    try {
+      admin
+          .createTopics(ImmutableList.of(new NewTopic(topic, 1, (short) 1)))
+          .all()
+          .get(10, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void deleteTopic(String topic) {
+    try {
+      admin.deleteTopics(ImmutableList.of(topic)).all().get(10, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestCoordinatorFencing.java
@@ -94,7 +94,8 @@ public class TestCoordinatorFencing {
       awaitCommittedOffset(NEW_COORDINATOR_OFFSET);
 
       assertThatThrownBy(() -> commitOffset(staleCoordinator, NEXT_STALE_OFFSET))
-          .isInstanceOf(ProducerFencedException.class);
+          .isInstanceOf(ProducerFencedException.class)
+          .hasMessageContaining("fence");
 
       assertThat(committedOffset())
           .as("fenced coordinator must not clobber the new coordinator's committed offset")

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -311,7 +311,7 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String transactionalSuffix() {
     // this is for internal use and is not part of the config definition...
-    return originalProps.get(INTERNAL_TRANSACTIONAL_SUFFIX_PROP);
+    return originalProps.getOrDefault(INTERNAL_TRANSACTIONAL_SUFFIX_PROP, "");
   }
 
   public Map<String, String> catalogProps() {
@@ -448,6 +448,9 @@ public class IcebergSinkConfig extends AbstractConfig {
    * across coordinator instances and task restarts within a connector, and unique across
    * connectors. Its stability lets an incoming coordinator's {@code initTransactions()} bump the
    * producer epoch and fence a stale coordinator.
+   *
+   * <p>Unlike the worker producer id, this intentionally omits {@link #transactionalSuffix()}: a
+   * per-task/per-instance suffix would make each coordinator's id unique and prevent fencing.
    */
   public String coordinatorTransactionalId() {
     return transactionalPrefix() + connectGroupId() + "-coordinator";

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -443,6 +443,16 @@ public class IcebergSinkConfig extends AbstractConfig {
     return "";
   }
 
+  /**
+   * The transactional ID for the coordinator's producer: scoped to the coordinator role, stable
+   * across coordinator instances and task restarts within a connector, and unique across
+   * connectors. Its stability lets an incoming coordinator's {@code initTransactions()} bump the
+   * producer epoch and fence a stale coordinator.
+   */
+  public String coordinatorTransactionalId() {
+    return transactionalPrefix() + connectGroupId() + "-coordinator";
+  }
+
   public String hadoopConfDir() {
     return getString(HADOOP_CONF_DIR_PROP);
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -56,8 +56,8 @@ abstract class Channel {
   private final String producerId;
 
   Channel(
-      String name,
       String consumerGroupId,
+      String transactionalId,
       IcebergSinkConfig config,
       KafkaClientFactory clientFactory,
       SinkTaskContext context) {
@@ -65,7 +65,6 @@ abstract class Channel {
     this.connectGroupId = config.connectGroupId();
     this.context = context;
 
-    String transactionalId = config.transactionalPrefix() + name + config.transactionalSuffix();
     this.producer = clientFactory.createProducer(transactionalId);
     this.consumer = clientFactory.createConsumer(consumerGroupId);
     this.admin = clientFactory.createAdmin();
@@ -147,10 +146,11 @@ abstract class Channel {
   }
 
   /**
-   * Commit consumer offsets. Only commits offsets if it has not committed offsets before or the
-   * value is greater than the cached offset.
-   *
-   * <p>Note: there is a risk that two parallel coordinators may overwrite each other's offsets.
+   * Commits consumer offsets through the coordinator's transactional producer, committing a
+   * partition's offset only when it advances past the last committed value. The producer uses a
+   * connector-stable {@code transactional.id}, so a newly elected coordinator's {@code
+   * initTransactions()} bumps the producer epoch and fences a superseded coordinator, whose commit
+   * then fails with a {@link org.apache.kafka.common.errors.ProducerFencedException}.
    */
   protected void commitConsumerOffsets() {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
@@ -177,7 +177,20 @@ abstract class Channel {
 
     if (!offsetsToCommit.isEmpty()) {
       LOG.debug("Committing consumer offsets: {}", offsetsToCommit);
-      consumer.commitSync(offsetsToCommit);
+      synchronized (producer) {
+        producer.beginTransaction();
+        try {
+          producer.sendOffsetsToTransaction(offsetsToCommit, consumer.groupMetadata());
+          producer.commitTransaction();
+        } catch (Exception e) {
+          try {
+            producer.abortTransaction();
+          } catch (Exception ex) {
+            LOG.warn("Error aborting producer transaction", ex);
+          }
+          throw e;
+        }
+      }
       offsetsToCommit.forEach(
           (topicPartition, metadata) ->
               committedOffsets.put(topicPartition.partition(), metadata.offset()));

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -37,6 +37,8 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,11 +148,17 @@ abstract class Channel {
   }
 
   /**
-   * Commits consumer offsets through the coordinator's transactional producer, committing a
-   * partition's offset only when it advances past the last committed value. The producer uses a
-   * connector-stable {@code transactional.id}, so a newly elected coordinator's {@code
-   * initTransactions()} bumps the producer epoch and fences a superseded coordinator, whose commit
-   * then fails with a {@link org.apache.kafka.common.errors.ProducerFencedException}.
+   * Commits consumer offsets in a separate Kafka transaction on the coordinator's transactional
+   * producer, committing a partition's offset only when it advances past the last committed value.
+   * The producer uses a connector-stable {@code transactional.id}, so a newly elected coordinator's
+   * {@code initTransactions()} bumps the producer epoch and fences a superseded coordinator, whose
+   * offset commit then fails with a {@link org.apache.kafka.common.errors.ProducerFencedException}.
+   *
+   * <p>This transaction covers only the consumer offset commit, not the Iceberg table snapshot
+   * commit. The snapshot commit runs outside any Kafka transaction, so a stale coordinator can
+   * still land a snapshot in the window between the new coordinator's {@code initTransactions()}
+   * and its own fenced offset commit; that case is guarded separately at the Iceberg level by the
+   * {@code SnapshotAncestryValidator} offset validator, not by epoch fencing.
    */
   protected void commitConsumerOffsets() {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
@@ -183,10 +191,9 @@ abstract class Channel {
           producer.sendOffsetsToTransaction(offsetsToCommit, consumer.groupMetadata());
           producer.commitTransaction();
         } catch (Exception e) {
-          try {
-            producer.abortTransaction();
-          } catch (Exception ex) {
-            LOG.warn("Error aborting producer transaction", ex);
+          // fenced producers are fatal and can't abort, so only non-fenced producers abort
+          if (!isProducerFenced(e)) {
+            abortTransaction();
           }
           throw e;
         }
@@ -194,6 +201,19 @@ abstract class Channel {
       offsetsToCommit.forEach(
           (topicPartition, metadata) ->
               committedOffsets.put(topicPartition.partition(), metadata.offset()));
+    }
+  }
+
+  private static boolean isProducerFenced(Exception error) {
+    return error instanceof ProducerFencedException
+        || error instanceof InvalidProducerEpochException;
+  }
+
+  private void abortTransaction() {
+    try {
+      producer.abortTransaction();
+    } catch (Exception e) {
+      LOG.warn("Error aborting producer transaction", e);
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -197,8 +197,14 @@ public class CommitterImpl implements Committer {
 
   private void processControlEvents() {
     if (coordinatorThread != null && coordinatorThread.isTerminated()) {
-      throw new NotRunningException(
-          String.format("Coordinator unexpectedly terminated on committer %s", taskId));
+      if (coordinatorThread.isFenced()) {
+        LOG.warn("Coordinator on committer {} was fenced by a newer coordinator; clearing", taskId);
+        coordinatorThread = null;
+      } else {
+        throw new NotRunningException(
+            String.format("Coordinator unexpectedly terminated on committer %s", taskId),
+            coordinatorThread.error());
+      }
     }
     if (worker != null) {
       worker.process();

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -94,7 +94,12 @@ class Coordinator extends Channel {
       KafkaClientFactory clientFactory,
       SinkTaskContext context) {
     // pass consumer group ID to which we commit low watermark offsets
-    super("coordinator", config.connectGroupId() + "-coord", config, clientFactory, context);
+    super(
+        config.connectGroupId() + "-coord",
+        config.coordinatorTransactionalId(),
+        config,
+        clientFactory,
+        context);
 
     this.catalog = catalog;
     this.config = config;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +29,7 @@ class CoordinatorThread extends Thread {
 
   private final Coordinator coordinator;
   private volatile boolean terminated;
+  private volatile Throwable error;
 
   CoordinatorThread(Coordinator coordinator) {
     super(THREAD_NAME);
@@ -39,6 +42,7 @@ class CoordinatorThread extends Thread {
       coordinator.start();
     } catch (Exception e) {
       LOG.error("Coordinator error during start, exiting thread", e);
+      this.error = e;
       this.terminated = true;
     }
 
@@ -47,6 +51,7 @@ class CoordinatorThread extends Thread {
         coordinator.process();
       } catch (Exception e) {
         LOG.error("Coordinator error during process, exiting thread", e);
+        this.error = e;
         this.terminated = true;
       }
     }
@@ -60,6 +65,19 @@ class CoordinatorThread extends Thread {
 
   boolean isTerminated() {
     return terminated;
+  }
+
+  Throwable error() {
+    return error;
+  }
+
+  /**
+   * Whether the coordinator terminated because a newer coordinator reused its {@code
+   * transactional.id} and bumped the producer epoch, fencing this one.
+   */
+  boolean isFenced() {
+    return error instanceof ProducerFencedException
+        || error instanceof InvalidProducerEpochException;
   }
 
   void terminate() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/NotRunningException.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/NotRunningException.java
@@ -22,4 +22,8 @@ public class NotRunningException extends RuntimeException {
   public NotRunningException(String msg) {
     super(msg);
   }
+
+  public NotRunningException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -49,8 +49,8 @@ class Worker extends Channel {
       SinkTaskContext context) {
     // pass transient consumer group ID to which we never commit offsets
     super(
-        "worker",
         config.controlGroupIdPrefix() + UUID.randomUUID(),
+        config.transactionalPrefix() + "worker" + config.transactionalSuffix(),
         config,
         clientFactory,
         context);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
@@ -39,12 +40,14 @@ import org.apache.iceberg.connect.TableSinkConfig;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.KafkaFuture;
@@ -138,6 +141,14 @@ public class ChannelTestBase {
     TopicPartition tp = new TopicPartition(CTL_TOPIC_NAME, 0);
     consumer.rebalance(ImmutableList.of(tp));
     consumer.updateBeginningOffsets(ImmutableMap.of(tp, 0L));
+  }
+
+  protected Map<TopicPartition, OffsetAndMetadata> committedGroupOffsets(String groupId) {
+    Map<TopicPartition, OffsetAndMetadata> latest = Maps.newHashMap();
+    producer.consumerGroupOffsetsHistory().stream()
+        .filter(commit -> commit.containsKey(groupId))
+        .forEach(commit -> latest.putAll(commit.get(groupId)));
+    return latest;
   }
 
   private class Listener implements ConsumerRebalanceListener {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -101,6 +101,8 @@ public class ChannelTestBase {
     when(config.controlTopic()).thenReturn(CTL_TOPIC_NAME);
     when(config.commitThreads()).thenReturn(1);
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
+    when(config.coordinatorTransactionalId())
+        .thenReturn(CONNECT_CONSUMER_GROUP_ID + "-coordinator");
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
     when(config.commitMaxConsecutiveFailures()).thenReturn(1);
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.AvroUtil;
@@ -70,14 +69,8 @@ public class TestChannel extends ChannelTestBase {
 
     // the offset committed for the group is what a restarted channel resumes from, and what the
     // coordinator stamps on the snapshot, so a regression here is durable
-    assertThat(lastGroupOffsets()).containsEntry(CTL_TOPIC_PARTITION, new OffsetAndMetadata(5L));
-  }
-
-  private Map<TopicPartition, OffsetAndMetadata> lastGroupOffsets() {
-    List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> history =
-        producer.consumerGroupOffsetsHistory();
-    assertThat(history).isNotEmpty();
-    return history.get(history.size() - 1).values().iterator().next();
+    assertThat(committedGroupOffsets(consumer.groupMetadata().groupId()))
+        .containsEntry(CTL_TOPIC_PARTITION, new OffsetAndMetadata(5L));
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestChannel.java
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -70,8 +70,14 @@ public class TestChannel extends ChannelTestBase {
 
     // the offset committed for the group is what a restarted channel resumes from, and what the
     // coordinator stamps on the snapshot, so a regression here is durable
-    assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .containsEntry(CTL_TOPIC_PARTITION, new OffsetAndMetadata(5L));
+    assertThat(lastGroupOffsets()).containsEntry(CTL_TOPIC_PARTITION, new OffsetAndMetadata(5L));
+  }
+
+  private Map<TopicPartition, OffsetAndMetadata> lastGroupOffsets() {
+    List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> history =
+        producer.consumerGroupOffsetsHistory();
+    assertThat(history).isNotEmpty();
+    return history.get(history.size() - 1).values().iterator().next();
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
@@ -40,7 +40,11 @@ import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 
 public class TestCommitterImpl {
@@ -123,8 +127,9 @@ public class TestCommitterImpl {
   @Test
   public void testCommitFailurePropagatesAsNotRunningException()
       throws NoSuchFieldException, IllegalAccessException {
+    RuntimeException cause = new RuntimeException("commit failed");
     Coordinator coordinator = mock(Coordinator.class);
-    doThrow(new RuntimeException("commit failed")).when(coordinator).process();
+    doThrow(cause).when(coordinator).process();
 
     CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
     coordinatorThread.start();
@@ -132,6 +137,7 @@ public class TestCommitterImpl {
     // wait for the thread to catch the exception, set terminated, and call stop
     verify(coordinator, timeout(1000)).stop();
     assertThat(coordinatorThread.isTerminated()).isTrue();
+    assertThat(coordinatorThread.isFenced()).isFalse();
 
     CommitterImpl committer = new CommitterImpl();
     Field field = CommitterImpl.class.getDeclaredField("coordinatorThread");
@@ -140,7 +146,9 @@ public class TestCommitterImpl {
 
     assertThatThrownBy(() -> committer.save(Collections.emptyList()))
         .isInstanceOf(NotRunningException.class)
-        .hasMessageContaining("Coordinator unexpectedly terminated");
+        .hasMessageContaining("Coordinator unexpectedly terminated")
+        .cause()
+        .isSameAs(cause);
   }
 
   @Test
@@ -164,5 +172,55 @@ public class TestCommitterImpl {
     assertThatThrownBy(() -> committer.save(Collections.emptyList()))
         .isInstanceOf(NotRunningException.class)
         .hasMessageContaining("Coordinator unexpectedly terminated");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ProducerFenced", "InvalidProducerEpoch"})
+  public void testFencedCoordinatorIsClearedWithoutFailingTask(String exceptionType)
+      throws NoSuchFieldException, IllegalAccessException {
+    RuntimeException fenceException =
+        "ProducerFenced".equals(exceptionType)
+            ? new ProducerFencedException("fenced by a newer coordinator")
+            : new InvalidProducerEpochException("producer epoch bumped by a newer coordinator");
+
+    Coordinator coordinator = mock(Coordinator.class);
+    doThrow(fenceException).when(coordinator).process();
+
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.start();
+
+    verify(coordinator, timeout(1000)).stop();
+    assertThat(coordinatorThread.isTerminated()).isTrue();
+    assertThat(coordinatorThread.isFenced()).isTrue();
+
+    CommitterImpl committer = new CommitterImpl();
+    Field field = CommitterImpl.class.getDeclaredField("coordinatorThread");
+    field.setAccessible(true);
+    field.set(committer, coordinatorThread);
+
+    committer.save(Collections.emptyList());
+    assertThat(field.get(committer)).isNull();
+  }
+
+  @Test
+  public void testRequestedTerminationWithNoRecordedErrorIsTreatedAsFatal()
+      throws NoSuchFieldException, IllegalAccessException {
+    Coordinator coordinator = mock(Coordinator.class);
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.terminate();
+
+    assertThat(coordinatorThread.isTerminated()).isTrue();
+    assertThat(coordinatorThread.isFenced()).isFalse();
+    assertThat(coordinatorThread.error()).isNull();
+
+    CommitterImpl committer = new CommitterImpl();
+    Field field = CommitterImpl.class.getDeclaredField("coordinatorThread");
+    field.setAccessible(true);
+    field.set(committer, coordinatorThread);
+
+    assertThatThrownBy(() -> committer.save(Collections.emptyList()))
+        .isInstanceOf(NotRunningException.class)
+        .hasMessageContaining("Coordinator unexpectedly terminated")
+        .hasNoCause();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
@@ -201,26 +201,4 @@ public class TestCommitterImpl {
     committer.save(Collections.emptyList());
     assertThat(field.get(committer)).isNull();
   }
-
-  @Test
-  public void testRequestedTerminationWithNoRecordedErrorIsTreatedAsFatal()
-      throws NoSuchFieldException, IllegalAccessException {
-    Coordinator coordinator = mock(Coordinator.class);
-    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
-    coordinatorThread.terminate();
-
-    assertThat(coordinatorThread.isTerminated()).isTrue();
-    assertThat(coordinatorThread.isFenced()).isFalse();
-    assertThat(coordinatorThread.error()).isNull();
-
-    CommitterImpl committer = new CommitterImpl();
-    Field field = CommitterImpl.class.getDeclaredField("coordinatorThread");
-    field.setAccessible(true);
-    field.set(committer, coordinatorThread);
-
-    assertThatThrownBy(() -> committer.save(Collections.emptyList()))
-        .isInstanceOf(NotRunningException.class)
-        .hasMessageContaining("Coordinator unexpectedly terminated")
-        .hasNoCause();
-  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -55,12 +55,12 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
 
@@ -324,8 +324,6 @@ public class TestCoordinator extends ChannelTestBase {
   public void testCommitConsumerOffsetsDoesNotRewind() {
     Coordinator coordinator = startCoordinator();
 
-    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
-
     long healthyWatermark = 100L;
     coordinator.controlTopicOffsets().put(0, healthyWatermark);
     coordinator.commitConsumerOffsets();
@@ -333,39 +331,28 @@ public class TestCoordinator extends ChannelTestBase {
     coordinator.controlTopicOffsets().put(0, 5L);
     coordinator.commitConsumerOffsets();
 
-    OffsetAndMetadata committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
-
-    assertThat(committed)
-        .as("commitConsumerOffsets should not rewind the shared -coord consumer group offsets")
+    assertThat(lastCommittedOffset(0))
+        .as("commitConsumerOffsets should not rewind the -coord consumer group offsets")
         .isEqualTo(healthyWatermark);
   }
 
   @Test
-  public void testCommitConsumerDuplicateDoesNotCommit() {
+  public void testFencedCoordinatorCannotCommitOffsets() {
     Coordinator coordinator = startCoordinator();
-
-    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
-
-    long healthyWatermark = 100L;
-    coordinator.controlTopicOffsets().put(0, healthyWatermark);
-    coordinator.commitConsumerOffsets();
-
-    long nextWatermark = healthyWatermark + 5;
-    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(nextWatermark)));
 
     coordinator.controlTopicOffsets().put(0, 100L);
     coordinator.commitConsumerOffsets();
 
-    OffsetAndMetadata committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
+    producer.fenceProducer();
 
-    assertThat(committed)
-        .as(
-            "commitConsumerOffsets should not commit offsets when offset has not changed relative to local cache")
-        .isEqualTo(nextWatermark);
+    coordinator.controlTopicOffsets().put(0, 150L);
+    assertThatThrownBy(coordinator::commitConsumerOffsets)
+        .as("a fenced coordinator must not be able to commit offsets")
+        .isInstanceOf(ProducerFencedException.class);
+
+    assertThat(lastCommittedOffset(0))
+        .as("the fenced coordinator's offset must never reach the offset store")
+        .isEqualTo(100L);
   }
 
   @Test
@@ -373,17 +360,10 @@ public class TestCoordinator extends ChannelTestBase {
     Coordinator coordinator = startCoordinator();
 
     long newWatermark = 5L;
-
-    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
     coordinator.controlTopicOffsets().put(0, newWatermark);
-
     coordinator.commitConsumerOffsets();
 
-    OffsetAndMetadata committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
-
-    assertThat(committed)
+    assertThat(lastCommittedOffset(0))
         .as("commitConsumerOffsets should advance offsets on its first commit")
         .isEqualTo(newWatermark);
   }
@@ -393,8 +373,6 @@ public class TestCoordinator extends ChannelTestBase {
     Coordinator coordinator = startCoordinator();
 
     long healthyWatermark = 100L;
-    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
-
     coordinator.controlTopicOffsets().put(0, healthyWatermark);
     coordinator.commitConsumerOffsets();
 
@@ -402,11 +380,7 @@ public class TestCoordinator extends ChannelTestBase {
     coordinator.controlTopicOffsets().put(0, watermarkToCommit);
     coordinator.commitConsumerOffsets();
 
-    OffsetAndMetadata committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
-
-    assertThat(committed)
+    assertThat(lastCommittedOffset(0))
         .as("commitConsumerOffsets should advance offsets when its value is greater")
         .isEqualTo(watermarkToCommit);
   }
@@ -433,19 +407,28 @@ public class TestCoordinator extends ChannelTestBase {
     coordinator.controlTopicOffsets().put(1, watermarkToSkip);
     coordinator.commitConsumerOffsets();
 
-    Map<TopicPartition, OffsetAndMetadata> committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl0, ctl1));
-
-    OffsetAndMetadata committed0 = committedOffsetAndMetadata.get(ctl0);
-    OffsetAndMetadata committed1 = committedOffsetAndMetadata.get(ctl1);
-
-    assertThat(committed0 == null ? 0L : committed0.offset())
+    assertThat(lastCommittedOffset(0))
         .as("commitConsumerOffsets should advance the consumer group offsets")
         .isEqualTo(watermarkToCommit);
 
-    assertThat(committed1 == null ? 0L : committed1.offset())
+    assertThat(lastCommittedOffset(1))
         .as("commitConsumerOffsets should not rewind consumer group offsets")
         .isEqualTo(healthWatermark1);
+  }
+
+  private Long lastCommittedOffset(int partition) {
+    TopicPartition topicPartition = new TopicPartition(CTL_TOPIC_NAME, partition);
+    Long result = null;
+    for (Map<String, Map<TopicPartition, OffsetAndMetadata>> committed :
+        producer.consumerGroupOffsetsHistory()) {
+      for (Map<TopicPartition, OffsetAndMetadata> offsets : committed.values()) {
+        OffsetAndMetadata metadata = offsets.get(topicPartition);
+        if (metadata != null) {
+          result = metadata.offset();
+        }
+      }
+    }
+    return result;
   }
 
   private Coordinator startCoordinator() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -26,9 +26,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -357,6 +358,39 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   @Test
+  public void testFencedCoordinatorThreadIsClearedByCommitterWithoutFailingTask()
+      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+
+    producer.fenceProducer();
+
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.start();
+    coordinatorThread.join(5000);
+
+    assertThat(coordinatorThread.isTerminated()).isTrue();
+    assertThat(coordinatorThread.isFenced())
+        .as("a real coordinator whose producer was fenced must report as fenced")
+        .isTrue();
+
+    CommitterImpl committer = new CommitterImpl();
+    Field field = CommitterImpl.class.getDeclaredField("coordinatorThread");
+    field.setAccessible(true);
+    field.set(committer, coordinatorThread);
+
+    committer.save(Collections.emptyList());
+
+    assertThat(field.get(committer))
+        .as("committer must clear a fenced coordinator instead of failing the task")
+        .isNull();
+  }
+
+  @Test
   public void testCommitNewConsumerAdvances() {
     Coordinator coordinator = startCoordinator();
 
@@ -418,18 +452,13 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   private Long lastCommittedOffset(int partition) {
-    TopicPartition topicPartition = new TopicPartition(CTL_TOPIC_NAME, partition);
-    Long result = null;
-    for (Map<String, Map<TopicPartition, OffsetAndMetadata>> committed :
-        producer.consumerGroupOffsetsHistory()) {
-      for (Map<TopicPartition, OffsetAndMetadata> offsets : committed.values()) {
-        OffsetAndMetadata metadata = offsets.get(topicPartition);
-        if (metadata != null) {
-          result = metadata.offset();
-        }
-      }
-    }
-    return result;
+    String groupId = consumer.groupMetadata().groupId();
+    OffsetAndMetadata metadata =
+        committedGroupOffsets(groupId).get(new TopicPartition(CTL_TOPIC_NAME, partition));
+    assertThat(metadata)
+        .as("expected a committed offset for partition %s in group %s", partition, groupId)
+        .isNotNull();
+    return metadata.offset();
   }
 
   private Coordinator startCoordinator() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -348,7 +348,8 @@ public class TestCoordinator extends ChannelTestBase {
     coordinator.controlTopicOffsets().put(0, 150L);
     assertThatThrownBy(coordinator::commitConsumerOffsets)
         .as("a fenced coordinator must not be able to commit offsets")
-        .isInstanceOf(ProducerFencedException.class);
+        .isInstanceOf(ProducerFencedException.class)
+        .hasMessageContaining("fenced");
 
     assertThat(lastCommittedOffset(0))
         .as("the fenced coordinator's offset must never reach the offset store")


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/iceberg/issues/18038

Add support for coordinator fencing. This can prevent stale ("zombie") coordinators from committing stale consumer offsets.

### Implementation

Currently, we generate a new UUID for every new coordinator. This means that the Kafka transaction we use trivially passes since no epoch fencing can be performed on the newly generated ID (e.g., between a stale or an up to date coordinator).

The change is to use a persistent transactional ID for the coordinator. We name this using the connect group ID which is unique to that connector. Then any leader change of that group will trigger Kafka to update the epoch of the transaction, and correctly fence stale coordinators. A stale coordinator will identify that it has been fenced, and exit the coordinator thread. We leave the worker task running and defer to Kafka Connect on determining its lifecycle.

Note: we introduced a [in-memory monotonic increasing offset guard](https://github.com/apache/iceberg/pull/17552) to make offsets monotonically increasing (values that are non-increasing are not committed). This was a tightly scoped fix to reduce the risk of a coordinator committing old offsets (which can cause data loss). However, it is theoretically possible that offsets could still be updated if an older coordinator wrote a higher offset than it last stored, but is less than another coordinator's written offset. The way to solve this and the canonical one in Kafka is with producer fencing. So we add the offset commit in its own transaction, and defer to kafka for epoch fencing.

Note: we also intentionally make the commit consumer offsets its separate transaction. It is outside the scope of this PR to refactor the offset transaction semantics (eg grouping the control topic offset write with the consumer offset commit). This delivers the minimal set of changes to have fenced consumer offset commits.

### Testing

Used an integration test to reproduce this failure scenario first (ie a stale coordinator with an increasing offset but is older than another offset of a newer coordinator). Also added unit tests as well.

### Release Notes

Add this to the release notes that this change will be included in:
> Kafka transaction fencing for consumer-offset commits: The commit coordinator now uses a stable, connector-scoped producer transactional.id, so a newly elected coordinator fences any superseded one via
> producer-epoch bumping and prevents it from committing stale consumer offsets. During the rollout of the upgraded version this guard is not yet in effect: a coordinator still on the previous version uses a
> different transactional.id, sits in a separate fencing namespace, and can keep committing until it is restarted onto the new version. Confirm the rollout is complete and the offset-commit guard fully active 
> by verifying each connector is back to a single coordinator (e.g., the `iceberg_kafka_connect_metrics_coordinator_metrics_start_commit_total` metric reports one coordinator per connector). When the coordinator count settles to 1 per connector, no stale coordinators remain.

### Related Work

In-memory monotonic offset guard:
* https://github.com/apache/iceberg/issues/17551
* https://github.com/apache/iceberg/pull/17552

Larger scoped coordinator refactor (PR is stale, has merge conflicts):
* https://github.com/apache/iceberg/pull/17376

Related preventative setting offset reset strategy:
* https://github.com/apache/iceberg/pull/18006