### PR TITLE
Flink: Backport building nested field getters once in RowDataProjection to 1.20, 2.2 and 2.3 (#16790)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -67,20 +67,24 @@ public class RowDataProjection implements RowData {
    */
   public static RowDataProjection create(
       RowType rowType, Types.StructType schema, Types.StructType projectedSchema) {
-    return new RowDataProjection(rowType, schema, projectedSchema);
+    return new RowDataProjection(createFieldGetters(rowType, schema, projectedSchema));
   }
 
   private final RowData.FieldGetter[] getters;
   private RowData rowData;
 
-  private RowDataProjection(
+  private RowDataProjection(RowData.FieldGetter[] getters) {
+    this.getters = getters;
+  }
+
+  private static RowData.FieldGetter[] createFieldGetters(
       RowType rowType, Types.StructType rowStruct, Types.StructType projectType) {
     Map<Integer, Integer> fieldIdToPosition = Maps.newHashMap();
     for (int i = 0; i < rowStruct.fields().size(); i++) {
       fieldIdToPosition.put(rowStruct.fields().get(i).fieldId(), i);
     }
 
-    this.getters = new RowData.FieldGetter[projectType.fields().size()];
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[projectType.fields().size()];
     for (int i = 0; i < getters.length; i++) {
       Types.NestedField projectField = projectType.fields().get(i);
       Types.NestedField rowField = rowStruct.field(projectField.fieldId());
@@ -95,6 +99,8 @@ public class RowDataProjection implements RowData {
           createFieldGetter(
               rowType, fieldIdToPosition.get(projectField.fieldId()), rowField, projectField);
     }
+
+    return getters;
   }
 
   private static RowData.FieldGetter createFieldGetter(
@@ -108,16 +114,18 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
+        RowData.FieldGetter[] nestedGetters =
+            createFieldGetters(
+                nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
+        int nestedFieldCount = nestedRowType.getFieldCount();
         return row -> {
           // null nested struct value
           if (row.isNullAt(position)) {
             return null;
           }
 
-          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
-          return RowDataProjection.create(
-                  nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
-              .wrap(nestedRow);
+          // a new wrapper per access keeps nested rows valid after the parent is re-wrapped
+          return new RowDataProjection(nestedGetters).wrap(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
@@ -211,6 +211,29 @@ public class TestRowDataProjection {
   }
 
   @Test
+  void nestedRowIsNotMutatedByNextWrap() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(0, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                3,
+                "location",
+                Types.StructType.of(
+                    Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                    Types.NestedField.required(2, "long", Types.FloatType.get()))));
+    RowDataProjection projection = RowDataProjection.create(schema, schema.select("location"));
+
+    RowData first =
+        projection.wrap(GenericRowData.of(1L, GenericRowData.of(1.0f, 1.0f))).getRow(0, 2);
+    RowData second =
+        projection.wrap(GenericRowData.of(2L, GenericRowData.of(9.0f, 9.0f))).getRow(0, 2);
+
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.getFloat(0)).isEqualTo(1.0f);
+    assertThat(second.getFloat(0)).isEqualTo(9.0f);
+  }
+
+  @Test
   public void testPrimitivesFullProjection() {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Schema schema = dataGenerator.icebergSchema();

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -68,20 +68,24 @@ public class RowDataProjection implements RowData {
    */
   public static RowDataProjection create(
       RowType rowType, Types.StructType schema, Types.StructType projectedSchema) {
-    return new RowDataProjection(rowType, schema, projectedSchema);
+    return new RowDataProjection(createFieldGetters(rowType, schema, projectedSchema));
   }
 
   private final RowData.FieldGetter[] getters;
   private RowData rowData;
 
-  private RowDataProjection(
+  private RowDataProjection(RowData.FieldGetter[] getters) {
+    this.getters = getters;
+  }
+
+  private static RowData.FieldGetter[] createFieldGetters(
       RowType rowType, Types.StructType rowStruct, Types.StructType projectType) {
     Map<Integer, Integer> fieldIdToPosition = Maps.newHashMap();
     for (int i = 0; i < rowStruct.fields().size(); i++) {
       fieldIdToPosition.put(rowStruct.fields().get(i).fieldId(), i);
     }
 
-    this.getters = new RowData.FieldGetter[projectType.fields().size()];
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[projectType.fields().size()];
     for (int i = 0; i < getters.length; i++) {
       Types.NestedField projectField = projectType.fields().get(i);
       Types.NestedField rowField = rowStruct.field(projectField.fieldId());
@@ -96,6 +100,8 @@ public class RowDataProjection implements RowData {
           createFieldGetter(
               rowType, fieldIdToPosition.get(projectField.fieldId()), rowField, projectField);
     }
+
+    return getters;
   }
 
   private static RowData.FieldGetter createFieldGetter(
@@ -109,16 +115,18 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
+        RowData.FieldGetter[] nestedGetters =
+            createFieldGetters(
+                nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
+        int nestedFieldCount = nestedRowType.getFieldCount();
         return row -> {
           // null nested struct value
           if (row.isNullAt(position)) {
             return null;
           }
 
-          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
-          return RowDataProjection.create(
-                  nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
-              .wrap(nestedRow);
+          // a new wrapper per access keeps nested rows valid after the parent is re-wrapped
+          return new RowDataProjection(nestedGetters).wrap(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:

--- a/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
+++ b/flink/v2.2/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
@@ -211,6 +211,29 @@ public class TestRowDataProjection {
   }
 
   @Test
+  void nestedRowIsNotMutatedByNextWrap() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(0, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                3,
+                "location",
+                Types.StructType.of(
+                    Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                    Types.NestedField.required(2, "long", Types.FloatType.get()))));
+    RowDataProjection projection = RowDataProjection.create(schema, schema.select("location"));
+
+    RowData first =
+        projection.wrap(GenericRowData.of(1L, GenericRowData.of(1.0f, 1.0f))).getRow(0, 2);
+    RowData second =
+        projection.wrap(GenericRowData.of(2L, GenericRowData.of(9.0f, 9.0f))).getRow(0, 2);
+
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.getFloat(0)).isEqualTo(1.0f);
+    assertThat(second.getFloat(0)).isEqualTo(9.0f);
+  }
+
+  @Test
   public void testPrimitivesFullProjection() {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Schema schema = dataGenerator.icebergSchema();

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -68,20 +68,24 @@ public class RowDataProjection implements RowData {
    */
   public static RowDataProjection create(
       RowType rowType, Types.StructType schema, Types.StructType projectedSchema) {
-    return new RowDataProjection(rowType, schema, projectedSchema);
+    return new RowDataProjection(createFieldGetters(rowType, schema, projectedSchema));
   }
 
   private final RowData.FieldGetter[] getters;
   private RowData rowData;
 
-  private RowDataProjection(
+  private RowDataProjection(RowData.FieldGetter[] getters) {
+    this.getters = getters;
+  }
+
+  private static RowData.FieldGetter[] createFieldGetters(
       RowType rowType, Types.StructType rowStruct, Types.StructType projectType) {
     Map<Integer, Integer> fieldIdToPosition = Maps.newHashMap();
     for (int i = 0; i < rowStruct.fields().size(); i++) {
       fieldIdToPosition.put(rowStruct.fields().get(i).fieldId(), i);
     }
 
-    this.getters = new RowData.FieldGetter[projectType.fields().size()];
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[projectType.fields().size()];
     for (int i = 0; i < getters.length; i++) {
       Types.NestedField projectField = projectType.fields().get(i);
       Types.NestedField rowField = rowStruct.field(projectField.fieldId());
@@ -96,6 +100,8 @@ public class RowDataProjection implements RowData {
           createFieldGetter(
               rowType, fieldIdToPosition.get(projectField.fieldId()), rowField, projectField);
     }
+
+    return getters;
   }
 
   private static RowData.FieldGetter createFieldGetter(
@@ -109,16 +115,18 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
+        RowData.FieldGetter[] nestedGetters =
+            createFieldGetters(
+                nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
+        int nestedFieldCount = nestedRowType.getFieldCount();
         return row -> {
           // null nested struct value
           if (row.isNullAt(position)) {
             return null;
           }
 
-          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
-          return RowDataProjection.create(
-                  nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
-              .wrap(nestedRow);
+          // a new wrapper per access keeps nested rows valid after the parent is re-wrapped
+          return new RowDataProjection(nestedGetters).wrap(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
@@ -211,6 +211,29 @@ public class TestRowDataProjection {
   }
 
   @Test
+  void nestedRowIsNotMutatedByNextWrap() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(0, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                3,
+                "location",
+                Types.StructType.of(
+                    Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                    Types.NestedField.required(2, "long", Types.FloatType.get()))));
+    RowDataProjection projection = RowDataProjection.create(schema, schema.select("location"));
+
+    RowData first =
+        projection.wrap(GenericRowData.of(1L, GenericRowData.of(1.0f, 1.0f))).getRow(0, 2);
+    RowData second =
+        projection.wrap(GenericRowData.of(2L, GenericRowData.of(9.0f, 9.0f))).getRow(0, 2);
+
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.getFloat(0)).isEqualTo(1.0f);
+    assertThat(second.getFloat(0)).isEqualTo(9.0f);
+  }
+
+  @Test
   public void testPrimitivesFullProjection() {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Schema schema = dataGenerator.icebergSchema();


### PR DESCRIPTION
Backport of #16790 to Flink 1.20, 2.2 and 2.3. When a projected field is a nested struct, `RowDataProjection` now builds the nested field getters once, when the projection is created, instead of rebuilding a whole nested projection for every row. Each access still returns a new wrapper, so a nested row taken from one `wrap` call keeps its values after the next one.

`RowDataProjection` in 2.2 and 2.3 and `TestRowDataProjection` in all three versions were identical to their 2.1 counterparts before #16790, so they are direct copies of the merged files. The 1.20 `RowDataProjection` differs from 2.1 only by the `Variant` import and the `getVariant` override, which this change does not touch, so it gets the same three hunks. `TestRowDataProjection`, including the ported `nestedRowIsNotMutatedByNextWrap`, passes on all three versions.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Backport the merged RowDataProjection nested field getter change from #16790 to the Flink 1.20, 2.2 and 2.3 modules.
