### PR TITLE
Docker: Use WAL mode for the REST fixture's SQLite backend

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -35,7 +35,7 @@ COPY --chown=iceberg:iceberg open-api/build/libs/iceberg-open-api-test-fixtures-
 COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh /usr/lib/iceberg-rest/entrypoint.sh
 
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
-ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db
+ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL
 ENV CATALOG_JDBC_USER=user
 ENV CATALOG_JDBC_PASSWORD=password
 ENV CATALOG_JDBC_STRICT__MODE=true

--- a/docker/iceberg-rest-fixture/README.md
+++ b/docker/iceberg-rest-fixture/README.md
@@ -42,8 +42,13 @@ underscores become dashes (`-`). Names are lowercased.
 | `CATALOG_IO__IMPL` | `io-impl` |
 | `CATALOG_JDBC_USER` | `jdbc.user` |
 
-If `catalog-impl` and `uri` are unset, the fixture defaults to an in-memory
-SQLite `JdbcCatalog`.
+If `catalog-impl` and `uri` are unset, the fixture defaults to a SQLite
+`JdbcCatalog` at `/tmp/iceberg_catalog.db` opened in WAL mode
+(`jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL`), so concurrent
+clients don't fail with `SQLITE_BUSY`.
+
+Keep the `?journal_mode=WAL` suffix if you override `CATALOG_URI` with another
+SQLite path.
 
 ### Catalog name
 

--- a/kafka-connect/kafka-connect-runtime/docker/docker-compose.yml
+++ b/kafka-connect/kafka-connect-runtime/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     environment:
       - AWS_REGION=us-east-1
       - CATALOG_WAREHOUSE=s3://bucket/warehouse/
-      - CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory
+      - CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio:9000
       - CATALOG_S3_PATH__STYLE__ACCESS=true


### PR DESCRIPTION
Relates to #18043

The fixture runs `JdbcCatalog` on a file-backed SQLite db with the default rollback journal, which only lets one connection touch the db at a time. When multiple clients hit the fixture in parallel, one eventually fails with `SQLITE_BUSY` ("database is locked").

This switches the default `CATALOG_URI` to `jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL` so reads and writes don't block each other. Also documents it in the README and updates the kafka-connect docker-compose, which was still carrying `jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory` from the old databricks image (not actually an option, just part of the filename).

Verified with sqlite-jdbc that the URI opens the db with `journal_mode=wal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
