### PR TITLE
[1.11.x] Core: Fix partition info display in RewritePositionDeleteFilesSparkAction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BinPackRewritePositionDeletePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackRewritePositionDeletePlanner.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.PositionDeletesScanTask;
 import org.apache.iceberg.PositionDeletesTable;
@@ -187,18 +188,20 @@ public class BinPackRewritePositionDeletePlanner
       Types.StructType partitionType, Iterable<PositionDeletesScanTask> tasks) {
     StructLikeMap<List<PositionDeletesScanTask>> filesByPartition =
         StructLikeMap.create(partitionType);
+    PartitionData partitionKeyTemplate = new PartitionData(partitionType);
 
     for (PositionDeletesScanTask task : tasks) {
       StructLike coerced =
           PartitionUtil.coercePartition(partitionType, task.spec(), task.partition());
+      StructLike partitionKey = partitionKeyTemplate.copyFor(coerced);
 
-      List<PositionDeletesScanTask> partitionTasks = filesByPartition.get(coerced);
+      List<PositionDeletesScanTask> partitionTasks = filesByPartition.get(partitionKey);
       if (partitionTasks == null) {
         partitionTasks = Lists.newArrayList();
       }
 
       partitionTasks.add(task);
-      filesByPartition.put(coerced, partitionTasks);
+      filesByPartition.put(partitionKey, partitionTasks);
     }
 
     return filesByPartition;

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewritePositionDeletePlanner.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewritePositionDeletePlanner.java
@@ -98,6 +98,24 @@ class TestBinPackRewritePositionDeletePlanner {
   }
 
   @Test
+  void partitionDescription() {
+    addFiles();
+    BinPackRewritePositionDeletePlanner planner = new BinPackRewritePositionDeletePlanner(table);
+    planner.init(REWRITE_ALL);
+
+    FileRewritePlan<FileGroupInfo, PositionDeletesScanTask, DeleteFile, RewritePositionDeletesGroup>
+        plan = planner.plan();
+
+    List<RewritePositionDeletesGroup> groups = Lists.newArrayList(plan.groups().iterator());
+    assertThat(groups)
+        .extracting(group -> group.info().partition().toString())
+        .containsExactlyInAnyOrder(
+            FILE_1.partition().toString(),
+            FILE_2.partition().toString(),
+            FILE_3.partition().toString());
+  }
+
+  @Test
   void testUnpartitionedTable() {
     table.updateSpec().removeField("data_bucket").commit();
     table.refresh();


### PR DESCRIPTION
## Summary

Backports #15175 to the 1.11.x release branch.

- Copies coerced partition values into PartitionData before using them as planner map keys.
- Preserves readable partition descriptions in rewrite group job metadata.
- Includes the original regression coverage for partition descriptions.

## Testing

- ./gradlew :iceberg-core:test --tests org.apache.iceberg.actions.TestBinPackRewritePositionDeletePlanner
- ./gradlew :iceberg-core:spotlessJavaCheck

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: unreviewed
- Prompt Summary: Backport apache/iceberg#15175 to the 1.11.x release branch and create a pull request.