### PR TITLE
Parquet: Preserve geometry CRS in writer metrics

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -268,11 +268,9 @@ abstract class BaseParquetWriter<T> {
     @Override
     public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
-      // geometry values are pure WKB stored in a BINARY column; the writer also scans the
-      // coordinates to produce a bounding box (the Parquet footer cannot). The concrete CRS is
-      // immaterial here: ParquetMetrics rewrites the bound's type from the table schema before
-      // serialization, and the serialization is keyed on the type id, which ignores the CRS.
-      return Optional.of(ParquetValueWriters.geometry(desc, Types.GeometryType.crs84()));
+      // geometry values are pure WKB stored in a BINARY column
+      return Optional.of(
+          ParquetValueWriters.geometry(desc, Types.GeometryType.of(geometryType.getCrs())));
     }
 
     @Override

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetValueWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetValueWriters.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnWriteStore;
@@ -35,6 +37,17 @@ import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
 
 class TestParquetValueWriters {
+
+  @Test
+  void geometryWriterUsesParquetCRS() {
+    Types.GeometryType geometryType = Types.GeometryType.of("EPSG:4326");
+    Schema schema = new Schema(optional(2, "geom", geometryType));
+    MessageType parquetSchema = ParquetSchemaUtil.convert(schema, "table");
+    ParquetValueWriter<Record> writer = GenericParquetWriter.create(schema, parquetSchema);
+
+    FieldMetrics<?> metrics = writer.metrics().findFirst().orElseThrow();
+    assertThat(metrics.originalType()).isEqualTo(geometryType);
+  }
 
   @Test
   void geospatialValueSizeMetricsExcludeNulls() {


### PR DESCRIPTION
## Description

Pass the CRS from Parquet's geometry logical type annotation to the generic
`GeometryWriter` instead of assigning `OGC:CRS84` unconditionally. This keeps the
writer-side `FieldMetrics.originalType` aligned with the geometry type encoded in
the Parquet schema and removes reliance on `ParquetMetrics` replacing the type
later.

## Tests

- Added `TestParquetValueWriters.geometryWriterUsesParquetCRS` to verify that a
  non-default CRS is preserved in writer-side metrics.

---
**AI Disclosure**
- Model: Grok
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Preserve the geometry CRS from the Parquet logical type in writer-side metrics and add regression coverage.