### PR TITLE
Spec: Allow spaces in UDF type strings

### DIFF
--- a/format/udf-spec.md
+++ b/format/udf-spec.md
@@ -109,9 +109,9 @@ Types are based on the [Iceberg Type](https://iceberg.apache.org/spec/#schemas-a
 Primitive and semi-structured type strings are encoded based on [Iceberg Type JSON Representation][iceberg-type-json]
 (e.g., `int`, `string`, `timestamp`, `decimal(9, 2)`, `variant`). Type strings must contain no quote characters.
 
-Type strings are used exactly as Iceberg serializes them. Parameterized types may contain spaces, either separating
-parameters (`decimal(9, 2)`, `geography(OGC:CRS84, spherical)`) or within a parameter value (`geometry(srid: 3857)`).
-Readers must not add or remove spaces in a type string.
+Writers must use Iceberg's canonical serialized form. Readers should accept optional whitespace around parameters and
+separators. Implementations must compare parsed types, not raw type strings. Canonicalization may normalize syntactic
+whitespace but must preserve whitespace within parameter values (`geometry(srid: 3857)`).
 
 Nested types (`struct`, `list`, `map`) use the [Iceberg Type JSON Representation][iceberg-type-json] with the
 following fields required. Any other fields must be ignored.
@@ -130,14 +130,14 @@ separators that this format adds must not be followed by a space. Each type uses
 * Map: `map<key-type,value-type>` (e.g., `map<string,int>`)
 * Struct: `struct<name1:type1,name2:type2,...>` with field names and types (e.g., `struct<id:int,name:string>`)
 
-A type string is embedded unchanged, so a parameterized type may still contribute spaces of its own (see [Types](#types)).
-
 Examples of complete definition-id signatures:
 
 * `int` – single int parameter
 * `int,string` – two parameters: int and string
 * `int,list<int>,struct<id:int,name:string>` – three parameters: an int, a list and a struct
 * `decimal(9, 2),geometry(srid: 3857)` – two parameterized parameters, each keeping its own spaces
+* `geometry(epsg:4326)` – a geometry parameter; CRS values are lowercased, so `geometry(EPSG:4326)` yields this id
+* `geometry(ogc:crs84)` – a geometry parameter declared as `geometry`, since canonical form always carries a CRS
 
 #### Specific Name
 

--- a/format/udf-spec.md
+++ b/format/udf-spec.md
@@ -107,7 +107,11 @@ Notes:
 Types are based on the [Iceberg Type](https://iceberg.apache.org/spec/#schemas-and-data-types).
 
 Primitive and semi-structured type strings are encoded based on [Iceberg Type JSON Representation][iceberg-type-json]
-(e.g., `int`, `string`, `timestamp`, `decimal(9,2)`, `variant`). Type strings must contain no spaces or quote characters.
+(e.g., `int`, `string`, `timestamp`, `decimal(9, 2)`, `variant`). Type strings must contain no quote characters.
+
+Type strings are used exactly as Iceberg serializes them. Parameterized types may contain spaces, either separating
+parameters (`decimal(9, 2)`, `geography(OGC:CRS84, spherical)`) or within a parameter value (`geometry(srid: 3857)`).
+Readers must not add or remove spaces in a type string.
 
 Nested types (`struct`, `list`, `map`) use the [Iceberg Type JSON Representation][iceberg-type-json] with the
 following fields required. Any other fields must be ignored.
@@ -118,19 +122,22 @@ following fields required. Any other fields must be ignored.
   e.g., `{ "type": "struct", "fields": [ { "name": "id", "type": "int" }, { "name": "name", "type": "string" } ] }`
 
 #### Definition ID
-The `definition-id` is a canonical string derived from the parameter types, formatted as a comma-separated list with no
-spaces. Each type uses the following string representation:
+The `definition-id` is a canonical string derived from the parameter types, formatted as a comma-separated list. The
+separators that this format adds must not be followed by a space. Each type uses the following string representation:
 
 * Primitives and semi-structured: the type name (e.g., `int`, `variant`)
 * List: `list<element-type>` (e.g., `list<int>`)
 * Map: `map<key-type,value-type>` (e.g., `map<string,int>`)
 * Struct: `struct<name1:type1,name2:type2,...>` with field names and types (e.g., `struct<id:int,name:string>`)
 
+A type string is embedded unchanged, so a parameterized type may still contribute spaces of its own (see [Types](#types)).
+
 Examples of complete definition-id signatures:
 
 * `int` – single int parameter
 * `int,string` – two parameters: int and string
 * `int,list<int>,struct<id:int,name:string>` – three parameters: an int, a list and a struct
+* `decimal(9, 2),geometry(srid: 3857)` – two parameterized parameters, each keeping its own spaces
 
 #### Specific Name
 


### PR DESCRIPTION
The UDF spec requires that type strings "contain no spaces or quote characters", but Iceberg
serializes parameterized type strings with a space after each parameter separator —
`decimal(9, 2)`, `geography(OGC:CRS84, spherical)`. No implementation that uses Iceberg's own
type serialization can satisfy that rule, and the spec's own `decimal(9,2)` example does not
conform to it either.

The spaces can't be normalized away, because a space inside a parameter value is significant:
`geometry(srid: 3857)` and `geometry(srid:3857)` are different types.

This PR:
- Drops the no-spaces requirement for type strings, and states that type strings are used and
  compared exactly as Iceberg serializes them.
- Fixes the `decimal(9,2)` example to `decimal(9, 2)`.
- Keeps the no-spaces requirement for `definition-id`, but scopes it to the separators that the
  definition-id format itself adds. An embedded type string keeps its own spaces.


Prerequisite for #15994.

