### PR TITLE
AWS: Add S3 API call timeout configuration for S3Client and S3AsyncClient

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -48,6 +48,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+        .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
         .build();
   }
 
@@ -66,6 +67,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -118,6 +118,7 @@ public class AwsClientFactories {
           .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
           .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
           .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+          .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
           .build();
     }
 
@@ -138,6 +139,7 @@ public class AwsClientFactories {
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -83,6 +83,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .applyMutation(s3FileIOProperties()::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties()::applyServiceConfigurations)
           .applyMutation(s3FileIOProperties()::applyRetryConfigurations)
+          .applyMutation(s3FileIOProperties()::applyApiCallTimeoutConfigurations)
           .credentialsProvider(
               new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))
           .region(Region.of(region()))

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -58,6 +58,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+        .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
         .build();
   }
 
@@ -76,6 +77,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -488,6 +488,20 @@ public class S3FileIOProperties implements Serializable {
   public static final long S3_RETRY_MAX_WAIT_MS_DEFAULT = 20_000; // 20 seconds
 
   /**
+   * Overall time budget, in milliseconds, for a single S3 API call including all of its retry
+   * attempts. Unset (the SDK default, effectively unbounded) unless configured. Guards against a
+   * request that never completes (e.g. a stalled connection below the HTTP client's own
+   * connect/socket timeouts) leaving the calling thread parked indefinitely.
+   */
+  public static final String S3_API_CALL_TIMEOUT_MS = "s3.api-call-timeout-ms";
+
+  /**
+   * Time budget, in milliseconds, for a single attempt of an S3 API call (i.e. one retry attempt,
+   * not the whole operation). Unset (the SDK default) unless configured.
+   */
+  public static final String S3_API_CALL_ATTEMPT_TIMEOUT_MS = "s3.api-call-attempt-timeout-ms";
+
+  /**
    * Controls whether to list prefixes as directories for S3 Directory buckets Defaults value is
    * true, where it will add the "/"
    *
@@ -545,6 +559,8 @@ public class S3FileIOProperties implements Serializable {
   private int s3RetryNumRetries;
   private long s3RetryMinWaitMs;
   private long s3RetryMaxWaitMs;
+  private Long s3ApiCallTimeoutMs;
+  private Long s3ApiCallAttemptTimeoutMs;
 
   private boolean s3DirectoryBucketListPrefixAsDirectory;
   private final Map<String, String> allProperties;
@@ -584,6 +600,8 @@ public class S3FileIOProperties implements Serializable {
     this.s3RetryNumRetries = S3_RETRY_NUM_RETRIES_DEFAULT;
     this.s3RetryMinWaitMs = S3_RETRY_MIN_WAIT_MS_DEFAULT;
     this.s3RetryMaxWaitMs = S3_RETRY_MAX_WAIT_MS_DEFAULT;
+    this.s3ApiCallTimeoutMs = null;
+    this.s3ApiCallAttemptTimeoutMs = null;
     this.s3DirectoryBucketListPrefixAsDirectory =
         S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY_DEFAULT;
     this.isS3AnalyticsAcceleratorEnabled = S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT;
@@ -700,6 +718,20 @@ public class S3FileIOProperties implements Serializable {
         PropertyUtil.propertyAsLong(properties, S3_RETRY_MIN_WAIT_MS, S3_RETRY_MIN_WAIT_MS_DEFAULT);
     this.s3RetryMaxWaitMs =
         PropertyUtil.propertyAsLong(properties, S3_RETRY_MAX_WAIT_MS, S3_RETRY_MAX_WAIT_MS_DEFAULT);
+    this.s3ApiCallTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(properties, S3_API_CALL_TIMEOUT_MS);
+    Preconditions.checkArgument(
+        s3ApiCallTimeoutMs == null || s3ApiCallTimeoutMs > 0,
+        "%s must be positive, but was: %s",
+        S3_API_CALL_TIMEOUT_MS,
+        s3ApiCallTimeoutMs);
+    this.s3ApiCallAttemptTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(properties, S3_API_CALL_ATTEMPT_TIMEOUT_MS);
+    Preconditions.checkArgument(
+        s3ApiCallAttemptTimeoutMs == null || s3ApiCallAttemptTimeoutMs > 0,
+        "%s must be positive, but was: %s",
+        S3_API_CALL_ATTEMPT_TIMEOUT_MS,
+        s3ApiCallAttemptTimeoutMs);
     this.s3DirectoryBucketListPrefixAsDirectory =
         PropertyUtil.propertyAsBoolean(
             properties,
@@ -967,6 +999,32 @@ public class S3FileIOProperties implements Serializable {
     return (long) s3RetryNumRetries() * s3RetryMaxWaitMs();
   }
 
+  public Long s3ApiCallTimeoutMs() {
+    return s3ApiCallTimeoutMs;
+  }
+
+  public void setS3ApiCallTimeoutMs(Long s3ApiCallTimeoutMs) {
+    Preconditions.checkArgument(
+        s3ApiCallTimeoutMs == null || s3ApiCallTimeoutMs > 0,
+        "%s must be positive, but was: %s",
+        S3_API_CALL_TIMEOUT_MS,
+        s3ApiCallTimeoutMs);
+    this.s3ApiCallTimeoutMs = s3ApiCallTimeoutMs;
+  }
+
+  public Long s3ApiCallAttemptTimeoutMs() {
+    return s3ApiCallAttemptTimeoutMs;
+  }
+
+  public void setS3ApiCallAttemptTimeoutMs(Long s3ApiCallAttemptTimeoutMs) {
+    Preconditions.checkArgument(
+        s3ApiCallAttemptTimeoutMs == null || s3ApiCallAttemptTimeoutMs > 0,
+        "%s must be positive, but was: %s",
+        S3_API_CALL_ATTEMPT_TIMEOUT_MS,
+        s3ApiCallAttemptTimeoutMs);
+    this.s3ApiCallAttemptTimeoutMs = s3ApiCallAttemptTimeoutMs;
+  }
+
   public boolean isS3DirectoryBucketListPrefixAsDirectory() {
     return s3DirectoryBucketListPrefixAsDirectory;
   }
@@ -1138,6 +1196,44 @@ public class S3FileIOProperties implements Serializable {
                             .build())
                     .build())
             .build());
+  }
+
+  /**
+   * Override the overall API call and per-attempt timeouts for an S3 sync or async client, if
+   * configured. Neither is set by default (SDK default, effectively unbounded), so this is a no-op
+   * unless {@link #S3_API_CALL_TIMEOUT_MS} and/or {@link #S3_API_CALL_ATTEMPT_TIMEOUT_MS} are
+   * explicitly configured. When set, a request that never completes (e.g. a connection stalled
+   * below the HTTP client's own connect/socket timeouts) throws {@code
+   * software.amazon.awssdk.core.exception.ApiCallTimeoutException} / {@code
+   * ApiCallAttemptTimeoutException} instead of leaving the calling thread parked indefinitely.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
+   *     S3AsyncClient.builder()
+   *         .applyMutation(s3FileIOProperties::applyApiCallTimeoutConfigurations)
+   * </pre>
+   */
+  public <T extends S3BaseClientBuilder<T, ?>> void applyApiCallTimeoutConfigurations(T builder) {
+    if (s3ApiCallTimeoutMs == null && s3ApiCallAttemptTimeoutMs == null) {
+      return;
+    }
+
+    ClientOverrideConfiguration.Builder configBuilder =
+        null != builder.overrideConfiguration()
+            ? builder.overrideConfiguration().toBuilder()
+            : ClientOverrideConfiguration.builder();
+
+    if (s3ApiCallTimeoutMs != null) {
+      configBuilder.apiCallTimeout(Duration.ofMillis(s3ApiCallTimeoutMs));
+    }
+
+    if (s3ApiCallAttemptTimeoutMs != null) {
+      configBuilder.apiCallAttemptTimeout(Duration.ofMillis(s3ApiCallAttemptTimeoutMs));
+    }
+
+    builder.overrideConfiguration(configBuilder.build());
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.TestHelpers;
@@ -40,6 +41,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.retries.internal.DefaultAdaptiveRetryStrategy;
@@ -111,6 +113,30 @@ public class TestAwsClientFactories {
                         "us-east-1"))
                 .s3Async())
         .isInstanceOf(DefaultS3CrtAsyncClient.class);
+  }
+
+  @Test
+  public void testAssumeRoleS3AsyncClientAppliesApiCallTimeoutConfigurations() {
+    ClientOverrideConfiguration overrideConfiguration =
+        ((S3AsyncClient)
+                AwsClientFactories.from(
+                        ImmutableMap.of(
+                            AwsProperties.CLIENT_FACTORY,
+                            AssumeRoleAwsClientFactory.class.getName(),
+                            AwsProperties.CLIENT_ASSUME_ROLE_ARN,
+                            "arn::test",
+                            AwsProperties.CLIENT_ASSUME_ROLE_REGION,
+                            "us-east-1",
+                            S3FileIOProperties.S3_CRT_ENABLED,
+                            "false",
+                            S3FileIOProperties.S3_API_CALL_TIMEOUT_MS,
+                            "60000"))
+                    .s3Async())
+            .serviceClientConfiguration()
+            .overrideConfiguration();
+    assertThat(overrideConfiguration.apiCallTimeout())
+        .as("api call timeout was not applied to the async client")
+        .isEqualTo(Optional.of(Duration.ofMillis(60000)));
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -22,9 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.AwsClientProperties;
@@ -568,6 +570,80 @@ public class TestS3FileIOProperties {
 
     RetryPolicy retryPolicy = builder.overrideConfiguration().retryPolicy().get();
     assertThat(retryPolicy.numRetries()).as("retries was not set").isEqualTo(999);
+  }
+
+  @Test
+  public void testApplyApiCallTimeoutConfigurationsNotSetByDefault() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(Maps.newHashMap());
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyApiCallTimeoutConfigurations(builder);
+
+    assertThat(builder.overrideConfiguration().apiCallTimeout())
+        .as("api call timeout should be unset by default")
+        .isEmpty();
+    assertThat(builder.overrideConfiguration().apiCallAttemptTimeout())
+        .as("api call attempt timeout should be unset by default")
+        .isEmpty();
+  }
+
+  @Test
+  public void testApplyApiCallTimeoutConfigurations() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.S3_API_CALL_TIMEOUT_MS, "60000");
+    properties.put(S3FileIOProperties.S3_API_CALL_ATTEMPT_TIMEOUT_MS, "30000");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyApiCallTimeoutConfigurations(builder);
+
+    ClientOverrideConfiguration overrideConfiguration = builder.overrideConfiguration();
+    assertThat(overrideConfiguration.apiCallTimeout())
+        .as("api call timeout was not set")
+        .isEqualTo(Optional.of(Duration.ofMillis(60000)));
+    assertThat(overrideConfiguration.apiCallAttemptTimeout())
+        .as("api call attempt timeout was not set")
+        .isEqualTo(Optional.of(Duration.ofMillis(30000)));
+  }
+
+  @Test
+  public void testApplyApiCallTimeoutConfigurationsMustBePositive() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.S3_API_CALL_TIMEOUT_MS, "0");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("s3.api-call-timeout-ms must be positive, but was: 0");
+  }
+
+  @Test
+  public void testApplyApiCallAttemptTimeoutConfigurationsMustBePositive() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.S3_API_CALL_ATTEMPT_TIMEOUT_MS, "0");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("s3.api-call-attempt-timeout-ms must be positive, but was: 0");
+  }
+
+  @Test
+  public void testDefaultS3FileIOAwsClientFactoryAppliesApiCallTimeoutToAsyncClient() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.S3_CRT_ENABLED, "false");
+    properties.put(S3FileIOProperties.S3_API_CALL_TIMEOUT_MS, "60000");
+    properties.put(S3FileIOProperties.S3_API_CALL_ATTEMPT_TIMEOUT_MS, "30000");
+
+    DefaultS3FileIOAwsClientFactory factory = new DefaultS3FileIOAwsClientFactory();
+    factory.initialize(properties);
+
+    ClientOverrideConfiguration overrideConfiguration =
+        factory.s3Async().serviceClientConfiguration().overrideConfiguration();
+    assertThat(overrideConfiguration.apiCallTimeout())
+        .as("api call timeout was not applied to the async client")
+        .isEqualTo(Optional.of(Duration.ofMillis(60000)));
+    assertThat(overrideConfiguration.apiCallAttemptTimeout())
+        .as("api call attempt timeout was not applied to the async client")
+        .isEqualTo(Optional.of(Duration.ofMillis(30000)));
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -629,6 +629,7 @@ public class TestS3FileIOProperties {
   @Test
   public void testDefaultS3FileIOAwsClientFactoryAppliesApiCallTimeoutToAsyncClient() {
     Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsClientProperties.CLIENT_REGION, "us-east-1");
     properties.put(S3FileIOProperties.S3_CRT_ENABLED, "false");
     properties.put(S3FileIOProperties.S3_API_CALL_TIMEOUT_MS, "60000");
     properties.put(S3FileIOProperties.S3_API_CALL_ATTEMPT_TIMEOUT_MS, "30000");

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -408,6 +408,8 @@ workloads with exceptionally high throughput against tables that S3 has not yet 
 | s3.retry.num-retries | 5       | Number of times to retry S3 operations. Recommended 32 for high-throughput workloads. |
 | s3.retry.min-wait-ms | 2s      | Minimum wait time to retry a S3 operation.                                            |
 | s3.retry.max-wait-ms | 20s     | Maximum wait time to retry a S3 read operation.                                       |
+| s3.api-call-timeout-ms | (not set) | Timeout for the entire S3 API call, including retries. Not enabled unless explicitly set. |
+| s3.api-call-attempt-timeout-ms | (not set) | Timeout for a single S3 API call attempt, before retries. Not enabled unless explicitly set. |
 
 ### S3 Strong Consistency
 


### PR DESCRIPTION
S3 write calls (putObject, multipart upload) block synchronously with no timeout — a stalled connection can hang the calling thread indefinitely with no exception or log output. Add `s3.api-call-timeout-ms` and s`3.api-call-attempt-timeout-ms`, wired to the SDK's ClientOverrideConfiguration, so a stalled call throws instead of hanging silently. Off by default; only active if configured.