### PR TITLE
Spark 3.5, 4.0: Add sort_by parameter to rewrite_manifests procedure

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -395,6 +395,101 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteManifestsWithSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category', 'data'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithSortBySingleColumn() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithInvalidSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('nonexistent'))",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found in current partition spec");
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithEmptySortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array())",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("sort_by must not be empty when provided");
+  }
+
+  @TestTemplate
   public void testPartitionStatsIncrementalCompute() throws IOException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -487,7 +487,8 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
                 sql(
                     "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array())",
                     catalogName, tableIdent))
-        .isInstanceOf(AnalysisException.class);
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageContaining("no viable alternative at input ')'");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -480,13 +480,14 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
+    // The Iceberg CALL grammar requires ARRAY to have at least one element, so an empty sort_by
+    // array is rejected at parse time rather than by the procedure's runtime validation.
     assertThatThrownBy(
             () ->
                 sql(
                     "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array())",
                     catalogName, tableIdent))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("sort_by must not be empty when provided");
+        .isInstanceOf(AnalysisException.class);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import java.util.Arrays;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
@@ -49,9 +51,11 @@ class RewriteManifestsProcedure extends BaseProcedure {
       optionalInParameter("use_caching", DataTypes.BooleanType);
   private static final ProcedureParameter SPEC_ID_PARAM =
       optionalInParameter("spec_id", DataTypes.IntegerType);
+  private static final ProcedureParameter SORT_BY_PARAM =
+      optionalInParameter("sort_by", STRING_ARRAY);
 
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM};
+      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM, SORT_BY_PARAM};
 
   // counts are not nullable since the action result is never null
   private static final StructType OUTPUT_TYPE =
@@ -91,6 +95,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
     Identifier tableIdent = input.ident(TABLE_PARAM);
     Boolean useCaching = input.asBoolean(USE_CACHING_PARAM, null);
     Integer specId = input.asInt(SPEC_ID_PARAM, null);
+    String[] sortBy = input.asStringArray(SORT_BY_PARAM, null);
 
     return modifyIcebergTable(
         tableIdent,
@@ -103,6 +108,12 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
           if (specId != null) {
             action.specId(specId);
+          }
+
+          if (sortBy != null) {
+            Preconditions.checkArgument(
+                sortBy.length > 0, "sort_by must not be empty when provided");
+            action.sortBy(Arrays.asList(sortBy));
           }
 
           RewriteManifests.Result result = action.execute();

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -395,6 +395,101 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteManifestsWithSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category', 'data'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithSortBySingleColumn() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithInvalidSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('nonexistent'))",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found in current partition spec");
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithEmptySortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array())",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("sort_by must not be empty when provided");
+  }
+
+  @TestTemplate
   public void testPartitionStatsIncrementalCompute() throws IOException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -318,7 +318,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
             () -> sql("CALL %s.system.rewrite_manifests(table => 't', tAbLe => 't')", catalogName))
         .isInstanceOf(AnalysisException.class)
         .hasMessage(
-            "[UNRECOGNIZED_PARAMETER_NAME] Cannot invoke routine `rewrite_manifests` because the routine call included a named argument reference for the argument named `tAbLe`, but this routine does not include any signature containing an argument with this name. Did you mean one of the following? [`table` `spec_id` `use_caching`]. SQLSTATE: 4274K");
+            "[UNRECOGNIZED_PARAMETER_NAME] Cannot invoke routine `rewrite_manifests` because the routine call included a named argument reference for the argument named `tAbLe`, but this routine does not include any signature containing an argument with this name. Did you mean one of the following? [`table` `sort_by` `spec_id`]. SQLSTATE: 4274K");
 
     assertThatThrownBy(() -> sql("CALL %s.system.rewrite_manifests('')", catalogName))
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -18,9 +18,11 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
@@ -54,9 +56,11 @@ class RewriteManifestsProcedure extends BaseProcedure {
       optionalInParameter("use_caching", DataTypes.BooleanType);
   private static final ProcedureParameter SPEC_ID_PARAM =
       optionalInParameter("spec_id", DataTypes.IntegerType);
+  private static final ProcedureParameter SORT_BY_PARAM =
+      optionalInParameter("sort_by", STRING_ARRAY);
 
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM};
+      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM, SORT_BY_PARAM};
 
   // counts are not nullable since the action result is never null
   private static final StructType OUTPUT_TYPE =
@@ -96,6 +100,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
     Identifier tableIdent = input.ident(TABLE_PARAM);
     Boolean useCaching = input.asBoolean(USE_CACHING_PARAM, null);
     Integer specId = input.asInt(SPEC_ID_PARAM, null);
+    String[] sortBy = input.asStringArray(SORT_BY_PARAM, null);
 
     return modifyIcebergTable(
         tableIdent,
@@ -108,6 +113,12 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
           if (specId != null) {
             action.specId(specId);
+          }
+
+          if (sortBy != null) {
+            Preconditions.checkArgument(
+                sortBy.length > 0, "sort_by must not be empty when provided");
+            action.sortBy(Arrays.asList(sortBy));
           }
 
           RewriteManifests.Result result = action.execute();


### PR DESCRIPTION
Backport of https://github.com/apache/iceberg/pull/15467 into Spark v4.0 and v3.5