### PR TITLE
Build: Pull MinIO images from Quay

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
@@ -41,7 +41,11 @@ public class MinioUtil {
   }
 
   public static MinIOContainer createContainer(String tag, AwsCredentials credentials) {
-    var container = new MinIOContainer(DockerImageName.parse("minio/minio").withTag(tag));
+    var image =
+        DockerImageName.parse("quay.io/minio/minio")
+            .asCompatibleSubstituteFor("minio/minio")
+            .withTag(tag);
+    var container = new MinIOContainer(image);
 
     // this enables virtual-host-style requests. see
     // https://github.com/minio/minio/tree/master/docs/config#domain

--- a/docker/iceberg-flink-quickstart/docker-compose.yml
+++ b/docker/iceberg-flink-quickstart/docker-compose.yml
@@ -98,7 +98,7 @@ services:
 
   # MinIO for S3-compatible object storage
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     hostname: minio
     environment:
       MINIO_ROOT_USER: admin
@@ -117,7 +117,7 @@ services:
 
   # Create the warehouse bucket
   create-bucket:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       minio:
         condition: service_healthy

--- a/kafka-connect/kafka-connect-runtime/docker/docker-compose.yml
+++ b/kafka-connect/kafka-connect-runtime/docker/docker-compose.yml
@@ -20,7 +20,7 @@ volumes:
 
 services:
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     hostname: minio
     environment:
       - MINIO_ROOT_USER=minioadmin
@@ -33,7 +33,7 @@ services:
     command: server /data --console-address ":9001"
 
   create-bucket:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       - minio
     volumes:

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -74,7 +74,7 @@ services:
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio:9000
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     environment:
       - MINIO_ROOT_USER=admin
@@ -91,7 +91,7 @@ services:
   mc:
     depends_on:
       - minio
-    image: minio/mc
+    image: quay.io/minio/mc
     container_name: mc
     networks:
       iceberg_net:


### PR DESCRIPTION
Related:
- https://github.com/apache/iggy/pull/4148
- https://github.com/apache/doris/pull/67897

Docker Hub is no longer serving `minio/minio` (https://hub.docker.com/r/minio/minio) or `minio/mc` (https://hub.docker.com/r/minio/mc), stopping the [AWS integration tests](https://github.com/apache/iceberg/actions/runs/34644106884) and [Kafka Connect integration tests](https://github.com/apache/iceberg/actions/runs/34644106890) from starting on `main` (+ open PRs).

This PR switches to the corresponding Quay images, as the related PRs above do - those other projects are encountering the same issue as us.

Note: we have discussed moving away from MinIO before, but I don't think that has progressed - see:
- https://github.com/apache/iceberg/issues/14638
- https://github.com/apache/iceberg/pull/15577
- https://lists.apache.org/thread/vnw9jonmfcsz6bwojhfch1nmywyl50h3
- https://lists.apache.org/thread/wnt4ojcjsv1frfg1drxpz3gj0l91c5jl