### PR TITLE
Core: Bound Idempotency-Key retries to the advertised key lifetime

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -74,7 +74,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *   <li>SC_REQUEST_TIMEOUT (408)
  * </ul>
  *
- * Most code and behavior is taken from {@link
+ * Requests carrying an {@code Idempotency-Key} header are treated as retry-safe for these codes
+ * even when the HTTP method is not idempotent.
+ *
+ * <p>Most code and behavior is taken from {@link
  * org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy}, with minor modifications to
  * {@link #getRetryInterval(HttpResponse, int, HttpContext)} to achieve exponential backoff.
  */
@@ -130,8 +133,10 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Retry if the request is considered idempotent
-    return Method.isIdempotent(request.getMethod());
+    // Retry if the request is idempotent, or carries an Idempotency-Key (server guarantees safe
+    // retry)
+    return Method.isIdempotent(request.getMethod())
+        || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
   }
 
   @Override
@@ -189,8 +194,10 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Check if the request is idempotent
-    return Method.isIdempotent(request.getMethod())
-        && idempotentRetriableCodes.contains(responseCode);
+    // Check if the request is idempotent or carries an Idempotency-Key
+    boolean retrySafe =
+        Method.isIdempotent(request.getMethod())
+            || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
+    return retrySafe && idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -194,7 +194,8 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Check if the request is idempotent or carries an Idempotency-Key
+    // A request is retry-safe if its HTTP method is idempotent or it carries an Idempotency-Key
+    // header (which lets the server replay a finalized result on retry).
     boolean retrySafe =
         Method.isIdempotent(request.getMethod())
             || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -23,6 +23,7 @@ import java.io.InterruptedIOException;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -82,15 +83,24 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * {@link #getRetryInterval(HttpResponse, int, HttpContext)} to achieve exponential backoff.
  */
 class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
+  private static final String FIRST_ATTEMPT_MILLIS_ATTR =
+      "iceberg.rest.idempotency.first-attempt-millis";
+
   private final int maxRetries;
+  private final Duration keyLifetime;
   private final Set<Class<? extends IOException>> nonRetriableExceptions;
   private final Set<Integer> retriableCodes;
   private final Set<Integer> idempotentRetriableCodes;
 
   ExponentialHttpRequestRetryStrategy(int maximumRetries) {
+    this(maximumRetries, null);
+  }
+
+  ExponentialHttpRequestRetryStrategy(int maximumRetries, Duration keyLifetime) {
     Preconditions.checkArgument(
         maximumRetries > 0, "Cannot set retries to %s, the value must be positive", maximumRetries);
     this.maxRetries = maximumRetries;
+    this.keyLifetime = keyLifetime;
     this.retriableCodes = ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS);
     this.idempotentRetriableCodes =
         ImmutableSet.of(
@@ -133,10 +143,12 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // Retry if the request is idempotent, or carries an Idempotency-Key (server guarantees safe
-    // retry)
-    return Method.isIdempotent(request.getMethod())
-        || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
+    // Retry if the request is retry-safe (idempotent method or carries an Idempotency-Key)
+    if (!isRetrySafe(request)) {
+      return false;
+    }
+
+    return !wouldExceedKeyLifetime(request, null, execCount, context);
   }
 
   @Override
@@ -154,10 +166,17 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     //    - It's in a predefined list of retriable codes.
     //    - The request is idempotent, and the response code indicates a retry is safe.
     //    - The response code is '503 Service Unavailable' and includes a 'Retry-After' header.
-    return execCount <= maxRetries
-        && (retriableCodes.contains(response.getCode())
-            || shouldRetryIdempotent(request, response.getCode())
-            || is503Retryable);
+    boolean shouldRetry =
+        execCount <= maxRetries
+            && (retriableCodes.contains(response.getCode())
+                || shouldRetryIdempotent(request, response.getCode())
+                || is503Retryable);
+
+    if (!shouldRetry) {
+      return false;
+    }
+
+    return !wouldExceedKeyLifetime(request, response, execCount, context);
   }
 
   @Override
@@ -183,10 +202,16 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       }
     }
 
-    int delayMillis = 1000 * (int) Math.min(Math.pow(2.0, (long) execCount - 1.0), 64.0);
+    long delayMillis = nextBackoffMillis(execCount);
     int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMillis * 0.1)));
 
     return TimeValue.ofMilliseconds(delayMillis + jitter);
+  }
+
+  private static boolean isRetrySafe(HttpRequest request) {
+    return request != null
+        && (Method.isIdempotent(request.getMethod())
+            || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER));
   }
 
   private boolean shouldRetryIdempotent(HttpRequest request, int responseCode) {
@@ -194,11 +219,39 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       return false;
     }
 
-    // A request is retry-safe if its HTTP method is idempotent or it carries an Idempotency-Key
-    // header (which lets the server replay a finalized result on retry).
-    boolean retrySafe =
-        Method.isIdempotent(request.getMethod())
-            || request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER);
-    return retrySafe && idempotentRetriableCodes.contains(responseCode);
+    return isRetrySafe(request) && idempotentRetriableCodes.contains(responseCode);
+  }
+
+  private static long nextBackoffMillis(int execCount) {
+    return 1000L * (long) Math.min(Math.pow(2.0, (long) execCount - 1.0), 64.0);
+  }
+
+  private boolean wouldExceedKeyLifetime(
+      HttpRequest request, HttpResponse response, int execCount, HttpContext context) {
+    // Only bound requests that carry an Idempotency-Key and only when the server advertised a
+    // lifetime.
+    if (keyLifetime == null
+        || context == null
+        || request == null
+        || !request.containsHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER)) {
+      return false;
+    }
+
+    long now = System.currentTimeMillis();
+    Object attr = context.getAttribute(FIRST_ATTEMPT_MILLIS_ATTR);
+    long firstAttemptMillis;
+    if (attr instanceof Long) {
+      firstAttemptMillis = (Long) attr;
+    } else {
+      firstAttemptMillis = now;
+      context.setAttribute(FIRST_ATTEMPT_MILLIS_ATTR, firstAttemptMillis);
+    }
+
+    long nextIntervalMillis =
+        response != null
+            ? getRetryInterval(response, execCount, context).toMilliseconds()
+            : nextBackoffMillis(execCount);
+    // Stop if the next attempt would land at/after the advertised lifetime window.
+    return (now - firstAttemptMillis) + nextIntervalMillis >= keyLifetime.toMillis();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -81,6 +83,7 @@ public class HTTPClient extends BaseHTTPClient {
   static final String CLIENT_GIT_COMMIT_SHORT_HEADER = "X-Client-Git-Commit-Short";
 
   private static final String REST_MAX_RETRIES = "rest.client.max-retries";
+  static final String REST_IDEMPOTENCY_KEY_LIFETIME = "rest.client.idempotency-key-lifetime";
   static final String REST_MAX_CONNECTIONS = "rest.client.max-connections";
   static final int REST_MAX_CONNECTIONS_DEFAULT = 100;
   static final String REST_MAX_CONNECTIONS_PER_ROUTE = "rest.client.connections-per-route";
@@ -125,7 +128,9 @@ public class HTTPClient extends BaseHTTPClient {
     clientBuilder.setConnectionManager(connectionManager);
 
     int maxRetries = PropertyUtil.propertyAsInt(properties, REST_MAX_RETRIES, 5);
-    clientBuilder.setRetryStrategy(new ExponentialHttpRequestRetryStrategy(maxRetries));
+    Duration keyLifetime = parseKeyLifetime(properties.get(REST_IDEMPOTENCY_KEY_LIFETIME));
+    clientBuilder.setRetryStrategy(
+        new ExponentialHttpRequestRetryStrategy(maxRetries, keyLifetime));
 
     String userAgent = PropertyUtil.propertyAsString(properties, REST_USER_AGENT, null);
     if (userAgent != null) {
@@ -162,6 +167,18 @@ public class HTTPClient extends BaseHTTPClient {
   public HTTPClient withAuthSession(AuthSession session) {
     Preconditions.checkNotNull(session, "Invalid auth session: null");
     return new HTTPClient(this, session);
+  }
+
+  private static Duration parseKeyLifetime(String lifetime) {
+    if (lifetime == null) {
+      return null;
+    }
+    try {
+      return Duration.parse(lifetime);
+    } catch (DateTimeParseException e) {
+      LOG.warn("Ignoring malformed idempotency-key lifetime: {}", lifetime, e);
+      return null;
+    }
   }
 
   private static String extractResponseBodyAsString(ClassicHttpResponse response) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -213,11 +213,14 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     // build the final configuration and set up the catalog's auth
-    Map<String, String> mergedProps = config.merge(props);
+    Map<String, String> mergedProps = Maps.newHashMap(config.merge(props));
 
     // Enable Idempotency-Key header for mutation endpoints if the server advertises support
     if (config.idempotencyKeyLifetime() != null) {
       this.mutationHeaders = RESTUtil::idempotencyHeaders;
+      // Pass the advertised key lifetime to the client so it stops retrying a keyed request before
+      // the key expires (a late retry would be treated as a brand-new mutation by the server).
+      mergedProps.put(HTTPClient.REST_IDEMPOTENCY_KEY_LIFETIME, config.idempotencyKeyLifetime());
     }
 
     if (config.endpoints().isEmpty()) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -229,4 +229,24 @@ public class TestExponentialHttpRequestRetryStrategy {
     context.setRequest(new BasicHttpRequest("GET", "/"));
     assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
   }
+
+  @ParameterizedTest
+  @ValueSource(ints = {429, 503, 500, 502, 504, 408})
+  public void testRetryHappensForNonIdempotentMethodWithIdempotencyKey(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "017f22e2-79b0-7cc3-98c4-dc0c0c07398f");
+    context.setRequest(request);
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {503, 500, 502, 504, 408})
+  public void testRetryDoesNotHappenForNonIdempotentMethodWithoutIdempotencyKey(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequest(new BasicHttpRequest("POST", "/"));
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isFalse();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -27,6 +27,7 @@ import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import javax.net.ssl.SSLException;
@@ -248,5 +249,65 @@ public class TestExponentialHttpRequestRetryStrategy {
     HttpClientContext context = HttpClientContext.create();
     context.setRequest(new BasicHttpRequest("POST", "/"));
     assertThat(retryStrategy.retryRequest(response, 3, context)).isFalse();
+  }
+
+  @Test
+  public void testKeyedRetryAbandonedWhenLifetimeExceeded() {
+    HttpRequestRetryStrategy strategy =
+        new ExponentialHttpRequestRetryStrategy(5, Duration.ofSeconds(1));
+    BasicHttpResponse response = new BasicHttpResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "busy");
+    response.addHeader(new BasicHeader(HttpHeaders.RETRY_AFTER, "3600"));
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "key-abandon");
+    context.setRequest(request);
+    assertThat(strategy.retryRequest(response, 1, context)).isFalse();
+  }
+
+  @Test
+  public void testKeyedRetryContinuesWithinLifetime() {
+    HttpRequestRetryStrategy strategy =
+        new ExponentialHttpRequestRetryStrategy(5, Duration.ofHours(1));
+    BasicHttpResponse response = new BasicHttpResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "busy");
+    response.addHeader(new BasicHeader(HttpHeaders.RETRY_AFTER, "1"));
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "key-continue");
+    context.setRequest(request);
+    assertThat(strategy.retryRequest(response, 1, context)).isTrue();
+  }
+
+  @Test
+  public void testKeyedNetworkExceptionRetryAbandonedWhenLifetimeExceeded() {
+    HttpRequestRetryStrategy strategy =
+        new ExponentialHttpRequestRetryStrategy(5, Duration.ofMillis(1));
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "key-net-abandon");
+    context.setRequest(request);
+    assertThat(strategy.retryRequest(request, new IOException("connection reset"), 1, context))
+        .isFalse();
+  }
+
+  @Test
+  public void testKeyedNetworkExceptionRetryHonoredWithoutLifetime() {
+    HttpRequestRetryStrategy strategy = new ExponentialHttpRequestRetryStrategy(5);
+    HttpClientContext context = HttpClientContext.create();
+    BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+    request.addHeader(RESTUtil.IDEMPOTENCY_KEY_HEADER, "key-net-ok");
+    context.setRequest(request);
+    assertThat(strategy.retryRequest(request, new IOException("connection reset"), 1, context))
+        .isTrue();
+  }
+
+  @Test
+  public void testIdempotentGetNotConstrainedByKeyLifetime() {
+    HttpRequestRetryStrategy strategy =
+        new ExponentialHttpRequestRetryStrategy(5, Duration.ofMillis(1));
+    BasicHttpResponse response = new BasicHttpResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "busy");
+    response.addHeader(new BasicHeader(HttpHeaders.RETRY_AFTER, "3600"));
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequest(new BasicHttpRequest("GET", "/"));
+    assertThat(strategy.retryRequest(response, 1, context)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -166,6 +166,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     private final HTTPHeaders contextHeaders;
     private final java.util.concurrent.ConcurrentMap<String, RuntimeException>
         simulateFailureOnFirstSuccessByKey = new java.util.concurrent.ConcurrentHashMap<>();
+    // Records the Idempotency-Key value seen on every mutation request, in arrival order.
+    private final List<String> observedMutationIdempotencyKeys =
+        new java.util.concurrent.CopyOnWriteArrayList<>();
 
     HeaderValidatingAdapter(
         Catalog catalog, HTTPHeaders catalogHeaders, HTTPHeaders contextHeaders) {
@@ -192,6 +195,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           key,
           new CommitStateUnknownException(
               new RuntimeException("simulated transient 503 after success")));
+    }
+
+    /** Returns all Idempotency-Key values observed on mutation requests, in arrival order. */
+    public List<String> observedMutationIdempotencyKeys() {
+      return observedMutationIdempotencyKeys;
     }
 
     @Override
@@ -233,13 +241,16 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               handleRequest(
                   routeAndVars.first(), vars.build(), request, responseType, responseHeaders);
 
-          // For tests: simulate a transient 503 after the first successful mutation for a key.
+          // For tests: record observed keys and simulate transient failures for keyed mutations.
           Optional<HTTPHeaders.HTTPHeader> keyHeader =
               request.headers().firstEntry(RESTUtil.IDEMPOTENCY_KEY_HEADER);
           boolean isMutation =
               request.method() == HTTPMethod.POST || request.method() == HTTPMethod.DELETE;
           if (isMutation && keyHeader.isPresent()) {
             String key = keyHeader.get().value();
+            // Record every Idempotency-Key seen on a mutation (including retries) so tests can
+            // assert that all transport attempts carry the identical key.
+            observedMutationIdempotencyKeys.add(key);
             RuntimeException failure = simulateFailureOnFirstSuccessByKey.remove(key);
             if (failure != null) {
               throw failure;
@@ -3477,30 +3488,49 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     IdempotentEnv env = idempotentEnv(key, ns, "t_idemp");
     CreateTableRequest req = createReq(env.ident);
 
-    // First attempt: server finalizes success but responds 503
-    assertThatThrownBy(
-            () ->
-                env.http.post(
-                    ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
-                    req,
-                    LoadTableResponse.class,
-                    env.headers,
-                    ErrorHandlers.tableErrorHandler()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("simulated transient 503");
-
-    // Verify request shape (method, path, headers including Idempotency-Key)
-    verifyCreatePost(ns, env.headers);
-
-    // Retry with same key: server should replay 200 OK
-    LoadTableResponse replay =
+    // The client auto-retries the keyed POST on 503; the server replays the finalized 200, so
+    // the call succeeds transparently without the caller needing to retry manually.
+    LoadTableResponse response =
         env.http.post(
             ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
             req,
             LoadTableResponse.class,
             env.headers,
             ErrorHandlers.tableErrorHandler());
-    assertThat(replay).isNotNull();
+    assertThat(response).isNotNull();
+
+    // Verify request shape (method, path, headers including Idempotency-Key)
+    verifyCreatePost(ns, env.headers);
+  }
+
+  @Test
+  public void testIdempotentCreateRetryCarriesSameKey() {
+    // Pin the invariant: when the client auto-retries a keyed POST (503-then-200), every transport
+    // attempt must carry the identical Idempotency-Key so the server can replay the cached result.
+    String key = "idemp-same-key-retry";
+    adapterForRESTServer.simulate503OnFirstSuccessForKey(key);
+    Namespace ns = Namespace.of("ns_samekey");
+    IdempotentEnv env = idempotentEnv(key, ns, "t_samekey");
+    CreateTableRequest req = createReq(env.ident);
+
+    // Trigger the 503-then-200 retry cycle; the call must succeed transparently.
+    LoadTableResponse response =
+        env.http.post(
+            ResourcePaths.forCatalogProperties(ImmutableMap.of()).tables(ns),
+            req,
+            LoadTableResponse.class,
+            env.headers,
+            ErrorHandlers.tableErrorHandler());
+    assertThat(response).isNotNull();
+
+    // The adapter must have observed the Idempotency-Key on exactly 2 transport attempts
+    // (initial attempt + one auto-retry) and both values must be identical.
+    List<String> observedKeys =
+        adapterForRESTServer.observedMutationIdempotencyKeys().stream()
+            .filter(k -> k.equals(key))
+            .collect(Collectors.toList());
+    assertThat(observedKeys).hasSize(2);
+    assertThat(observedKeys.get(0)).isNotNull().isEqualTo(observedKeys.get(1));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -167,8 +168,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     private final java.util.concurrent.ConcurrentMap<String, RuntimeException>
         simulateFailureOnFirstSuccessByKey = new java.util.concurrent.ConcurrentHashMap<>();
     // Records the Idempotency-Key value seen on every mutation request, in arrival order.
-    private final List<String> observedMutationIdempotencyKeys =
-        new java.util.concurrent.CopyOnWriteArrayList<>();
+    private final List<String> observedMutationIdempotencyKeys = new CopyOnWriteArrayList<>();
 
     HeaderValidatingAdapter(
         Catalog catalog, HTTPHeaders catalogHeaders, HTTPHeaders contextHeaders) {
@@ -3530,7 +3530,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             .filter(k -> k.equals(key))
             .collect(Collectors.toList());
     assertThat(observedKeys).hasSize(2);
-    assertThat(observedKeys.get(0)).isNotNull().isEqualTo(observedKeys.get(1));
   }
 
   @Test


### PR DESCRIPTION
## What / Why
Follow-up to #17947 (client-side Idempotency-Key retries). #17947 auto-retries keyed POSTs on retriable errors but never honors the server-advertised key lifetime, so a slow retry can fire *after* the key has expired — when the server no longer dedupes — risking a duplicate mutation.

The REST spec obligation on the client:
> Clients SHOULD NOT reuse an Idempotency-Key after this window elapses.

## Change
- `ExponentialHttpRequestRetryStrategy` now accepts the advertised key lifetime and declines a retry for a keyed request once the elapsed time since the first attempt plus the next retry interval would reach the lifetime window. Enforced on both the response and network-exception retry paths; non-keyed / idempotent requests are unaffected.
- The lifetime advertised in `GET /v1/config` (ISO-8601, e.g. `PT30M`) is plumbed to the HTTP client through the client properties and parsed once in `HTTPClient`; a malformed value is ignored (disables enforcement) rather than failing client construction.
- Extracted a shared `isRetrySafe(...)` predicate to remove duplication between the two retry paths (addresses a review nit; also clarifies that "retry-safe" is not the same as strictly idempotent).

## Tests
Added unit tests in `TestExponentialHttpRequestRetryStrategy`: keyed retry abandoned once the window is exceeded (both response and network-exception paths), keyed retry honored within the window and when no lifetime is advertised, and an idempotent GET unaffected by the key lifetime. `:iceberg-core` `rest.*` tests pass locally.

## Notes
- Client-only change; no OpenAPI/spec files touched (no vote needed).
- Stacked on #17947, which has not merged yet — until it lands, this PR's diff also shows #17947's commits.
- This change was developed with AI assistance (Claude), reviewed by the author.