### PR TITLE
Flink: Fix DynamicIcebergSink writing NULLs for case-mismatched columns

### DIFF
--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -36,6 +35,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 /**

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
+import org.apache.curator.shaded.com.google.common.base.Preconditions;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -64,11 +65,12 @@ interface DataConverter {
     return object -> object;
   }
 
-  static DataConverter getNullable(LogicalType sourceType, LogicalType targetType) {
-    return nullable(get(sourceType, targetType));
+  static DataConverter getNullable(
+      LogicalType sourceType, LogicalType targetType, Boolean caseSensitive) {
+    return nullable(get(sourceType, targetType, caseSensitive));
   }
 
-  static DataConverter get(LogicalType sourceType, LogicalType targetType) {
+  static DataConverter get(LogicalType sourceType, LogicalType targetType, boolean caseSensitive) {
     switch (targetType.getTypeRoot()) {
       case BOOLEAN:
       case INTEGER:
@@ -118,11 +120,11 @@ interface DataConverter {
           }
         };
       case ROW:
-        return new RowDataConverter((RowType) sourceType, (RowType) targetType);
+        return new RowDataConverter((RowType) sourceType, (RowType) targetType, caseSensitive);
       case ARRAY:
-        return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
+        return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType, caseSensitive);
       case MAP:
-        return new MapConverter((MapType) sourceType, (MapType) targetType);
+        return new MapConverter((MapType) sourceType, (MapType) targetType, caseSensitive);
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }
@@ -136,7 +138,7 @@ interface DataConverter {
     private final RowData.FieldGetter[] fieldGetters;
     private final DataConverter[] dataConverters;
 
-    RowDataConverter(RowType sourceType, RowType targetType) {
+    RowDataConverter(RowType sourceType, RowType targetType, Boolean caseSensitive) {
       this.fieldGetters = new RowData.FieldGetter[targetType.getFields().size()];
       this.dataConverters = new DataConverter[targetType.getFields().size()];
 
@@ -144,7 +146,7 @@ interface DataConverter {
         RowData.FieldGetter fieldGetter;
         DataConverter dataConverter;
         RowType.RowField targetField = targetType.getFields().get(i);
-        int sourceFieldIndex = sourceType.getFieldIndex(targetField.getName());
+        int sourceFieldIndex = findFieldIndex(sourceType, targetField.getName(), caseSensitive);
         if (sourceFieldIndex == -1) {
           if (targetField.getType().isNullable()) {
             fieldGetter = row -> null;
@@ -158,7 +160,9 @@ interface DataConverter {
         } else {
           RowType.RowField sourceField = sourceType.getFields().get(sourceFieldIndex);
           fieldGetter = RowData.createFieldGetter(sourceField.getType(), sourceFieldIndex);
-          dataConverter = DataConverter.getNullable(sourceField.getType(), targetField.getType());
+          dataConverter =
+              DataConverter.getNullable(
+                  sourceField.getType(), targetField.getType(), caseSensitive);
         }
 
         this.fieldGetters[i] = fieldGetter;
@@ -183,10 +187,11 @@ interface DataConverter {
     private final ArrayData.ElementGetter elementGetter;
     private final DataConverter elementConverter;
 
-    ArrayConverter(ArrayType sourceType, ArrayType targetType) {
+    ArrayConverter(ArrayType sourceType, ArrayType targetType, boolean caseSensitive) {
       this.elementGetter = ArrayData.createElementGetter(sourceType.getElementType());
       this.elementConverter =
-          DataConverter.getNullable(sourceType.getElementType(), targetType.getElementType());
+          DataConverter.getNullable(
+              sourceType.getElementType(), targetType.getElementType(), caseSensitive);
     }
 
     @Override
@@ -208,13 +213,15 @@ interface DataConverter {
     private final DataConverter keyConverter;
     private final DataConverter valueConverter;
 
-    MapConverter(MapType sourceType, MapType targetType) {
+    MapConverter(MapType sourceType, MapType targetType, boolean caseSensitive) {
       this.keyGetter = ArrayData.createElementGetter(sourceType.getKeyType());
       this.valueGetter = ArrayData.createElementGetter(sourceType.getValueType());
       this.keyConverter =
-          DataConverter.getNullable(sourceType.getKeyType(), targetType.getKeyType());
+          DataConverter.getNullable(
+              sourceType.getKeyType(), targetType.getKeyType(), caseSensitive);
       this.valueConverter =
-          DataConverter.getNullable(sourceType.getValueType(), targetType.getValueType());
+          DataConverter.getNullable(
+              sourceType.getValueType(), targetType.getValueType(), caseSensitive);
     }
 
     @Override
@@ -231,5 +238,25 @@ interface DataConverter {
 
       return new GenericMapData(convertedMap);
     }
+  }
+
+  private static int findFieldIndex(RowType sourceType, String targetName, boolean caseSensitive) {
+    if (caseSensitive) {
+      return sourceType.getFieldIndex(targetName);
+    }
+
+    int matchingIndex = -1;
+    for (int i = 0; i < sourceType.getFieldCount(); i++) {
+      if (sourceType.getFields().get(i).getName().equalsIgnoreCase(targetName)) {
+        Preconditions.checkArgument(
+            matchingIndex == -1,
+            "Ambiguous case-insensitive source field match for '%s' in %s",
+            targetName,
+            sourceType);
+        matchingIndex = i;
+      }
+    }
+
+    return matchingIndex;
   }
 }

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -22,7 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
-import org.apache.curator.shaded.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
@@ -184,7 +184,9 @@ class TableMetadataCache {
               compatible,
               CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED,
               DataConverter.get(
-                  FlinkSchemaUtil.convert(input), FlinkSchemaUtil.convert(compatible)));
+                  FlinkSchemaUtil.convert(input),
+                  FlinkSchemaUtil.convert(compatible),
+                  caseSensitive));
       cached.inputSchemas.put(input, newResult);
       return newResult;
     } else if (cached != null && cached.tableExists) {

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableUpdater.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableUpdater.java
@@ -142,7 +142,9 @@ class TableUpdater {
               tableSchema,
               result,
               DataConverter.get(
-                  FlinkSchemaUtil.convert(schema), FlinkSchemaUtil.convert(tableSchema)));
+                  FlinkSchemaUtil.convert(schema),
+                  FlinkSchemaUtil.convert(tableSchema),
+                  caseSensitive));
         case SCHEMA_UPDATE_NEEDED:
           LOG.info(
               "Triggering schema update for table {} {} to {}", identifier, tableSchema, schema);

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -56,7 +56,9 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -1901,5 +1903,60 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     return TestHelpers.convertRecordToRow(
             RandomGenericData.generate(schema, 1, seedOverride), schema)
         .get(0);
+  }
+
+  @Test
+  void testCaseInsensitiveDataConversionDropsValues() throws Exception {
+    Schema tableSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()),
+            Types.NestedField.optional(3, "extra", Types.StringType.get()));
+
+    TableIdentifier identifier = TableIdentifier.of(DATABASE, "t1");
+    CATALOG_EXTENSION.catalog().createTable(identifier, tableSchema, PartitionSpec.unpartitioned());
+
+    DynamicIcebergSink.forInput(env.fromData(1, 2, 3))
+        .generator(new CaseMismatchGenerator())
+        .catalogLoader(CATALOG_EXTENSION.catalogLoader())
+        .writeParallelism(1)
+        .immediateTableUpdate(true)
+        .caseSensitive(false)
+        .append();
+
+    env.execute("case-insensitive data conversion");
+
+    Table table = CATALOG_EXTENSION.catalog().loadTable(identifier);
+    List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
+
+    assertThat(records).hasSize(3);
+    assertThat(records)
+        .allSatisfy(
+            record -> {
+              assertThat(record.getField("id")).isNotNull();
+              assertThat(record.getField("data")).isNotNull();
+            });
+  }
+
+  private static class CaseMismatchGenerator implements DynamicRecordGenerator<Integer> {
+    @Override
+    public void generate(Integer value, Collector<DynamicRecord> out) {
+      Schema inputSchema =
+          new Schema(
+              Types.NestedField.optional(1, "Id", Types.IntegerType.get()),
+              Types.NestedField.optional(2, "Data", Types.StringType.get()));
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, value);
+      row.setField(1, StringData.fromString("value-" + value));
+      out.collect(
+          new DynamicRecord(
+              TableIdentifier.of(DATABASE, "t1"),
+              "main",
+              inputSchema,
+              row,
+              PartitionSpec.unpartitioned(),
+              DistributionMode.NONE,
+              1));
+    }
   }
 }

--- a/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v2.3/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -286,9 +286,16 @@ class TestRowDataConverter {
   }
 
   private static RowData convert(RowData sourceData, Schema sourceSchema, Schema targetSchema) {
+    return convert(sourceData, sourceSchema, targetSchema, true);
+  }
+
+  private static RowData convert(
+      RowData sourceData, Schema sourceSchema, Schema targetSchema, boolean caseSensitive) {
     return (RowData)
         DataConverter.get(
-                FlinkSchemaUtil.convert(sourceSchema), FlinkSchemaUtil.convert(targetSchema))
+                FlinkSchemaUtil.convert(sourceSchema),
+                FlinkSchemaUtil.convert(targetSchema),
+                caseSensitive)
             .convert(sourceData);
   }
 }


### PR DESCRIPTION
## Summary
- DynamicIcebergSink with `caseSensitive(false)` can write NULL for columns whose names differ only by case.
- `CompareSchemasVisitor` matches names case-insensitively and returns `DATA_CONVERSION_NEEDED`, but `DataConverter` used `RowType.getFieldIndex` (exact match), so the source field looked missing.
- Thread `caseSensitive` into `DataConverter` and look up fields with `equalsIgnoreCase` when matching is case-insensitive.

## Test plan
- [x] `TestRowDataConverter` case-insensitive remap (values kept, missing optional field is null)
- [x] `TestDynamicIcebergSink.testCaseInsensitiveDataConversionDropsValues`
- [x] `./gradlew :iceberg-flink:iceberg-flink-2.3:test -DflinkVersions=2.3 --tests org.apache.iceberg.flink.sink.dynamic.TestRowDataConverter --tests org.apache.iceberg.flink.sink.dynamic.TestDynamicIcebergSink.testCaseInsensitiveDataConversionDropsValues`
