### PR TITLE
Core, REST: Avoid loading all snapshots when committing in refs mode

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -495,7 +495,14 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   Snapshot newSnapshot = apply();
                   newSnapshotId.set(newSnapshot.snapshotId());
                   TableMetadata.Builder update = TableMetadata.buildFrom(base);
-                  if (base.snapshot(newSnapshot.snapshotId()) != null) {
+                  // a snapshot with the id this producer generated is always new; only a snapshot
+                  // returned by apply() with another id can be an existing snapshot, in which case
+                  // looking it up may load all snapshots when they are loaded lazily
+                  Long producedSnapshotId = snapshotId;
+                  boolean isProducedSnapshot =
+                      producedSnapshotId != null
+                          && producedSnapshotId == newSnapshot.snapshotId();
+                  if (!isProducedSnapshot && base.snapshot(newSnapshot.snapshotId()) != null) {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);
                   } else if (stageOnly) {
@@ -685,7 +692,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   protected long snapshotId() {
     if (snapshotId == null) {
       synchronized (this) {
-        while (snapshotId == null || ops.current().snapshot(snapshotId) != null) {
+        // only check ids that are already loaded: with lazily loaded snapshots, a collision with
+        // an unloaded historical snapshot id is left to be detected when the commit is applied,
+        // since checking here would force loading all snapshots for every new snapshot id
+        while (snapshotId == null || ops.current().snapshotIfKnown(snapshotId) != null) {
           this.snapshotId = ops.newSnapshotId();
         }
       }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -500,8 +500,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   // looking it up may load all snapshots when they are loaded lazily
                   Long producedSnapshotId = snapshotId;
                   boolean isProducedSnapshot =
-                      producedSnapshotId != null
-                          && producedSnapshotId == newSnapshot.snapshotId();
+                      producedSnapshotId != null && producedSnapshotId == newSnapshot.snapshotId();
                   if (!isProducedSnapshot && base.snapshot(newSnapshot.snapshotId()) != null) {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -559,12 +559,15 @@ public class TableMetadata implements Serializable {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
       loadedSnapshots.removeIf(s -> s.sequenceNumber() > lastSequenceNumber);
 
-      // retain snapshots that are unknown to the supplier, such as snapshots that were added to
-      // this metadata after the supplier was created and are not yet visible to it
+      // retain snapshots that were added to this metadata but are unknown to the supplier, such
+      // as staged snapshots that are not committed to the catalog yet. the supplier remains
+      // authoritative for all snapshots inherited from the base metadata
       Set<Long> loadedSnapshotIds =
           loadedSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      Set<Long> addedSnapshotIds = addedSnapshotIds(changes);
       for (Snapshot snapshot : snapshots) {
-        if (!loadedSnapshotIds.contains(snapshot.snapshotId())) {
+        if (addedSnapshotIds.contains(snapshot.snapshotId())
+            && !loadedSnapshotIds.contains(snapshot.snapshotId())) {
           loadedSnapshots.add(snapshot);
         }
       }
@@ -578,6 +581,13 @@ public class TableMetadata implements Serializable {
       this.snapshotsLoaded = true;
       this.snapshotsSupplier = null;
     }
+  }
+
+  private static Set<Long> addedSnapshotIds(List<MetadataUpdate> changes) {
+    return changes.stream()
+        .filter(change -> change instanceof MetadataUpdate.AddSnapshot)
+        .map(change -> ((MetadataUpdate.AddSnapshot) change).snapshot().snapshotId())
+        .collect(Collectors.toSet());
   }
 
   public SnapshotRef ref(String name) {
@@ -946,6 +956,7 @@ public class TableMetadata implements Serializable {
     private long currentSnapshotId;
     private List<Snapshot> snapshots;
     private SerializableSupplier<List<Snapshot>> snapshotsSupplier;
+    private boolean snapshotsLoaded;
     private final Map<String, SnapshotRef> refs;
     private final Map<Long, List<StatisticsFile>> statisticsFiles;
     private final Map<Long, List<PartitionStatisticsFile>> partitionStatisticsFiles;
@@ -988,6 +999,7 @@ public class TableMetadata implements Serializable {
       this.sortOrders = Lists.newArrayList();
       this.properties = Maps.newHashMap();
       this.snapshots = Lists.newArrayList();
+      this.snapshotsLoaded = true;
       this.currentSnapshotId = -1;
       this.changes = Lists.newArrayList();
       this.startingChangeCount = 0;
@@ -1029,6 +1041,7 @@ public class TableMetadata implements Serializable {
       synchronized (base) {
         this.snapshots = Lists.newArrayList(base.snapshots);
         this.snapshotsSupplier = base.snapshotsSupplier;
+        this.snapshotsLoaded = base.snapshotsLoaded;
         this.snapshotsById = Maps.newHashMap(base.snapshotsById);
         this.refs = Maps.newHashMap(base.refs);
       }
@@ -1326,10 +1339,9 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
-    // loads all snapshots into the builder for operations that require them, keeping snapshots
-    // that were added to the builder but are unknown to the supplier
+    // keeps snapshots that were added to the builder but are unknown to the supplier
     private void ensureSnapshotsLoaded() {
-      if (snapshotsSupplier == null) {
+      if (snapshotsLoaded || snapshotsSupplier == null) {
         return;
       }
 
@@ -1341,8 +1353,10 @@ public class TableMetadata implements Serializable {
 
       Set<Long> loadedSnapshotIds =
           loadedSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      Set<Long> addedSnapshotIds = addedSnapshotIds(changes);
       for (Snapshot snapshot : snapshots) {
-        if (!loadedSnapshotIds.contains(snapshot.snapshotId())) {
+        if (addedSnapshotIds.contains(snapshot.snapshotId())
+            && !loadedSnapshotIds.contains(snapshot.snapshotId())) {
           loadedSnapshots.add(snapshot);
         }
       }
@@ -1350,12 +1364,12 @@ public class TableMetadata implements Serializable {
       this.snapshots = loadedSnapshots;
       snapshots.forEach(snapshot -> snapshotsById.putIfAbsent(snapshot.snapshotId(), snapshot));
       this.snapshotsSupplier = null;
+      this.snapshotsLoaded = true;
     }
 
-    // looks up a snapshot by id, loading all snapshots if the id is not loaded yet
     private Snapshot snapshotById(long snapshotId) {
       Snapshot snapshot = snapshotsById.get(snapshotId);
-      if (snapshot == null && snapshotsSupplier != null) {
+      if (snapshot == null && !snapshotsLoaded) {
         ensureSnapshotsLoaded();
         snapshot = snapshotsById.get(snapshotId);
       }
@@ -1495,7 +1509,6 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder removeSnapshots(Collection<Long> idsToRemove) {
-      // all snapshots must be loaded to remove any of them
       ensureSnapshotsLoaded();
       return rewriteSnapshotsInternal(idsToRemove, false);
     }
@@ -1647,8 +1660,9 @@ public class TableMetadata implements Serializable {
             addPreviousFile(
                 previousFiles, previousFileLocation, base.lastUpdatedMillis(), properties);
       }
-      // rewriting the snapshot log validates its entries against all snapshots
-      if (snapshotsSupplier != null
+      // rewriting the snapshot log validates its entries against all snapshots, which requires
+      // loading them when the builder only holds a partial set inherited from the base
+      if (!snapshotsLoaded
           && (!intermediateSnapshotIdSet(changes, currentSnapshotId).isEmpty()
               || changes.stream()
                   .anyMatch(change -> change instanceof MetadataUpdate.RemoveSnapshots))) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -536,8 +536,8 @@ public class TableMetadata implements Serializable {
   /**
    * Returns the snapshot for the given id if it is already loaded, or null otherwise.
    *
-   * <p>Unlike {@link #snapshot(long)}, this never triggers loading all snapshots when snapshots
-   * are loaded lazily. Callers must be able to tolerate a null result for an existing but not yet
+   * <p>Unlike {@link #snapshot(long)}, this never triggers loading all snapshots when snapshots are
+   * loaded lazily. Callers must be able to tolerate a null result for an existing but not yet
    * loaded snapshot.
    */
   Snapshot snapshotIfKnown(long snapshotId) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -533,6 +533,17 @@ public class TableMetadata implements Serializable {
     return snapshotsById.get(snapshotId);
   }
 
+  /**
+   * Returns the snapshot for the given id if it is already loaded, or null otherwise.
+   *
+   * <p>Unlike {@link #snapshot(long)}, this never triggers loading all snapshots when snapshots
+   * are loaded lazily. Callers must be able to tolerate a null result for an existing but not yet
+   * loaded snapshot.
+   */
+  Snapshot snapshotIfKnown(long snapshotId) {
+    return snapshotsById.get(snapshotId);
+  }
+
   public Snapshot currentSnapshot() {
     return snapshotsById.get(currentSnapshotId);
   }
@@ -547,6 +558,16 @@ public class TableMetadata implements Serializable {
     if (!snapshotsLoaded) {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
       loadedSnapshots.removeIf(s -> s.sequenceNumber() > lastSequenceNumber);
+
+      // retain snapshots that are unknown to the supplier, such as snapshots that were added to
+      // this metadata after the supplier was created and are not yet visible to it
+      Set<Long> loadedSnapshotIds =
+          loadedSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      for (Snapshot snapshot : snapshots) {
+        if (!loadedSnapshotIds.contains(snapshot.snapshotId())) {
+          loadedSnapshots.add(snapshot);
+        }
+      }
 
       this.snapshots = ImmutableList.copyOf(loadedSnapshots);
       this.snapshotsById = indexAndValidateSnapshots(snapshots, lastSequenceNumber);
@@ -936,6 +957,7 @@ public class TableMetadata implements Serializable {
     private final List<MetadataUpdate> changes;
     private final int startingChangeCount;
     private boolean discardChanges = false;
+    private boolean snapshotsSupplierChanged = false;
     private Integer lastAddedSchemaId = null;
     private Integer lastAddedSpecId = null;
     private Integer lastAddedOrderId = null;
@@ -1000,7 +1022,17 @@ public class TableMetadata implements Serializable {
       this.sortOrders = Lists.newArrayList(base.sortOrders);
       this.properties = Maps.newHashMap(base.properties);
       this.currentSnapshotId = base.currentSnapshotId;
-      this.snapshots = Lists.newArrayList(base.snapshots());
+
+      // copy the snapshot state as-is: when base loads snapshots lazily, carry the supplier over
+      // instead of forcing all snapshots to load. the lock ensures a consistent copy in case a
+      // concurrent load replaces the snapshot state of base
+      synchronized (base) {
+        this.snapshots = Lists.newArrayList(base.snapshots);
+        this.snapshotsSupplier = base.snapshotsSupplier;
+        this.snapshotsById = Maps.newHashMap(base.snapshotsById);
+        this.refs = Maps.newHashMap(base.refs);
+      }
+
       this.encryptionKeys = Lists.newArrayList(base.encryptionKeys);
       this.changes = Lists.newArrayList(base.changes);
       this.startingChangeCount = changes.size();
@@ -1008,10 +1040,8 @@ public class TableMetadata implements Serializable {
       this.snapshotLog = Lists.newArrayList(base.snapshotLog);
       this.previousFileLocation = base.metadataFileLocation;
       this.previousFiles = base.previousFiles;
-      this.refs = Maps.newHashMap(base.refs);
       this.statisticsFiles = indexStatistics(base.statisticsFiles);
       this.partitionStatisticsFiles = indexPartitionStatistics(base.partitionStatisticsFiles);
-      this.snapshotsById = Maps.newHashMap(base.snapshotsById);
       this.schemasById = Maps.newHashMap(base.schemasById);
       this.specsById = Maps.newHashMap(base.specsById);
       this.sortOrdersById = Maps.newHashMap(base.sortOrdersById);
@@ -1292,7 +1322,45 @@ public class TableMetadata implements Serializable {
 
     public Builder setSnapshotsSupplier(SerializableSupplier<List<Snapshot>> snapshotsSupplier) {
       this.snapshotsSupplier = snapshotsSupplier;
+      this.snapshotsSupplierChanged = true;
       return this;
+    }
+
+    // loads all snapshots into the builder for operations that require them, keeping snapshots
+    // that were added to the builder but are unknown to the supplier
+    private void ensureSnapshotsLoaded() {
+      if (snapshotsSupplier == null) {
+        return;
+      }
+
+      List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
+      // ignore snapshots that are not part of this metadata lineage, such as snapshots that were
+      // committed concurrently after the base metadata was created
+      long baseLastSequenceNumber = base != null ? base.lastSequenceNumber : lastSequenceNumber;
+      loadedSnapshots.removeIf(s -> s.sequenceNumber() > baseLastSequenceNumber);
+
+      Set<Long> loadedSnapshotIds =
+          loadedSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      for (Snapshot snapshot : snapshots) {
+        if (!loadedSnapshotIds.contains(snapshot.snapshotId())) {
+          loadedSnapshots.add(snapshot);
+        }
+      }
+
+      this.snapshots = loadedSnapshots;
+      snapshots.forEach(snapshot -> snapshotsById.putIfAbsent(snapshot.snapshotId(), snapshot));
+      this.snapshotsSupplier = null;
+    }
+
+    // looks up a snapshot by id, loading all snapshots if the id is not loaded yet
+    private Snapshot snapshotById(long snapshotId) {
+      Snapshot snapshot = snapshotsById.get(snapshotId);
+      if (snapshot == null && snapshotsSupplier != null) {
+        ensureSnapshotsLoaded();
+        snapshot = snapshotsById.get(snapshotId);
+      }
+
+      return snapshot;
     }
 
     public Builder setBranchSnapshot(Snapshot snapshot, String branch) {
@@ -1308,7 +1376,7 @@ public class TableMetadata implements Serializable {
         return this;
       }
 
-      Snapshot snapshot = snapshotsById.get(snapshotId);
+      Snapshot snapshot = snapshotById(snapshotId);
       ValidationException.check(
           snapshot != null, "Cannot set %s to unknown snapshot: %s", branch, snapshotId);
 
@@ -1324,7 +1392,7 @@ public class TableMetadata implements Serializable {
       }
 
       long snapshotId = ref.snapshotId();
-      Snapshot snapshot = snapshotsById.get(snapshotId);
+      Snapshot snapshot = snapshotById(snapshotId);
       ValidationException.check(
           snapshot != null, "Cannot set %s to unknown snapshot: %s", name, snapshotId);
       ValidationException.check(
@@ -1427,6 +1495,8 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder removeSnapshots(Collection<Long> idsToRemove) {
+      // all snapshots must be loaded to remove any of them
+      ensureSnapshotsLoaded();
       return rewriteSnapshotsInternal(idsToRemove, false);
     }
 
@@ -1544,7 +1614,7 @@ public class TableMetadata implements Serializable {
           || (discardChanges && !changes.isEmpty())
           || metadataLocation != null
           || suppressHistoricalSnapshots
-          || null != snapshotsSupplier;
+          || snapshotsSupplierChanged;
     }
 
     public TableMetadata build() {
@@ -1577,6 +1647,14 @@ public class TableMetadata implements Serializable {
             addPreviousFile(
                 previousFiles, previousFileLocation, base.lastUpdatedMillis(), properties);
       }
+      // rewriting the snapshot log validates its entries against all snapshots
+      if (snapshotsSupplier != null
+          && (!intermediateSnapshotIdSet(changes, currentSnapshotId).isEmpty()
+              || changes.stream()
+                  .anyMatch(change -> change instanceof MetadataUpdate.RemoveSnapshots))) {
+        ensureSnapshotsLoaded();
+      }
+
       List<HistoryEntry> newSnapshotLog =
           updateSnapshotLog(snapshotLog, snapshotsById, currentSnapshotId, changes);
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1302,7 +1302,16 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableMetadata current,
       Set<Endpoint> supportedEndpoints) {
     return new RESTTableOperations(
-        restClient, path, readHeaders, mutationHeaderSupplier, fileIO, current, supportedEndpoints);
+        restClient,
+        path,
+        readHeaders,
+        mutationHeaderSupplier,
+        fileIO,
+        RESTTableOperations.UpdateType.SIMPLE,
+        Lists.newArrayList(),
+        current,
+        supportedEndpoints,
+        snapshotMode);
   }
 
   /**
@@ -1344,7 +1353,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         updateType,
         createChanges,
         current,
-        supportedEndpoints);
+        supportedEndpoints,
+        snapshotMode);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -324,8 +324,6 @@ class RESTTableOperations implements TableOperations {
         || !Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
       TableMetadata refreshed = checkUUID(current, response.tableMetadata());
       if (reinstallSnapshotsSupplier) {
-        // re-install the lazy snapshot supplier so that snapshots suppressed by refs mode can
-        // still be loaded on demand from the refreshed metadata
         refreshed =
             TableMetadata.buildFrom(refreshed)
                 .withMetadataLocation(response.metadataLocation())

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -38,7 +39,9 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -61,6 +64,7 @@ class RESTTableOperations implements TableOperations {
   private final List<MetadataUpdate> createChanges;
   private final TableMetadata replaceBase;
   private final Set<Endpoint> endpoints;
+  private final SnapshotMode snapshotMode;
   private UpdateType updateType;
   private TableMetadata current;
 
@@ -80,7 +84,8 @@ class RESTTableOperations implements TableOperations {
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
-        endpoints);
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -92,7 +97,17 @@ class RESTTableOperations implements TableOperations {
       List<MetadataUpdate> createChanges,
       TableMetadata current,
       Set<Endpoint> endpoints) {
-    this(client, path, headers, headers, io, updateType, createChanges, current, endpoints);
+    this(
+        client,
+        path,
+        headers,
+        headers,
+        io,
+        updateType,
+        createChanges,
+        current,
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -112,7 +127,8 @@ class RESTTableOperations implements TableOperations {
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
-        endpoints);
+        endpoints,
+        SnapshotMode.ALL);
   }
 
   RESTTableOperations(
@@ -124,7 +140,8 @@ class RESTTableOperations implements TableOperations {
       UpdateType updateType,
       List<MetadataUpdate> createChanges,
       TableMetadata current,
-      Set<Endpoint> endpoints) {
+      Set<Endpoint> endpoints,
+      SnapshotMode snapshotMode) {
     this.client = client;
     this.path = path;
     this.readHeaders = readHeaders;
@@ -139,6 +156,7 @@ class RESTTableOperations implements TableOperations {
       this.current = current;
     }
     this.endpoints = endpoints;
+    this.snapshotMode = snapshotMode != null ? snapshotMode : SnapshotMode.ALL;
   }
 
   @Override
@@ -150,7 +168,15 @@ class RESTTableOperations implements TableOperations {
   public TableMetadata refresh() {
     Endpoint.check(endpoints, Endpoint.V1_LOAD_TABLE);
     return updateCurrentMetadata(
-        client.get(path, LoadTableResponse.class, readHeaders, ErrorHandlers.tableErrorHandler()));
+        client.get(
+            path,
+            snapshotModeToParam(snapshotMode),
+            LoadTableResponse.class,
+            readHeaders,
+            ErrorHandlers.tableErrorHandler()),
+        // a refs mode response suppresses historical snapshots, so a lazy snapshot supplier must
+        // be re-installed. commit responses always contain all snapshots and need no supplier
+        snapshotMode == SnapshotMode.REFS);
   }
 
   @Override
@@ -286,15 +312,48 @@ class RESTTableOperations implements TableOperations {
   }
 
   private TableMetadata updateCurrentMetadata(LoadTableResponse response) {
+    return updateCurrentMetadata(response, false);
+  }
+
+  private TableMetadata updateCurrentMetadata(
+      LoadTableResponse response, boolean reinstallSnapshotsSupplier) {
     // LoadTableResponse is used to deserialize the response, but config is not allowed by the REST
     // spec so it can be
     // safely ignored. there is no requirement to update config on refresh or commit.
     if (current == null
         || !Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
-      this.current = checkUUID(current, response.tableMetadata());
+      TableMetadata refreshed = checkUUID(current, response.tableMetadata());
+      if (reinstallSnapshotsSupplier) {
+        // re-install the lazy snapshot supplier so that snapshots suppressed by refs mode can
+        // still be loaded on demand from the refreshed metadata
+        refreshed =
+            TableMetadata.buildFrom(refreshed)
+                .withMetadataLocation(response.metadataLocation())
+                .setPreviousFileLocation(null)
+                .setSnapshotsSupplier(
+                    () ->
+                        client
+                            .get(
+                                path,
+                                snapshotModeToParam(SnapshotMode.ALL),
+                                LoadTableResponse.class,
+                                readHeaders,
+                                ErrorHandlers.tableErrorHandler())
+                            .tableMetadata()
+                            .snapshots())
+                .discardChanges()
+                .build();
+      }
+
+      this.current = refreshed;
     }
 
     return current;
+  }
+
+  private static Map<String, String> snapshotModeToParam(SnapshotMode mode) {
+    return ImmutableMap.of(
+        RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, mode.name().toLowerCase(Locale.US));
   }
 
   private static TableMetadata checkUUID(TableMetadata currentMetadata, TableMetadata newMetadata) {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
@@ -186,9 +186,16 @@ public class TestSnapshotLoading extends TestBase {
   }
 
   @TestTemplate
-  public void testBuildingNewMetadataTriggersSnapshotLoad() {
-    TableMetadata.buildFrom(latestTableMetadata).removeRef(SnapshotRef.MAIN_BRANCH).build();
+  public void testBuildingNewMetadataDoesNotTriggerSnapshotLoad() {
+    // building new metadata carries the lazy snapshot supplier over instead of loading all
+    // snapshots, so that commits against lazily loaded metadata stay lazy
+    TableMetadata newTableMetadata =
+        TableMetadata.buildFrom(latestTableMetadata).removeRef(SnapshotRef.MAIN_BRANCH).build();
 
+    verify(snapshotsSupplierMock, times(0)).get();
+
+    assertThat(newTableMetadata.snapshots())
+        .containsExactlyElementsOf(originalTableMetadata.snapshots());
     verify(snapshotsSupplierMock, times(1)).get();
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -809,6 +809,9 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_B).commit();
 
+    // only verify requests made by the loads below, not by the commits above
+    Mockito.clearInvocations(adapter);
+
     Table refsTable = catalog.loadTable(TABLE);
     String eTag = responseHeaders.get(HttpHeaders.ETAG);
     assertThat(eTag).isNotNull();

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1134,6 +1134,172 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
   }
 
+  @Test
+  public void testCommitOnRefsModeTableLoadsAllSnapshots() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            SnapshotMode.REFS.name()));
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(TABLE.namespace());
+    }
+
+    // create a table with two snapshots so that refs mode suppresses historical snapshots
+    Table table = catalog.createTable(TABLE, SCHEMA);
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-a.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-b.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    Table refsTable = catalog.loadTable(TABLE);
+
+    // don't call snapshots() directly as that would cause to load all snapshots. Instead,
+    // make sure the snapshots field holds exactly 1 snapshot
+    assertThat(((BaseTable) refsTable).operations().current())
+        .extracting("snapshots")
+        .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
+        .hasSize(1);
+
+    Mockito.clearInvocations(adapter);
+
+    refsTable
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-c.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    // the commit refreshes the table without the refs argument, once before applying the changes
+    // and once after committing to check that the new snapshot was saved
+    verify(adapter, times(2))
+        .execute(
+            matches(HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of()),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+
+    // committing must not force loading all snapshots through the lazy snapshot supplier
+    verify(adapter, Mockito.never())
+        .execute(
+            matches(
+                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+    verify(adapter, Mockito.never())
+        .execute(
+            matches(
+                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "refs")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+
+    assertThat(refsTable.currentSnapshot()).isEqualTo(catalog.loadTable(TABLE).currentSnapshot());
+    assertThat(catalog.loadTable(TABLE).snapshots()).hasSize(3);
+  }
+
+  @Test
+  public void testStagedCommitOnRefsModeTableDoesNotLoadAllSnapshots() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            SnapshotMode.REFS.name()));
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(TABLE.namespace());
+    }
+
+    // create a table with two snapshots so that refs mode suppresses historical snapshots
+    Table table = catalog.createTable(TABLE, SCHEMA);
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-a.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-b.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    Table refsTable = catalog.loadTable(TABLE);
+    Snapshot currentSnapshot = refsTable.currentSnapshot();
+
+    Mockito.clearInvocations(adapter);
+
+    // stage a snapshot without updating any ref, as write-audit-publish does
+    refsTable
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-c.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .stageOnly()
+        .commit();
+
+    // committing must not force loading all snapshots through the lazy snapshot supplier
+    verify(adapter, Mockito.never())
+        .execute(
+            matches(
+                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+
+    // the staged snapshot must be committed but must not update any ref
+    Table freshTable = catalog.loadTable(TABLE);
+    assertThat(freshTable.currentSnapshot()).isEqualTo(currentSnapshot);
+    assertThat(freshTable.snapshots()).hasSize(3);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"1", "2"})
   public void testTableSnapshotLoadingWithDivergedBranches(String formatVersion) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1138,7 +1138,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
-  public void testTableSnapshotLoadingRefreshKeepsLazySupplier() {
+  void tableSnapshotLoadingRefreshKeepsLazySupplier() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
 
     RESTCatalog catalog =
@@ -1205,7 +1205,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
-  public void testCommitOnRefsModeTableDoesNotLoadAllSnapshots() {
+  void commitOnRefsModeTableDoesNotLoadAllSnapshots() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
 
     RESTCatalog catalog =
@@ -1297,7 +1297,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
-  public void testStagedCommitOnRefsModeTableDoesNotLoadAllSnapshots() {
+  void stagedCommitOnRefsModeTableDoesNotLoadAllSnapshots() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
 
     RESTCatalog catalog =

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1095,6 +1095,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 .build())
         .commit();
 
+    // only verify requests made by the loads below, not by the commits above
+    Mockito.clearInvocations(adapter);
+
     Table refsTable = catalog.loadTable(TABLE);
 
     // don't call snapshots() directly as that would cause to load all snapshots. Instead,
@@ -1135,7 +1138,74 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
-  public void testCommitOnRefsModeTableLoadsAllSnapshots() {
+  public void testTableSnapshotLoadingRefreshKeepsLazySupplier() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            // default loading to refs only
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            SnapshotMode.REFS.name()));
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(TABLE.namespace());
+    }
+
+    Table table = catalog.createTable(TABLE, SCHEMA);
+
+    for (int i = 0; i < 3; i++) {
+      table
+          .newFastAppend()
+          .appendFile(
+              DataFiles.builder(PartitionSpec.unpartitioned())
+                  .withPath(String.format("/path/to/data-%s.parquet", i))
+                  .withFileSizeInBytes(10)
+                  .withRecordCount(2)
+                  .build())
+          .commit();
+    }
+
+    Table refsTable = catalog.loadTable(TABLE);
+
+    // load in refs mode: only the retained ref snapshot is loaded eagerly
+    assertThat(((BaseTable) refsTable).operations().current())
+        .extracting("snapshots")
+        .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
+        .hasSize(1);
+
+    // advance the table so the metadata location changes, then refresh
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-adv.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    // refresh must re-install the lazy snapshots supplier in refs mode
+    refsTable.refresh();
+
+    // still partial after refresh (refs mode) -- supplier must be re-installed
+    assertThat(((BaseTable) refsTable).operations().current())
+        .extracting("snapshots")
+        .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
+        .hasSize(1);
+
+    // resolving all snapshots must lazy-load the full history via the reinstalled supplier
+    assertThat(refsTable.snapshots()).hasSize(4);
+  }
+
+  @Test
+  public void testCommitOnRefsModeTableDoesNotLoadAllSnapshots() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
 
     RESTCatalog catalog =
@@ -1197,11 +1267,12 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 .build())
         .commit();
 
-    // the commit refreshes the table without the refs argument, once before applying the changes
-    // and once after committing to check that the new snapshot was saved
+    // the commit refreshes the table in refs mode, once before applying the changes and once
+    // after committing to check that the new snapshot was saved
     verify(adapter, times(2))
         .execute(
-            matches(HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of()),
+            matches(
+                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "refs")),
             eq(LoadTableResponse.class),
             any(),
             any());
@@ -1216,8 +1287,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
     verify(adapter, Mockito.never())
         .execute(
-            matches(
-                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "refs")),
+            matches(HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of()),
             eq(LoadTableResponse.class),
             any(),
             any());
@@ -1285,11 +1355,18 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .stageOnly()
         .commit();
 
-    // committing must not force loading all snapshots through the lazy snapshot supplier
+    // committing must not force loading all snapshots through the lazy snapshot supplier, even
+    // though the staged snapshot is not referenced by any ref
     verify(adapter, Mockito.never())
         .execute(
             matches(
                 HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+    verify(adapter, Mockito.never())
+        .execute(
+            matches(HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of()),
             eq(LoadTableResponse.class),
             any(),
             any());
@@ -1362,6 +1439,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 .build())
         .toBranch(branch)
         .commit();
+
+    // only verify requests made by the loads below, not by the commits above
+    Mockito.clearInvocations(adapter);
 
     Table refsTable = catalog.loadTable(TABLE);
 


### PR DESCRIPTION
Closes #17830. Supersedes and incorporates #17832 (thanks @waterWang — the refresh-path fix and its test come from that PR; co-authored).

### Problem

With `snapshot-loading-mode=refs`, lazy snapshot loading only helps readers. Every commit forced full snapshot loads three ways: `TableMetadata.buildFrom` eagerly copied `base.snapshots()`, the snapshot-id probes in `SnapshotProducer` fault-loaded on any unloaded id, and `refresh()` requested metadata without the `snapshots` param and dropped the lazy supplier (#17830). A single `fastAppend` transferred the complete snapshot list **four times**, one of which was downloaded and immediately discarded:

### Before this change

| # | Request              | Payload                                                    | Why                                                             |
|---|----------------------|------------------------------------------------------------|-----------------------------------------------------------------|
| 1 | `GET /tables/{t}`    | all snapshots — **discarded** (metadata location unchanged) | refresh at the start of `apply()`                               |
| 2 | `GET ?snapshots=all` | all snapshots                                              | lazy supplier fired by `TableMetadata.buildFrom` / id probes    |
| 3 | `POST /tables/{t}`   | all snapshots (response)                                   | the commit itself                                               |
| 4 | `GET /tables/{t}`    | all snapshots                                              | post-commit saved-snapshot check                                |

### After this change

| # | Request               | Payload                                        | Why                               |
|---|-----------------------|------------------------------------------------|-----------------------------------|
| 1 | `GET ?snapshots=refs` | ref-pointed snapshots only                     | refresh at the start of `apply()` |
| 2 | `POST /tables/{t}`    | all snapshots (response; installed as current) | the commit itself                 |
| 3 | `GET ?snapshots=refs` | ref-pointed snapshots only                     | post-commit saved-snapshot check  |

The two refreshes are the same calls as before, ***shrunk to refs-sized responses***. The `snapshots=all` fetch is gone entirely, the builder and id probes no longer force loading. The `POST` is unchanged; its full response is installed as current metadata, which is why the post-commit check needs no extra fetch. Applies to normal and WAP commits alike. New tests pin these exact request sequences and assert `snapshots=all` is never requested by a commit.
