### PR TITLE
Spark: Backport Z-order null boolean and case-insensitive column fixes to 3.5, 4.0 and 4.2

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -198,7 +198,8 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
       if (identityPartitionFieldIds.contains(field.fieldId())) {
         LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
       } else {
-        validZOrderColNames.add(colName);
+        // use the resolved name so a case-insensitive match is not carried through as-is
+        validZOrderColNames.add(schema.findColumnName(field.fieldId()));
       }
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -256,6 +256,9 @@ class SparkZOrderUDF implements Serializable {
         functions
             .udf(
                 (Boolean value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
                   ByteBuffer buffer = inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
                   buffer.put(0, (byte) (value ? -127 : 0));
                   return buffer.array();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -112,6 +112,7 @@ import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBase;
@@ -126,8 +127,10 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -2140,6 +2143,105 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 4);
     List<Object[]> actualRecordsWithLineage = currentDataWithLineage();
     assertEquals("Rows must match", expectedRecords, actualRecordsWithLineage);
+  }
+
+  @TestTemplate
+  public void zOrderUDFEncodesNullValuesAsZeroBytes() {
+    Object[][] nullsByType = {
+      {"CAST(NULL AS BOOLEAN)", DataTypes.BooleanType},
+      {"CAST(NULL AS TINYINT)", DataTypes.ByteType},
+      {"CAST(NULL AS SMALLINT)", DataTypes.ShortType},
+      {"CAST(NULL AS INT)", DataTypes.IntegerType},
+      {"CAST(NULL AS BIGINT)", DataTypes.LongType},
+      {"CAST(NULL AS FLOAT)", DataTypes.FloatType},
+      {"CAST(NULL AS DOUBLE)", DataTypes.DoubleType},
+      {"CAST(NULL AS DATE)", DataTypes.DateType},
+      {"CAST(NULL AS TIMESTAMP)", DataTypes.TimestampType},
+      {"CAST(NULL AS TIMESTAMP_NTZ)", DataTypes.TimestampNTZType},
+      {"CAST(NULL AS STRING)", DataTypes.StringType},
+      {"CAST(NULL AS BINARY)", DataTypes.BinaryType},
+    };
+
+    for (Object[] nullByType : nullsByType) {
+      String literal = (String) nullByType[0];
+      DataType type = (DataType) nullByType[1];
+      SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+      Dataset<Row> result =
+          spark
+              .sql("SELECT " + literal + " as test_col")
+              .withColumn(
+                  "zorder_result", zorderUDF.sortedLexicographically(col("test_col"), type));
+
+      byte[] zorderBytes = result.collectAsList().get(0).getAs("zorder_result");
+      assertThat(zorderBytes)
+          .as("A null %s must produce ordered bytes rather than failing", type.simpleString())
+          .isNotNull()
+          .isNotEmpty();
+      assertThat(zorderBytes)
+          .as("A null %s must sort lowest, as an all-zero byte sequence", type.simpleString())
+          .containsOnly((byte) 0);
+    }
+  }
+
+  @TestTemplate
+  public void zOrderSortWithNullBooleanValues() {
+    Schema schema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "flag", Types.BooleanType.get()));
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    for (int batch = 0; batch < 2; batch++) {
+      spark
+          .createDataFrame(
+              Lists.newArrayList(
+                  RowFactory.create(1, true),
+                  RowFactory.create(2, null),
+                  RowFactory.create(3, false)),
+              SparkSchemaUtil.convert(schema))
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(tableLocation);
+    }
+    table.refresh();
+
+    long dataSizeBefore = testDataSize(table);
+    RewriteDataFiles.Result result =
+        basicRewrite(table)
+            .zOrder("id", "flag")
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+            .execute();
+
+    assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+    assertThat(spark.read().format("iceberg").load(tableLocation).filter("flag IS NULL").count())
+        .isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void zOrderSortWithMismatchedColumnCase() {
+    withSQLConf(
+        ImmutableMap.of(SQLConf.CASE_SENSITIVE().key(), "false"),
+        () -> {
+          Table table = createTable(4);
+          long dataSizeBefore = testDataSize(table);
+
+          // 'C2' and 'C3' resolve case-insensitively to 'c2' and 'c3'
+          RewriteDataFiles.Result result =
+              basicRewrite(table)
+                  .zOrder("C2", "C3")
+                  .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+                  .execute();
+
+          assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+          assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+        });
   }
 
   protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -198,7 +198,8 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
       if (identityPartitionFieldIds.contains(field.fieldId())) {
         LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
       } else {
-        validZOrderColNames.add(colName);
+        // use the resolved name so a case-insensitive match is not carried through as-is
+        validZOrderColNames.add(schema.findColumnName(field.fieldId()));
       }
     }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -256,6 +256,9 @@ class SparkZOrderUDF implements Serializable {
         functions
             .udf(
                 (Boolean value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
                   ByteBuffer buffer = inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
                   buffer.put(0, (byte) (value ? -127 : 0));
                   return buffer.array();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -113,6 +113,7 @@ import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBase;
@@ -127,8 +128,10 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -2199,6 +2202,105 @@ public class TestRewriteDataFilesAction extends TestBase {
     Row row = rows.get(0);
     byte[] zorderBytes = row.getAs("zorder_result");
     assertThat(zorderBytes).isNotNull().isNotEmpty();
+  }
+
+  @TestTemplate
+  public void zOrderUDFEncodesNullValuesAsZeroBytes() {
+    Object[][] nullsByType = {
+      {"CAST(NULL AS BOOLEAN)", DataTypes.BooleanType},
+      {"CAST(NULL AS TINYINT)", DataTypes.ByteType},
+      {"CAST(NULL AS SMALLINT)", DataTypes.ShortType},
+      {"CAST(NULL AS INT)", DataTypes.IntegerType},
+      {"CAST(NULL AS BIGINT)", DataTypes.LongType},
+      {"CAST(NULL AS FLOAT)", DataTypes.FloatType},
+      {"CAST(NULL AS DOUBLE)", DataTypes.DoubleType},
+      {"CAST(NULL AS DATE)", DataTypes.DateType},
+      {"CAST(NULL AS TIMESTAMP)", DataTypes.TimestampType},
+      {"CAST(NULL AS TIMESTAMP_NTZ)", DataTypes.TimestampNTZType},
+      {"CAST(NULL AS STRING)", DataTypes.StringType},
+      {"CAST(NULL AS BINARY)", DataTypes.BinaryType},
+    };
+
+    for (Object[] nullByType : nullsByType) {
+      String literal = (String) nullByType[0];
+      DataType type = (DataType) nullByType[1];
+      SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+      Dataset<Row> result =
+          spark
+              .sql("SELECT " + literal + " as test_col")
+              .withColumn(
+                  "zorder_result", zorderUDF.sortedLexicographically(col("test_col"), type));
+
+      byte[] zorderBytes = result.collectAsList().get(0).getAs("zorder_result");
+      assertThat(zorderBytes)
+          .as("A null %s must produce ordered bytes rather than failing", type.simpleString())
+          .isNotNull()
+          .isNotEmpty();
+      assertThat(zorderBytes)
+          .as("A null %s must sort lowest, as an all-zero byte sequence", type.simpleString())
+          .containsOnly((byte) 0);
+    }
+  }
+
+  @TestTemplate
+  public void zOrderSortWithNullBooleanValues() {
+    Schema schema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "flag", Types.BooleanType.get()));
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    for (int batch = 0; batch < 2; batch++) {
+      spark
+          .createDataFrame(
+              Lists.newArrayList(
+                  RowFactory.create(1, true),
+                  RowFactory.create(2, null),
+                  RowFactory.create(3, false)),
+              SparkSchemaUtil.convert(schema))
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(tableLocation);
+    }
+    table.refresh();
+
+    long dataSizeBefore = testDataSize(table);
+    RewriteDataFiles.Result result =
+        basicRewrite(table)
+            .zOrder("id", "flag")
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+            .execute();
+
+    assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+    assertThat(spark.read().format("iceberg").load(tableLocation).filter("flag IS NULL").count())
+        .isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void zOrderSortWithMismatchedColumnCase() {
+    withSQLConf(
+        ImmutableMap.of(SQLConf.CASE_SENSITIVE().key(), "false"),
+        () -> {
+          Table table = createTable(4);
+          long dataSizeBefore = testDataSize(table);
+
+          // 'C2' and 'C3' resolve case-insensitively to 'c2' and 'c3'
+          RewriteDataFiles.Result result =
+              basicRewrite(table)
+                  .zOrder("C2", "C3")
+                  .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+                  .execute();
+
+          assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+          assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+        });
   }
 
   protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -198,7 +198,8 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
       if (identityPartitionFieldIds.contains(field.fieldId())) {
         LOG.warn("Ignoring '{}' as such values are constant within a partition", colName);
       } else {
-        validZOrderColNames.add(colName);
+        // use the resolved name so a case-insensitive match is not carried through as-is
+        validZOrderColNames.add(schema.findColumnName(field.fieldId()));
       }
     }
 

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -256,6 +256,9 @@ class SparkZOrderUDF implements Serializable {
         functions
             .udf(
                 (Boolean value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
                   ByteBuffer buffer = inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
                   buffer.put(0, (byte) (value ? -127 : 0));
                   return buffer.array();

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -113,6 +113,7 @@ import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBase;
@@ -127,8 +128,10 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -2297,6 +2300,105 @@ public class TestRewriteDataFilesAction extends TestBase {
     Row row = rows.get(0);
     byte[] zorderBytes = row.getAs("zorder_result");
     assertThat(zorderBytes).isNotNull().isNotEmpty();
+  }
+
+  @TestTemplate
+  public void zOrderUDFEncodesNullValuesAsZeroBytes() {
+    Object[][] nullsByType = {
+      {"CAST(NULL AS BOOLEAN)", DataTypes.BooleanType},
+      {"CAST(NULL AS TINYINT)", DataTypes.ByteType},
+      {"CAST(NULL AS SMALLINT)", DataTypes.ShortType},
+      {"CAST(NULL AS INT)", DataTypes.IntegerType},
+      {"CAST(NULL AS BIGINT)", DataTypes.LongType},
+      {"CAST(NULL AS FLOAT)", DataTypes.FloatType},
+      {"CAST(NULL AS DOUBLE)", DataTypes.DoubleType},
+      {"CAST(NULL AS DATE)", DataTypes.DateType},
+      {"CAST(NULL AS TIMESTAMP)", DataTypes.TimestampType},
+      {"CAST(NULL AS TIMESTAMP_NTZ)", DataTypes.TimestampNTZType},
+      {"CAST(NULL AS STRING)", DataTypes.StringType},
+      {"CAST(NULL AS BINARY)", DataTypes.BinaryType},
+    };
+
+    for (Object[] nullByType : nullsByType) {
+      String literal = (String) nullByType[0];
+      DataType type = (DataType) nullByType[1];
+      SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+      Dataset<Row> result =
+          spark
+              .sql("SELECT " + literal + " as test_col")
+              .withColumn(
+                  "zorder_result", zorderUDF.sortedLexicographically(col("test_col"), type));
+
+      byte[] zorderBytes = result.collectAsList().get(0).getAs("zorder_result");
+      assertThat(zorderBytes)
+          .as("A null %s must produce ordered bytes rather than failing", type.simpleString())
+          .isNotNull()
+          .isNotEmpty();
+      assertThat(zorderBytes)
+          .as("A null %s must sort lowest, as an all-zero byte sequence", type.simpleString())
+          .containsOnly((byte) 0);
+    }
+  }
+
+  @TestTemplate
+  public void zOrderSortWithNullBooleanValues() {
+    Schema schema =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            optional(2, "flag", Types.BooleanType.get()));
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    for (int batch = 0; batch < 2; batch++) {
+      spark
+          .createDataFrame(
+              Lists.newArrayList(
+                  RowFactory.create(1, true),
+                  RowFactory.create(2, null),
+                  RowFactory.create(3, false)),
+              SparkSchemaUtil.convert(schema))
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(tableLocation);
+    }
+    table.refresh();
+
+    long dataSizeBefore = testDataSize(table);
+    RewriteDataFiles.Result result =
+        basicRewrite(table)
+            .zOrder("id", "flag")
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+            .execute();
+
+    assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+    assertThat(spark.read().format("iceberg").load(tableLocation).filter("flag IS NULL").count())
+        .isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void zOrderSortWithMismatchedColumnCase() {
+    withSQLConf(
+        ImmutableMap.of(SQLConf.CASE_SENSITIVE().key(), "false"),
+        () -> {
+          Table table = createTable(4);
+          long dataSizeBefore = testDataSize(table);
+
+          // 'C2' and 'C3' resolve case-insensitively to 'c2' and 'c3'
+          RewriteDataFiles.Result result =
+              basicRewrite(table)
+                  .zOrder("C2", "C3")
+                  .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
+                  .execute();
+
+          assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+          assertThat(result.rewrittenDataFilesCount()).isGreaterThan(0);
+        });
   }
 
   protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {


### PR DESCRIPTION
Backport of #17669 to Spark 3.5, 4.0 and 4.2, as noted in that PR.

The main-source changes are identical to the 4.1 version:

- `SparkZOrderUDF.booleanToOrderedBytesUDF()` returns `PRIMITIVE_EMPTY` for a null `Boolean` instead of throwing an NPE, matching the null-sorts-lowest convention already used by the other converters.
- `SparkZOrderFileRewriteRunner.validZOrderColNames` stores the resolved field name rather than the caller's spelling, so a case-insensitive match no longer fails later in `zValue`.

The three regression tests from #17669 (`zOrderUDFEncodesNullValuesAsZeroBytes`, `zOrderSortWithNullBooleanValues`, `zOrderSortWithMismatchedColumnCase`) are added to `TestRewriteDataFilesAction` for each version.