### PR TITLE
Build: Exclude unpublished Kafka Connect runtime from the BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1261,9 +1261,13 @@ project(':iceberg-bom') {
       def sparkScalaVersions = [
         "3.5": ["2.12", "2.13"],
       ]
+      // Projects that build a distribution rather than a Maven artifact disable their publishing
+      // tasks, so their POM is never published and the BOM must not reference it.
+      def unpublishedProjects = ['iceberg-kafka-connect-runtime']
       rootProject.allprojects.forEach {
         // Do not include ':iceberg-spark', the bom itself and the root project.
-        if (it.name != 'iceberg-bom' && it != rootProject && it.childProjects.isEmpty()) {
+        if (it.name != 'iceberg-bom' && it != rootProject && it.childProjects.isEmpty()
+            && !unpublishedProjects.contains(it.name)) {
           if (it.name.startsWith("iceberg-spark-")) {
             def sparkScalaMatcher = sparkScalaPattern.matcher(it.name)
             if (!sparkScalaMatcher.find()) {


### PR DESCRIPTION
Closes #18052.

The BOM adds every leaf project, but `iceberg-kafka-connect-runtime` builds ZIP distributions rather than Maven artifacts and [disables its publishing tasks](https://github.com/apache/iceberg/blob/main/kafka-connect/build.gradle#L237-L240), so its POM is never published — the [1.11.0 POM](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-kafka-connect-runtime/1.11.0/iceberg-kafka-connect-runtime-1.11.0.pom) returns 404. The BOM therefore advertises a coordinate that cannot resolve.

The grouping project `iceberg-kafka-connect` is already excluded by the existing `childProjects.isEmpty()` check, so the runtime module is the only affected one — it is the only publishing-disabled *leaf* project in the build.

## Verifying this change

`./gradlew :iceberg-bom:generatePomFileForApachePublication`, then inspecting `bom/build/publications/apache/pom-default.xml`:

| | artifacts in BOM | `iceberg-kafka-connect-runtime` |
|---|---|---|
| before | 30 | present |
| after | 29 | absent |

Exactly one entry is removed. `iceberg-kafka-connect`, `iceberg-kafka-connect-events` and `iceberg-kafka-connect-transforms` are real published artifacts and remain.

I used an explicit exclusion list rather than deriving "does not publish" from the project state, because publishing is disabled inside that project's `afterEvaluate` while the BOM's `constraints` block is evaluated during configuration, so keying off task state here would depend on configuration ordering. Happy to switch to a shared property (for example a `skipPublish` flag set by the project and read here) if you would prefer something that cannot be forgotten when the next distribution-only module is added.

Generated-by: Claude Code (Opus 5)
