### PR TITLE
Build: Fix Spark publication and CI configuration

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -35,7 +35,7 @@ on:
       - '.github/workflows/flink-ci.yml'
       - '.github/workflows/hive-ci.yml'
       - '.github/workflows/java-ci.yml'
-      - '.github/workflows/jmh-benchmarks-ci.yml'
+      - '.github/workflows/jmh-benchmarks.yml'
       - '.github/workflows/kafka-connect-ci.yml'
       - '.github/workflows/cve-scan.yml'
       - '.github/workflows/labeler.yml'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -35,7 +35,7 @@ on:
     - '.github/workflows/docs-ci.yml'
     - '.github/workflows/hive-ci.yml'
     - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/jmh-benchmarks.yml'
     - '.github/workflows/kafka-connect-ci.yml'
     - '.github/workflows/cve-scan.yml'
     - '.github/workflows/labeler.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -35,7 +35,7 @@ on:
     - '.github/workflows/docs-ci.yml'
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/jmh-benchmarks.yml'
     - '.github/workflows/kafka-connect-ci.yml'
     - '.github/workflows/cve-scan.yml'
     - '.github/workflows/labeler.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -35,7 +35,7 @@ on:
     - '.github/workflows/docs-ci.yml'
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/jmh-benchmarks.yml'
     - '.github/workflows/kafka-connect-ci.yml'
     - '.github/workflows/cve-scan.yml'
     - '.github/workflows/labeler.yml'

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -36,7 +36,7 @@ on:
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'
     - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/jmh-benchmarks.yml'
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -53,4 +53,8 @@ jobs:
         run: |
           ./gradlew printVersion
           ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser="$NEXUS_USER" -PmavenPassword="$NEXUS_PW"
-          ./gradlew -DflinkVersions= -DsparkVersions=3.5,4.0 -DscalaVersion=2.13 -DkafkaVersions=3 publishApachePublicationToMavenRepository -PmavenUser="$NEXUS_USER" -PmavenPassword="$NEXUS_PW"
+          ./gradlew -DflinkVersions= -DsparkVersions=3.5 -DscalaVersion=2.13 -DkafkaVersions= \
+            :iceberg-spark:iceberg-spark-3.5_2.13:publishApachePublicationToMavenRepository \
+            :iceberg-spark:iceberg-spark-extensions-3.5_2.13:publishApachePublicationToMavenRepository \
+            :iceberg-spark:iceberg-spark-runtime-3.5_2.13:publishApachePublicationToMavenRepository \
+            -PmavenUser="$NEXUS_USER" -PmavenPassword="$NEXUS_PW"

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -36,7 +36,7 @@ on:
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'
     - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/jmh-benchmarks.yml'
     - '.github/workflows/kafka-connect-ci.yml'
     - '.github/workflows/cve-scan.yml'
     - '.github/workflows/labeler.yml'
@@ -81,6 +81,8 @@ jobs:
       # Keep matrix <= 20 jobs; exceeding it queues a second wave and slows CI.
       max-parallel: 20
       matrix:
+        # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
+        # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
         jvm: [17, 21]
         event_name: ['${{ github.event_name }}']
         spark: ['3.5', '4.0', '4.1', '4.2']
@@ -89,8 +91,7 @@ jobs:
         # so they run as concurrent jobs rather than serially in one job.
         tests: [core, extensions]
         exclude:
-          # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
-          # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
+          # Spark 4.0+ only supports Scala 2.13.
           - spark: '4.0'
             scala: '2.12'
           - spark: '4.1'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -82,7 +82,6 @@ jobs:
       max-parallel: 20
       matrix:
         # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
-        # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
         jvm: [17, 21]
         event_name: ['${{ github.event_name }}']
         spark: ['3.5', '4.0', '4.1', '4.2']

--- a/build.gradle
+++ b/build.gradle
@@ -1258,8 +1258,11 @@ project(':iceberg-bom') {
       // only contain artifacts for that single Scala version. The following code ensures that
       // the BOM references the artifacts for all Scala versions.
       def sparkScalaPattern = ~"(.*)-([0-9][.][0-9]+)_([0-9][.][0-9]+)"
+      // Only include Spark versions published in binary releases.
       def sparkScalaVersions = [
         "3.5": ["2.12", "2.13"],
+        "4.0": ["2.13"],
+        "4.1": ["2.13"],
       ]
       rootProject.allprojects.forEach {
         // Do not include ':iceberg-spark', the bom itself and the root project.

--- a/dev/stage-binaries.sh
+++ b/dev/stage-binaries.sh
@@ -20,6 +20,7 @@
 
 SCALA_VERSION=2.12
 FLINK_VERSIONS=1.20,2.1,2.2,2.3
+# Spark 4.2 is intentionally excluded because it is not part of binary releases.
 SPARK_VERSIONS=3.5,4.0,4.1
 KAFKA_VERSIONS=3
 
@@ -29,4 +30,3 @@ KAFKA_VERSIONS=3
 # Flink does not yet support 2.13 (and is largely dropping a user-facing dependency on Scala). Hive doesn't need a Scala specification.
 ./gradlew -Prelease -DscalaVersion=2.13 -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.5_2.13:publishApachePublicationToMavenRepository --no-parallel --no-configuration-cache
 # Spark 4.0+ only supports Scala 2.13. no need to specify scalaVersion
-

--- a/dev/stage-binaries.sh
+++ b/dev/stage-binaries.sh
@@ -20,7 +20,6 @@
 
 SCALA_VERSION=2.12
 FLINK_VERSIONS=1.20,2.1,2.2,2.3
-# Spark 4.2 is intentionally excluded because it is not part of binary releases.
 SPARK_VERSIONS=3.5,4.0,4.1
 KAFKA_VERSIONS=3
 
@@ -30,3 +29,4 @@ KAFKA_VERSIONS=3
 # Flink does not yet support 2.13 (and is largely dropping a user-facing dependency on Scala). Hive doesn't need a Scala specification.
 ./gradlew -Prelease -DscalaVersion=2.13 -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.5_2.13:publishApachePublicationToMavenRepository --no-parallel --no-configuration-cache
 # Spark 4.0+ only supports Scala 2.13. no need to specify scalaVersion
+


### PR DESCRIPTION
## Summary

The supplemental snapshot publication repeats publication of common modules, Kafka Connect, and Spark 4.0 artifacts already covered by the all-modules pass. Limit it to the three additional Spark 3.5/Scala 2.13 artifacts: integration, extensions, and runtime.

Add Spark 4.0 and 4.1/Scala 2.13 entries to the BOM so consumers can use its version constraints for those artifacts. Keep Spark 4.2 excluded from the release BOM.

Correct stale JMH workflow paths in CI filters and align Spark matrix comments with the configuration they describe.

## Validation

- `./gradlew spotlessCheck`
- Dry-run of the three supplemental snapshot publication tasks
- Generated the all-modules BOM and verified Spark constraint counts
- Parsed all 23 GitHub workflow YAML files
- `git diff --check`

---
**AI Disclosure**
- Model: GPT-5 (initial changes, as previously recorded); GPT-6 (follow-up edits and description)
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Fix Spark snapshot publication, release BOM entries, and CI configuration; remove the outdated Java 21 comment and keep dev/stage-binaries.sh unchanged.

