### PR TITLE
Parquet: parse row-group size as long

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -400,7 +400,7 @@ public class Parquet {
       // Map Iceberg properties to pass down to the Parquet writer
       Context context = createContextFunc.apply(config);
 
-      int rowGroupSize = context.rowGroupSize();
+      long rowGroupSize = context.rowGroupSize();
       int pageSize = context.pageSize();
       int pageRowLimit = context.pageRowLimit();
       int dictionaryPageSize = context.dictionaryPageSize();
@@ -517,7 +517,7 @@ public class Parquet {
                 .setWriteSupport(getWriteSupport(type))
                 .withCompressionCodec(codec)
                 .withWriteMode(writeMode)
-                .withRowGroupSize((long) rowGroupSize)
+                .withRowGroupSize(rowGroupSize)
                 .withPageSize(pageSize)
                 .withPageRowCountLimit(pageRowLimit)
                 .withDictionaryEncoding(dictionaryEnabled)
@@ -542,7 +542,7 @@ public class Parquet {
     }
 
     static class Context {
-      private final int rowGroupSize;
+      private final long rowGroupSize;
       private final int pageSize;
       private final int pageRowLimit;
       private final int dictionaryPageSize;
@@ -562,7 +562,7 @@ public class Parquet {
       private final boolean trackUncompressedRowGroupSize;
 
       private Context(
-          int rowGroupSize,
+          long rowGroupSize,
           int pageSize,
           int pageRowLimit,
           int dictionaryPageSize,
@@ -601,8 +601,8 @@ public class Parquet {
       }
 
       static Context dataContext(Map<String, String> config) {
-        int rowGroupSize =
-            PropertyUtil.propertyAsInt(
+        long rowGroupSize =
+            PropertyUtil.propertyAsLong(
                 config, PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
         Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
@@ -711,8 +711,8 @@ public class Parquet {
         // default delete config using data config
         Context dataContext = dataContext(config);
 
-        int rowGroupSize =
-            PropertyUtil.propertyAsInt(
+        long rowGroupSize =
+            PropertyUtil.propertyAsLong(
                 config, DELETE_PARQUET_ROW_GROUP_SIZE_BYTES, dataContext.rowGroupSize());
         Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
@@ -804,7 +804,7 @@ public class Parquet {
         }
       }
 
-      int rowGroupSize() {
+      long rowGroupSize() {
         return rowGroupSize;
       }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -106,6 +106,27 @@ public class TestParquet {
   }
 
   @Test
+  public void testRowGroupSizeLargerThanIntegerMax() throws IOException {
+    Schema schema = new Schema(optional(1, "intCol", IntegerType.get()));
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("intCol", 1);
+
+    // Values above Integer.MAX_VALUE used to fail in PropertyUtil.propertyAsInt.
+    File file = createTempFile(temp);
+    write(
+        file,
+        schema,
+        ImmutableMap.of(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(4L * 1024 * 1024 * 1024)),
+        ParquetAvroWriter::buildWriter,
+        record);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      assertThat(reader.getRowGroups()).hasSize(1);
+    }
+  }
+
+  @Test
   public void testRowGroupSizeConfigurableWithWriter() throws IOException {
     // Explicit writer function supports PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT
     // and PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT configs.

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.parquet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.DELETE_PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_ADAPTIVE_ENABLED;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_MAX_BYTES;
@@ -54,10 +55,12 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
@@ -106,7 +109,7 @@ public class TestParquet {
   }
 
   @Test
-  public void testRowGroupSizeLargerThanIntegerMax() throws IOException {
+  public void rowGroupSizeLargerThanIntegerMax() throws IOException {
     Schema schema = new Schema(optional(1, "intCol", IntegerType.get()));
     org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
     GenericData.Record record = new GenericData.Record(avroSchema);
@@ -120,6 +123,32 @@ public class TestParquet {
         ImmutableMap.of(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(4L * 1024 * 1024 * 1024)),
         ParquetAvroWriter::buildWriter,
         record);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      assertThat(reader.getRowGroups()).hasSize(1);
+    }
+  }
+
+  @Test
+  public void deleteRowGroupSizeLargerThanIntegerMax() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()));
+    Record record = org.apache.iceberg.data.GenericRecord.create(schema);
+    record.setField("id", 1L);
+
+    File file = createTempFile(temp);
+    EqualityDeleteWriter<Record> deleteWriter =
+        Parquet.writeDeletes(Files.localOutput(file))
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(DELETE_PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(4L * 1024 * 1024 * 1024))
+            .overwrite()
+            .rowSchema(schema)
+            .withSpec(PartitionSpec.unpartitioned())
+            .equalityFieldIds(1)
+            .buildEqualityWriter();
+
+    try (EqualityDeleteWriter<Record> writer = deleteWriter) {
+      writer.write(record);
+    }
 
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
       assertThat(reader.getRowGroups()).hasSize(1);


### PR DESCRIPTION
Closes #18054

## What

Parse `write.parquet.row-group-size-bytes` and `write.delete.parquet.row-group-size-bytes` with `propertyAsLong` and thread row-group size as `long` through the private write path.

`PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT` stays `int` (128 MiB). Larger sizes are set via the string table property. `Parquet.concat(..., int)` is unchanged.

Iceberg's `ParquetWriter` already takes `long rowGroupSize`; this only unblocks the table-property parse.

## Test

- [x] `./gradlew :iceberg-parquet:test --tests org.apache.iceberg.parquet.TestParquet.testRowGroupSizeLargerThanIntegerMax --tests org.apache.iceberg.parquet.TestParquet.testRowGroupSizeConfigurable --tests org.apache.iceberg.parquet.TestParquet.testRowGroupSizeConfigurableWithWriter`
- [x] `./gradlew :iceberg-parquet:spotlessCheck`

AI-assisted: used a coding agent to port the parse change and unit test onto current `main`.
